### PR TITLE
Bring in changes from AKT icepack-integration branch

### DIFF
--- a/components/mpas-seaice/bld/build-namelist
+++ b/components/mpas-seaice/bld/build-namelist
@@ -620,7 +620,7 @@ add_default($nl, 'config_recover_tracer_means_check');
 # Namelist group: column_package #
 ##################################
 
-add_default($nl, 'config_use_column_physics_type');
+add_default($nl, 'config_column_physics_type');
 add_default($nl, 'config_use_column_shortwave');
 add_default($nl, 'config_use_column_vertical_thermodynamics');
 if ($ice_bgc eq 'ice_bgc') {

--- a/components/mpas-seaice/bld/build-namelist
+++ b/components/mpas-seaice/bld/build-namelist
@@ -620,6 +620,7 @@ add_default($nl, 'config_recover_tracer_means_check');
 # Namelist group: column_package #
 ##################################
 
+add_default($nl, 'config_use_column_physics_type');
 add_default($nl, 'config_use_column_shortwave');
 add_default($nl, 'config_use_column_vertical_thermodynamics');
 if ($ice_bgc eq 'ice_bgc') {

--- a/components/mpas-seaice/bld/build-namelist-section
+++ b/components/mpas-seaice/bld/build-namelist-section
@@ -162,7 +162,7 @@ add_default($nl, 'config_recover_tracer_means_check');
 # Namelist group: column_package #
 ##################################
 
-add_default($nl, 'config_use_column_physics_type');
+add_default($nl, 'config_column_physics_type');
 add_default($nl, 'config_use_column_shortwave');
 add_default($nl, 'config_use_column_vertical_thermodynamics');
 add_default($nl, 'config_use_column_biogeochemistry');

--- a/components/mpas-seaice/bld/build-namelist-section
+++ b/components/mpas-seaice/bld/build-namelist-section
@@ -162,6 +162,7 @@ add_default($nl, 'config_recover_tracer_means_check');
 # Namelist group: column_package #
 ##################################
 
+add_default($nl, 'config_use_column_physics_type');
 add_default($nl, 'config_use_column_shortwave');
 add_default($nl, 'config_use_column_vertical_thermodynamics');
 add_default($nl, 'config_use_column_biogeochemistry');

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -166,6 +166,7 @@
 <config_recover_tracer_means_check>false</config_recover_tracer_means_check>
 
 <!-- column_package -->
+<config_use_column_physics_type>'column_package'</config_use_column_physics_type>
 <config_use_column_shortwave>true</config_use_column_shortwave>
 <config_use_column_vertical_thermodynamics>true</config_use_column_vertical_thermodynamics>
 <config_use_column_biogeochemistry>false</config_use_column_biogeochemistry>

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -166,7 +166,7 @@
 <config_recover_tracer_means_check>false</config_recover_tracer_means_check>
 
 <!-- column_package -->
-<config_use_column_physics_type>'column_package'</config_use_column_physics_type>
+<config_column_physics_type>'column_package'</config_column_physics_type>
 <config_use_column_shortwave>true</config_use_column_shortwave>
 <config_use_column_vertical_thermodynamics>true</config_use_column_vertical_thermodynamics>
 <config_use_column_biogeochemistry>false</config_use_column_biogeochemistry>

--- a/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
@@ -781,9 +781,9 @@ Default: Defined in namelist_defaults.xml
 
 <!-- column_package -->
 
-<entry id="config_column_physics_type" type="character"
+<entry id="config_column_physics_type" type="char*1024"
 	category="column_package" group="column_package">
-Set column physics type.
+Set column physics library.
 
 Valid values: 'icepack' and 'column_package'
 Default: Defined in namelist_defaults.xml

--- a/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
@@ -781,6 +781,14 @@ Default: Defined in namelist_defaults.xml
 
 <!-- column_package -->
 
+<entry id="config_column_physics_type" type="character"
+	category="column_package" group="column_package">
+Set column physics type.
+
+Valid values: 'icepack' and 'column_package'
+Default: Defined in namelist_defaults.xml
+</entry>
+
 <entry id="config_use_column_shortwave" type="logical"
 	category="column_package" group="column_package">
 Run the shortwave radiation column physics calculation.

--- a/components/mpas-seaice/src/Makefile
+++ b/components/mpas-seaice/src/Makefile
@@ -1,9 +1,9 @@
 .SUFFIXES: .F .o
-.PHONY: model_forward analysis_members shared
+.PHONY: column_package icepack model_forward analysis_members shared
 
 all: core_seaice
 
-core_seaice: column_package shared analysis_members model_forward
+core_seaice: icepack column_package shared analysis_members model_forward
 	ar -ru libdycore.a `find . -type f -name "*.o"`
 
 gen_includes:
@@ -24,18 +24,22 @@ post_build:
 column_package:
 	(cd column; $(MAKE))
 
-shared: column_package
+icepack:
+	$(MAKE) -f ../../Makefile.icepack --directory=icepack/columnphysics
+
+shared: column_package icepack
 	(cd shared; $(MAKE))
 
-analysis_members: column_package shared
+analysis_members: column_package icepack shared
 	(cd analysis_members; $(MAKE))
 
-model_forward: column_package shared analysis_members
+model_forward: column_package icepack shared analysis_members
 	(cd model_forward; $(MAKE))
 
 clean:
 	$(RM) *.o *.mod *.f90 libdycore.a
 	(cd column; $(MAKE) clean)
+	$(MAKE) -f ../../Makefile.icepack --directory=icepack/columnphysics clean
 	(cd shared; $(MAKE) clean)
 	(cd analysis_members; $(MAKE) clean)
 	(cd model_forward; $(MAKE) clean)

--- a/components/mpas-seaice/src/Makefile.icepack
+++ b/components/mpas-seaice/src/Makefile.icepack
@@ -1,0 +1,239 @@
+.SUFFIXES: .F90 .o
+
+OBJS =  icepack_aerosol.o \
+	icepack_age.o \
+	icepack_algae.o \
+	icepack_atmo.o \
+	icepack_brine.o \
+	icepack_firstyear.o \
+	icepack_flux.o \
+	icepack_fsd.o \
+	icepack_intfc.o \
+	icepack_isotope.o \
+	icepack_itd.o \
+	icepack_kinds.o \
+	icepack_mechred.o \
+	icepack_meltpond_cesm.o \
+	icepack_meltpond_lvl.o \
+	icepack_meltpond_topo.o \
+	icepack_mushy_physics.o \
+	icepack_ocean.o \
+	icepack_orbital.o \
+	icepack_parameters.o \
+	icepack_shortwave.o \
+        icepack_shortwave_data.o \
+	icepack_snow.o \
+	icepack_therm_0layer.o \
+	icepack_therm_bl99.o \
+	icepack_therm_itd.o \
+	icepack_therm_mushy.o \
+	icepack_therm_shared.o \
+	icepack_therm_vertical.o \
+	icepack_tracers.o \
+	icepack_warnings.o \
+	icepack_wavefracspec.o \
+	icepack_zbgc.o \
+	icepack_zbgc_shared.o \
+	icepack_zsalinity.o
+
+
+all: $(OBJS)
+
+
+icepack_aerosol.o:icepack_kinds.o
+icepack_aerosol.o:icepack_parameters.o
+icepack_aerosol.o:icepack_tracers.o
+icepack_aerosol.o:icepack_warnings.o
+icepack_aerosol.o:icepack_zbgc_shared.o
+icepack_age.o:icepack_kinds.o
+icepack_age.o:icepack_warnings.o
+icepack_algae.o:icepack_aerosol.o
+icepack_algae.o:icepack_kinds.o
+icepack_algae.o:icepack_parameters.o
+icepack_algae.o:icepack_tracers.o
+icepack_algae.o:icepack_warnings.o
+icepack_algae.o:icepack_zbgc_shared.o
+icepack_atmo.o:icepack_kinds.o
+icepack_atmo.o:icepack_parameters.o
+icepack_atmo.o:icepack_tracers.o
+icepack_atmo.o:icepack_warnings.o
+icepack_brine.o:icepack_kinds.o
+icepack_brine.o:icepack_mushy_physics.o
+icepack_brine.o:icepack_parameters.o
+icepack_brine.o:icepack_therm_shared.o
+icepack_brine.o:icepack_tracers.o
+icepack_brine.o:icepack_warnings.o
+icepack_brine.o:icepack_zbgc_shared.o
+icepack_firstyear.o:icepack_kinds.o
+icepack_firstyear.o:icepack_parameters.o
+icepack_firstyear.o:icepack_warnings.o
+icepack_flux.o:icepack_kinds.o
+icepack_flux.o:icepack_parameters.o
+icepack_flux.o:icepack_tracers.o
+icepack_flux.o:icepack_warnings.o
+icepack_fsd.o:icepack_kinds.o
+icepack_fsd.o:icepack_parameters.o
+icepack_fsd.o:icepack_tracers.o
+icepack_fsd.o:icepack_warnings.o
+icepack_intfc.o:icepack_atmo.o
+icepack_intfc.o:icepack_brine.o
+icepack_intfc.o:icepack_fsd.o
+icepack_intfc.o:icepack_itd.o
+icepack_intfc.o:icepack_kinds.o
+icepack_intfc.o:icepack_mechred.o
+icepack_intfc.o:icepack_mushy_physics.o
+icepack_intfc.o:icepack_ocean.o
+icepack_intfc.o:icepack_orbital.o
+icepack_intfc.o:icepack_parameters.o
+icepack_intfc.o:icepack_shortwave.o
+icepack_intfc.o:icepack_shortwave_data.o
+icepack_intfc.o:icepack_snow.o
+icepack_intfc.o:icepack_therm_itd.o
+icepack_intfc.o:icepack_therm_shared.o
+icepack_intfc.o:icepack_therm_vertical.o
+icepack_intfc.o:icepack_tracers.o
+icepack_intfc.o:icepack_warnings.o
+icepack_intfc.o:icepack_wavefracspec.o
+icepack_intfc.o:icepack_zbgc.o
+icepack_isotope.o:icepack_kinds.o
+icepack_isotope.o:icepack_parameters.o
+icepack_isotope.o:icepack_tracers.o
+icepack_isotope.o:icepack_warnings.o
+icepack_itd.o:icepack_kinds.o
+icepack_itd.o:icepack_parameters.o
+icepack_itd.o:icepack_therm_shared.o
+icepack_itd.o:icepack_tracers.o
+icepack_itd.o:icepack_warnings.o
+icepack_itd.o:icepack_zbgc_shared.o
+icepack_mechred.o:icepack_itd.o
+icepack_mechred.o:icepack_kinds.o
+icepack_mechred.o:icepack_parameters.o
+icepack_mechred.o:icepack_tracers.o
+icepack_mechred.o:icepack_warnings.o
+icepack_meltpond_cesm.o:icepack_kinds.o
+icepack_meltpond_cesm.o:icepack_parameters.o
+icepack_meltpond_cesm.o:icepack_warnings.o
+icepack_meltpond_lvl.o:icepack_kinds.o
+icepack_meltpond_lvl.o:icepack_parameters.o
+icepack_meltpond_lvl.o:icepack_therm_shared.o
+icepack_meltpond_lvl.o:icepack_warnings.o
+icepack_meltpond_topo.o:icepack_kinds.o
+icepack_meltpond_topo.o:icepack_parameters.o
+icepack_meltpond_topo.o:icepack_therm_shared.o
+icepack_meltpond_topo.o:icepack_warnings.o
+icepack_mushy_physics.o:icepack_kinds.o
+icepack_mushy_physics.o:icepack_parameters.o
+icepack_mushy_physics.o:icepack_warnings.o
+icepack_ocean.o:icepack_kinds.o
+icepack_ocean.o:icepack_parameters.o
+icepack_ocean.o:icepack_warnings.o
+icepack_orbital.o:icepack_kinds.o
+icepack_orbital.o:icepack_parameters.o
+icepack_orbital.o:icepack_warnings.o
+icepack_parameters.o:icepack_kinds.o
+icepack_parameters.o:icepack_shortwave_data.o
+icepack_parameters.o:icepack_warnings.o
+icepack_shortwave.o:icepack_kinds.o
+icepack_shortwave.o:icepack_orbital.o
+icepack_shortwave.o:icepack_parameters.o
+icepack_shortwave.o:icepack_shortwave_data.o
+icepack_shortwave.o:icepack_tracers.o
+icepack_shortwave.o:icepack_warnings.o
+icepack_shortwave.o:icepack_zbgc_shared.o
+icepack_shortwave_data.o:icepack_kinds.o
+icepack_shortwave_data.o:icepack_warnings.o
+icepack_snow.o:icepack_kinds.o
+icepack_snow.o:icepack_parameters.o
+icepack_snow.o:icepack_therm_shared.o
+icepack_snow.o:icepack_warnings.o
+icepack_therm_0layer.o:icepack_kinds.o
+icepack_therm_0layer.o:icepack_parameters.o
+icepack_therm_0layer.o:icepack_therm_bl99.o
+icepack_therm_0layer.o:icepack_warnings.o
+icepack_therm_bl99.o:icepack_kinds.o
+icepack_therm_bl99.o:icepack_parameters.o
+icepack_therm_bl99.o:icepack_therm_shared.o
+icepack_therm_bl99.o:icepack_warnings.o
+icepack_therm_itd.o:icepack_fsd.o
+icepack_therm_itd.o:icepack_isotope.o
+icepack_therm_itd.o:icepack_itd.o
+icepack_therm_itd.o:icepack_kinds.o
+icepack_therm_itd.o:icepack_mushy_physics.o
+icepack_therm_itd.o:icepack_parameters.o
+icepack_therm_itd.o:icepack_therm_shared.o
+icepack_therm_itd.o:icepack_tracers.o
+icepack_therm_itd.o:icepack_warnings.o
+icepack_therm_itd.o:icepack_zbgc.o
+icepack_therm_mushy.o:icepack_kinds.o
+icepack_therm_mushy.o:icepack_mushy_physics.o
+icepack_therm_mushy.o:icepack_parameters.o
+icepack_therm_mushy.o:icepack_therm_shared.o
+icepack_therm_mushy.o:icepack_tracers.o
+icepack_therm_mushy.o:icepack_warnings.o
+icepack_therm_shared.o:icepack_kinds.o
+icepack_therm_shared.o:icepack_mushy_physics.o
+icepack_therm_shared.o:icepack_parameters.o
+icepack_therm_shared.o:icepack_warnings.o
+icepack_therm_vertical.o:icepack_aerosol.o
+icepack_therm_vertical.o:icepack_age.o
+icepack_therm_vertical.o:icepack_atmo.o
+icepack_therm_vertical.o:icepack_firstyear.o
+icepack_therm_vertical.o:icepack_flux.o
+icepack_therm_vertical.o:icepack_isotope.o
+icepack_therm_vertical.o:icepack_kinds.o
+icepack_therm_vertical.o:icepack_meltpond_cesm.o
+icepack_therm_vertical.o:icepack_meltpond_lvl.o
+icepack_therm_vertical.o:icepack_meltpond_topo.o
+icepack_therm_vertical.o:icepack_mushy_physics.o
+icepack_therm_vertical.o:icepack_parameters.o
+icepack_therm_vertical.o:icepack_snow.o
+icepack_therm_vertical.o:icepack_therm_0layer.o
+icepack_therm_vertical.o:icepack_therm_bl99.o
+icepack_therm_vertical.o:icepack_therm_mushy.o
+icepack_therm_vertical.o:icepack_therm_shared.o
+icepack_therm_vertical.o:icepack_tracers.o
+icepack_therm_vertical.o:icepack_warnings.o
+icepack_tracers.o:icepack_kinds.o
+icepack_tracers.o:icepack_parameters.o
+icepack_tracers.o:icepack_warnings.o
+icepack_warnings.o:icepack_kinds.o
+icepack_wavefracspec.o:icepack_fsd.o
+icepack_wavefracspec.o:icepack_kinds.o
+icepack_wavefracspec.o:icepack_parameters.o
+icepack_wavefracspec.o:icepack_tracers.o
+icepack_wavefracspec.o:icepack_warnings.o
+icepack_zbgc.o:icepack_algae.o
+icepack_zbgc.o:icepack_brine.o
+icepack_zbgc.o:icepack_itd.o
+icepack_zbgc.o:icepack_kinds.o
+icepack_zbgc.o:icepack_parameters.o
+icepack_zbgc.o:icepack_therm_shared.o
+icepack_zbgc.o:icepack_tracers.o
+icepack_zbgc.o:icepack_warnings.o
+icepack_zbgc.o:icepack_zbgc_shared.o
+icepack_zbgc.o:icepack_zsalinity.o
+icepack_zbgc_shared.o:icepack_kinds.o
+icepack_zbgc_shared.o:icepack_parameters.o
+icepack_zbgc_shared.o:icepack_tracers.o
+icepack_zbgc_shared.o:icepack_warnings.o
+icepack_zsalinity.o:icepack_brine.o
+icepack_zsalinity.o:icepack_kinds.o
+icepack_zsalinity.o:icepack_parameters.o
+icepack_zsalinity.o:icepack_therm_shared.o
+icepack_zsalinity.o:icepack_tracers.o
+icepack_zsalinity.o:icepack_warnings.o
+icepack_zsalinity.o:icepack_zbgc_shared.o
+
+
+.F90.o:
+	$(RM) $@ $*.mod
+ifeq "$(GEN_F90)" "true"
+	$(CPP) $(CPPFLAGS) $(CPPINCLUDES) $< > $*.f90
+
+	$(FC) $(FFLAGS) -c $*.f90 $(FCINCLUDES)
+else
+	$(FC) $(CPPFLAGS) $(FFLAGS) -c $*.F90 $(CPPINCLUDES) $(FCINCLUDES)
+endif
+
+clean:
+	$(RM) *.o *.mod

--- a/components/mpas-seaice/src/Makefile.icepack
+++ b/components/mpas-seaice/src/Makefile.icepack
@@ -131,7 +131,6 @@ icepack_orbital.o:icepack_kinds.o
 icepack_orbital.o:icepack_parameters.o
 icepack_orbital.o:icepack_warnings.o
 icepack_parameters.o:icepack_kinds.o
-icepack_parameters.o:icepack_shortwave_data.o
 icepack_parameters.o:icepack_warnings.o
 icepack_shortwave.o:icepack_kinds.o
 icepack_shortwave.o:icepack_orbital.o
@@ -142,6 +141,7 @@ icepack_shortwave.o:icepack_warnings.o
 icepack_shortwave.o:icepack_zbgc_shared.o
 icepack_shortwave_data.o:icepack_kinds.o
 icepack_shortwave_data.o:icepack_warnings.o
+icepack_shortwave_data.o:icepack_parameters.o
 icepack_snow.o:icepack_kinds.o
 icepack_snow.o:icepack_parameters.o
 icepack_snow.o:icepack_therm_shared.o

--- a/components/mpas-seaice/src/Registry.xml
+++ b/components/mpas-seaice/src/Registry.xml
@@ -687,6 +687,10 @@
 
 	<!-- column physics -->
 	<nml_record name="column_package" in_defaults="true">
+		<nml_option name="config_column_physics_type" type="character" default_value="column_package" units="unitless"
+			description="Type of column library."
+			possible_values="'icepack' and 'column_package'"
+		/>
 		<nml_option name="config_use_column_shortwave" type="logical" default_value="true" units="unitless"
 			description="Run the shortwave radiation column physics calculation."
 			possible_values="true or false"

--- a/components/mpas-seaice/src/Registry.xml
+++ b/components/mpas-seaice/src/Registry.xml
@@ -4676,6 +4676,26 @@
 		     dimensions="nCategories nCells Time"
 		     units="W m-2"
 		/>
+		<var name="penetratingShortwaveFluxVisibleDirect"
+		     type="real"
+		     dimensions="nCategories nCells Time"
+		     units="W m-2"
+		/>
+		<var name="penetratingShortwaveFluxVisibleDiffuse"
+		     type="real"
+		     dimensions="nCategories nCells Time"
+		     units="W m-2"
+		/>
+		<var name="penetratingShortwaveFluxIRDirect"
+		     type="real"
+		     dimensions="nCategories nCells Time"
+		     units="W m-2"
+		/>
+		<var name="penetratingShortwaveFluxIRDiffuse"
+		     type="real"
+		     dimensions="nCategories nCells Time"
+		     units="W m-2"
+		/>
 		<var name="shortwaveLayerPenetration"
 		     type="real"
 		     dimensions="nIceLayersP1 nCategories nCells Time"

--- a/components/mpas-seaice/src/model_forward/mpas_seaice_core.F
+++ b/components/mpas-seaice/src/model_forward/mpas_seaice_core.F
@@ -416,6 +416,8 @@ module seaice_core
       use mpas_decomp
       use seaice_icepack, only: &
            seaice_icepack_finalize
+      use seaice_column, only: &
+           seaice_column_finalize
       use seaice_mesh_pool, only: &
            seaice_mesh_pool_destroy
 
@@ -424,13 +426,21 @@ module seaice_core
       type (domain_type), intent(inout) :: domain
       integer :: ierr
 
+      character(len=strKIND), pointer :: &
+           config_column_physics_type
+
       iErr = 0
 
       call mpas_log_write(" Destruct mesh pool...")
       call seaice_mesh_pool_destroy(iErr)
 
       ! finalize column
-      call seaice_icepack_finalize(domain)
+      call mpas_pool_get_config(domain % configs, "config_column_physics_type", config_column_physics_type)
+      if (trim(config_column_physics_type) == "icepack") then
+         call seaice_icepack_finalize(domain)
+      else if (trim(config_column_physics_type) == "column_package") then
+         call seaice_column_finalize(domain)
+      endif ! config_column_physics_type
 
       call seaice_analysis_finalize(domain, ierr)
 

--- a/components/mpas-seaice/src/model_forward/mpas_seaice_core.F
+++ b/components/mpas-seaice/src/model_forward/mpas_seaice_core.F
@@ -3,7 +3,6 @@ module seaice_core
    use mpas_framework
    use mpas_timekeeping
    use seaice_analysis_driver
-   use seaice_column
    use mpas_threading
    use mpas_timer, only: mpas_timer_start, mpas_timer_stop
    use mpas_log, only: mpas_log_write
@@ -415,8 +414,8 @@ module seaice_core
 
       use mpas_derived_types
       use mpas_decomp
-      use seaice_column, only: &
-           seaice_column_finalize
+      use seaice_icepack, only: &
+           seaice_icepack_finalize
       use seaice_mesh_pool, only: &
            seaice_mesh_pool_destroy
 
@@ -431,7 +430,7 @@ module seaice_core
       call seaice_mesh_pool_destroy(iErr)
 
       ! finalize column
-      call seaice_column_finalize(domain)
+      call seaice_icepack_finalize(domain)
 
       call seaice_analysis_finalize(domain, ierr)
 

--- a/components/mpas-seaice/src/model_forward/mpas_seaice_core.F
+++ b/components/mpas-seaice/src/model_forward/mpas_seaice_core.F
@@ -3,6 +3,7 @@ module seaice_core
    use mpas_framework
    use mpas_timekeeping
    use seaice_analysis_driver
+   use seaice_column
    use mpas_threading
    use mpas_timer, only: mpas_timer_start, mpas_timer_stop
    use mpas_log, only: mpas_log_write

--- a/components/mpas-seaice/src/seaice.cmake
+++ b/components/mpas-seaice/src/seaice.cmake
@@ -104,7 +104,7 @@ list(APPEND RAW_SOURCES
   core_seaice/shared/mpas_seaice_numerics.F
   core_seaice/shared/mpas_seaice_constants.F
   core_seaice/shared/mpas_seaice_column.F
-#  core_seaice/shared/mpas_seaice_icepack.F
+  core_seaice/shared/mpas_seaice_icepack.F
   core_seaice/shared/mpas_seaice_diagnostics.F
   core_seaice/shared/mpas_seaice_error.F
   core_seaice/shared/mpas_seaice_mesh_pool.F

--- a/components/mpas-seaice/src/shared/Makefile
+++ b/components/mpas-seaice/src/shared/Makefile
@@ -20,6 +20,7 @@ OBJS = 	mpas_seaice_time_integration.o \
 	mpas_seaice_numerics.o \
 	mpas_seaice_constants.o \
 	mpas_seaice_column.o \
+	mpas_seaice_icepack.o \
 	mpas_seaice_diagnostics.o \
 	mpas_seaice_error.o \
 	mpas_seaice_mesh_pool.o \
@@ -36,6 +37,8 @@ mpas_seaice_mesh_pool.o:
 
 mpas_seaice_column.o: mpas_seaice_error.o
 
+mpas_seaice_icepack.o: mpas_seaice_error.o
+
 mpas_seaice_diagnostics.o: mpas_seaice_constants.o
 
 mpas_seaice_mesh.o: mpas_seaice_constants.o
@@ -46,7 +49,7 @@ mpas_seaice_testing.o: mpas_seaice_constants.o
 
 mpas_seaice_velocity_solver_constitutive_relation.o: mpas_seaice_constants.o mpas_seaice_testing.o
 
-mpas_seaice_forcing.o: mpas_seaice_constants.o mpas_seaice_mesh.o
+mpas_seaice_forcing.o: mpas_seaice_constants.o mpas_seaice_mesh.o mpas_seaice_column.o mpas_seaice_icepack.o
 
 mpas_seaice_velocity_solver_weak.o: mpas_seaice_constants.o mpas_seaice_testing.o mpas_seaice_velocity_solver_constitutive_relation.o mpas_seaice_mesh_pool.o
 
@@ -58,7 +61,7 @@ mpas_seaice_velocity_solver_pwl.o: mpas_seaice_constants.o mpas_seaice_numerics.
 
 mpas_seaice_velocity_solver_variational.o: mpas_seaice_constants.o mpas_seaice_velocity_solver_constitutive_relation.o mpas_seaice_velocity_solver_wachspress.o mpas_seaice_velocity_solver_pwl.o mpas_seaice_mesh_pool.o
 
-mpas_seaice_velocity_solver.o: mpas_seaice_constants.o mpas_seaice_mesh.o mpas_seaice_testing.o mpas_seaice_velocity_solver_weak.o mpas_seaice_velocity_solver_constitutive_relation.o mpas_seaice_velocity_solver_variational.o mpas_seaice_diagnostics.o mpas_seaice_mesh_pool.o mpas_seaice_special_boundaries.o
+mpas_seaice_velocity_solver.o: mpas_seaice_constants.o mpas_seaice_mesh.o mpas_seaice_testing.o mpas_seaice_velocity_solver_weak.o mpas_seaice_velocity_solver_constitutive_relation.o mpas_seaice_velocity_solver_variational.o mpas_seaice_diagnostics.o mpas_seaice_mesh_pool.o mpas_seaice_special_boundaries.o mpas_seaice_column.o mpas_seaice_icepack.o
 
 mpas_seaice_advection_upwind.o: mpas_seaice_constants.o mpas_seaice_mesh.o
 
@@ -68,13 +71,13 @@ mpas_seaice_advection_incremental_remap.o: mpas_seaice_constants.o mpas_seaice_m
 
 mpas_seaice_advection.o: mpas_seaice_advection_upwind.o mpas_seaice_advection_incremental_remap.o
 
-mpas_seaice_prescribed.o: mpas_seaice_constants.o mpas_seaice_column.o
+mpas_seaice_prescribed.o: mpas_seaice_constants.o mpas_seaice_column.o mpas_seaice_icepack.o
 
-mpas_seaice_time_integration.o: mpas_seaice_constants.o mpas_seaice_velocity_solver.o mpas_seaice_forcing.o mpas_seaice_advection.o mpas_seaice_diagnostics.o mpas_seaice_column.o mpas_seaice_prescribed.o mpas_seaice_special_boundaries.o
+mpas_seaice_time_integration.o: mpas_seaice_constants.o mpas_seaice_velocity_solver.o mpas_seaice_forcing.o mpas_seaice_advection.o mpas_seaice_diagnostics.o mpas_seaice_column.o mpas_seaice_icepack.o mpas_seaice_prescribed.o mpas_seaice_special_boundaries.o
 
-mpas_seaice_initialize.o: mpas_seaice_constants.o mpas_seaice_mesh.o mpas_seaice_velocity_solver.o mpas_seaice_testing.o mpas_seaice_forcing.o mpas_seaice_advection.o mpas_seaice_column.o mpas_seaice_forcing.o mpas_seaice_mesh_pool.o mpas_seaice_special_boundaries.o
+mpas_seaice_initialize.o: mpas_seaice_constants.o mpas_seaice_mesh.o mpas_seaice_velocity_solver.o mpas_seaice_testing.o mpas_seaice_forcing.o mpas_seaice_advection.o mpas_seaice_column.o mpas_seaice_icepack.o mpas_seaice_forcing.o mpas_seaice_mesh_pool.o mpas_seaice_special_boundaries.o
 
-mpas_seaice_core.o: mpas_seaice_constants.o mpas_seaice_time_integration.o mpas_seaice_velocity_solver.o mpas_seaice_forcing.o mpas_seaice_initialize.o mpas_seaice_column.o mpas_seaice_mesh_pool.o
+mpas_seaice_core.o: mpas_seaice_constants.o mpas_seaice_time_integration.o mpas_seaice_velocity_solver.o mpas_seaice_forcing.o mpas_seaice_initialize.o mpas_seaice_column.o mpas_seaice_icepack.o mpas_seaice_mesh_pool.o mpas_seaice_icepack.o
 
 mpas_seaice_core_interface.o: mpas_seaice_core.o
 
@@ -88,7 +91,7 @@ FW = ../../../mpas-framework/src
 ifeq "$(GEN_F90)" "true"
 	$(CPP) $(CPPFLAGS) $(CPPINCLUDES) $< > $*.f90
 
-	$(FC) $(FFLAGS) -c $*.f90 $(FCINCLUDES) -I$(FW)/framework -I$(FW)/operators -I$(FW)/external/esmf_time_f90 -I../column
+	$(FC) $(FFLAGS) -c $*.f90 $(FCINCLUDES) -I$(FW)/framework -I$(FW)/operators -I$(FW)/external/esmf_time_f90 -I../column -I../icepack/columnphysics
 else
-	$(FC) $(CPPFLAGS) $(FFLAGS) -c $*.F $(CPPINCLUDES) $(FCINCLUDES) -I$(FW)/framework -I$(FW)/operators -I$(FW)/external/esmf_time_f90 -I../column
+	$(FC) $(CPPFLAGS) $(FFLAGS) -c $*.F $(CPPINCLUDES) $(FCINCLUDES) -I$(FW)/framework -I$(FW)/operators -I$(FW)/external/esmf_time_f90 -I../column -I../icepack/columnphysics
 endif

--- a/components/mpas-seaice/src/shared/mpas_seaice_constants.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_constants.F
@@ -56,6 +56,9 @@ module seaice_constants
        seaiceOceanAlbedo, &             ! Ocean albedo
        seaiceVonKarmanConstant, &       ! Von Karman constant
        seaiceIceSurfaceRoughness, &     ! ice surface roughness (m)
+       seaiceSeaWaterSpecificHeat, &    ! specific heat of ocn (J/kg/K)
+       seaiceLatentHeatVaporization, &  ! latent heat, vaporization freshwater (J/kg)
+       seaiceReferenceSalinity, &       ! ice reference salinity (ppt)
        seaiceStabilityReferenceHeight   ! stability reference height (m)
 
   ! dynamics constants

--- a/components/mpas-seaice/src/shared/mpas_seaice_constants.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_constants.F
@@ -14,32 +14,6 @@ module seaice_constants
 
   use mpas_derived_types
 
-  use ice_constants_colpkg, only: &
-       gravit, &
-       rhoi, &
-       rhos, &
-       rhow, &
-       puny, &
-       stefan_boltzmann, &
-       emissivity, &
-       Tffresh, &
-       cp_air, &
-       cp_ocn, &
-       Lsub, &
-       Lvap, &
-       Lfresh, &
-       Pstar, &
-       Cstar, &
-       dragio, &
-       albocn, &
-       rhofresh, &
-       vonkar, &
-       iceruf, &
-       zref, &
-       ice_ref_salinity, &
-       sk_l, &
-       R_gC2molC
-
   private
   save
 
@@ -53,55 +27,52 @@ module seaice_constants
        seaiceDaysPerSecond = 1.0_RKIND/seaiceSecondsPerDay
 
   ! Earth constants
+  real (kind=RKIND), public :: &
+       seaiceGravity                      ! gravitational acceleration (m/s^2)
   real (kind=RKIND), parameter, public :: &
-       seaiceGravity = gravit, &    ! gravitational acceleration (m/s^2)
        omega         = 7.29212e-5_RKIND   ! angular rotation rate of the Earth [s-1]
 
   character (len=*), public, parameter :: &
        coupleAlarmID = 'coupling'
 
-  real(kind=RKIND), parameter, public :: &
-       seaicePuny = puny
+  real(kind=RKIND), public :: &
+       seaicePuny
 
   ! physical constants
-  real(kind=RKIND), parameter, public :: &
-       seaiceDensityIce        = rhoi, & ! density of ice (kg/m^3)
-       seaiceDensitySnow       = rhos, & ! density of snow (kg/m^3)
-       seaiceDensitySeaWater   = rhow, & ! density of seawater (kg/m^3)
-       seaiceDensityFreshwater = rhofresh ! density of freshwater (kg/m^3)
+  real(kind=RKIND), public :: &
+       seaiceDensityIce, &      ! density of ice (kg/m^3)
+       seaiceDensitySnow, &     ! density of snow (kg/m^3)
+       seaiceDensitySeaWater, & ! density of seawater (kg/m^3)
+       seaiceDensityFreshwater  ! density of freshwater (kg/m^3)
 
   ! thermodynamic constants
-  real(kind=RKIND), parameter, public :: &
-       seaiceStefanBoltzmann          = stefan_boltzmann, & ! J m-2 K-4 s-1
-       seaiceIceSnowEmissivity        = emissivity, &       ! emissivity of snow and ice
-       seaiceFreshWaterFreezingPoint  = Tffresh, &          ! freezing temp of fresh ice (K)
-       seaiceAirSpecificHeat          = cp_air, &           ! specific heat of air (J/kg/K)
-       seaiceSeaWaterSpecificHeat     = cp_ocn, &           ! specific heat of ocn (J/kg/K)
-       seaiceLatentHeatSublimation    = Lsub, &             ! latent heat, sublimation freshwater (J/kg)
-       seaiceLatentHeatVaporization   = Lvap, &             ! latent heat, vaporization freshwater (J/kg)
-       seaiceLatentHeatMelting        = Lfresh, &           ! latent heat of melting of fresh ice (J/kg)
-       seaiceOceanAlbedo              = albocn, &           ! Ocean albedo
-       seaiceVonKarmanConstant        = vonkar, &           ! Von Karman constant
-       seaiceIceSurfaceRoughness      = iceruf, &           ! ice surface roughness (m)
-       seaiceStabilityReferenceHeight = zref, &             ! stability reference height (m)
-       seaiceReferenceSalinity        = ice_ref_salinity    ! ice reference salinity (ppt)
+  real(kind=RKIND), public :: &
+       seaiceStefanBoltzmann, &         ! J m-2 K-4 s-1
+       seaiceIceSnowEmissivity, &       ! emissivity of snow and ice
+       seaiceFreshWaterFreezingPoint, & ! freezing temp of fresh ice (K)
+       seaiceAirSpecificHeat, &         ! specific heat of air (J/kg/K)
+       seaiceLatentHeatSublimation, &   ! latent heat, sublimation freshwater (J/kg)
+       seaiceLatentHeatMelting, &       ! latent heat of melting of fresh ice (J/kg)
+       seaiceOceanAlbedo, &             ! Ocean albedo
+       seaiceVonKarmanConstant, &       ! Von Karman constant
+       seaiceIceSurfaceRoughness, &     ! ice surface roughness (m)
+       seaiceStabilityReferenceHeight   ! stability reference height (m)
 
   ! dynamics constants
-  real(kind=RKIND), parameter, public :: &
-       seaiceIceStrengthConstantHiblerP = Pstar, & ! P* constant in Hibler strength formulation
-       seaiceIceStrengthConstantHiblerC = Cstar, & ! C* constant in Hibler strength formulation
-       seaiceIceOceanDragCoefficient    = dragio   ! ice ocean drag coefficient
+  real(kind=RKIND), public :: &
+       seaiceIceStrengthConstantHiblerP, & ! P* constant in Hibler strength formulation
+       seaiceIceStrengthConstantHiblerC, & ! C* constant in Hibler strength formulation
+       seaiceIceOceanDragCoefficient       ! ice ocean drag coefficient
 
   ! minimum sea ice area
-  real(kind=RKIND), parameter, public :: &
-       iceAreaMinimum       = seaicePuny, &
-       iceThicknessMinimum  = seaicePuny, &
-       snowThicknessMinimum = seaicePuny
+  real(kind=RKIND), public :: &
+       iceAreaMinimum, &
+       iceThicknessMinimum, &
+       snowThicknessMinimum
 
    ! biogeochemistry constants
-   real(kind=RKIND), parameter, public :: &
-        skeletalLayerThickness = sk_l      , &
-        gramsCarbonPerMolCarbon = R_gC2molC    ! g carbon per mol carbon
-
+   real(kind=RKIND), public :: &
+        skeletalLayerThickness, &
+        gramsCarbonPerMolCarbon   ! g carbon per mol carbon
 
 end module seaice_constants

--- a/components/mpas-seaice/src/shared/mpas_seaice_forcing.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_forcing.F
@@ -1830,8 +1830,8 @@ contains
 
   subroutine prepare_oceanic_coupling_variables_ncar(block, firstTimeStep)
 
-    use ice_colpkg, only: &
-         colpkg_sea_freezing_temperature
+    use seaice_icepack, only: &
+         seaice_icepack_sea_freezing_temperature
 
     type (block_type), pointer :: block
 
@@ -1882,7 +1882,7 @@ contains
        oceanMixedLayerDepth(iCell) = max(oceanMixedLayerDepth(iCell), 0.0_RKIND)
 
        ! sea freezing temperature
-       seaFreezingTemperature(iCell) = colpkg_sea_freezing_temperature(seaSurfaceSalinity(iCell))
+       seaFreezingTemperature(iCell) = seaice_icepack_sea_freezing_temperature(seaSurfaceSalinity(iCell))
 
     enddo ! iCell
 

--- a/components/mpas-seaice/src/shared/mpas_seaice_forcing.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_forcing.F
@@ -1832,6 +1832,8 @@ contains
 
     use seaice_icepack, only: &
          seaice_icepack_sea_freezing_temperature
+    use seaice_column, only: &
+         seaice_column_sea_freezing_temperature
 
     type (block_type), pointer :: block
 
@@ -1849,7 +1851,8 @@ contains
          seaFreezingTemperature
 
     character(len=strKIND), pointer :: &
-         config_sea_freezing_temperature_type
+         config_sea_freezing_temperature_type, &
+         config_column_physics_type
 
     logical, pointer :: &
          config_do_restart
@@ -1861,6 +1864,7 @@ contains
     integer :: &
          iCell
 
+    call MPAS_pool_get_config(block % configs, "config_column_physics_type", config_column_physics_type)
     call MPAS_pool_get_config(block % configs, "config_do_restart", config_do_restart)
     call MPAS_pool_get_config(block % configs, "config_sea_freezing_temperature_type", config_sea_freezing_temperature_type)
 
@@ -1875,16 +1879,29 @@ contains
     call MPAS_pool_get_array(ocean_coupling, "oceanMixedLayerDepth", oceanMixedLayerDepth)
     call MPAS_pool_get_array(ocean_coupling, "seaFreezingTemperature", seaFreezingTemperature)
 
-    do iCell = 1, nCellsSolve
+    if (trim(config_column_physics_type) == "icepack") then
+       do iCell = 1, nCellsSolve
 
-       ! ensure physical realism
-       seaSurfaceSalinity(iCell)   = max(seaSurfaceSalinity(iCell), 0.0_RKIND)
-       oceanMixedLayerDepth(iCell) = max(oceanMixedLayerDepth(iCell), 0.0_RKIND)
+          ! ensure physical realism
+          seaSurfaceSalinity(iCell)   = max(seaSurfaceSalinity(iCell), 0.0_RKIND)
+          oceanMixedLayerDepth(iCell) = max(oceanMixedLayerDepth(iCell), 0.0_RKIND)
 
-       ! sea freezing temperature
-       seaFreezingTemperature(iCell) = seaice_icepack_sea_freezing_temperature(seaSurfaceSalinity(iCell))
+          ! sea freezing temperature
+          seaFreezingTemperature(iCell) = seaice_icepack_sea_freezing_temperature(seaSurfaceSalinity(iCell))
 
-    enddo ! iCell
+       enddo ! iCell
+    else if (trim(config_column_physics_type) == "column_package") then
+       do iCell = 1, nCellsSolve
+
+          ! ensure physical realism
+          seaSurfaceSalinity(iCell)   = max(seaSurfaceSalinity(iCell), 0.0_RKIND)
+          oceanMixedLayerDepth(iCell) = max(oceanMixedLayerDepth(iCell), 0.0_RKIND)
+
+          ! sea freezing temperature
+          seaFreezingTemperature(iCell) = seaice_column_sea_freezing_temperature(seaSurfaceSalinity(iCell))
+
+       enddo ! iCell
+    endif ! config_column_physics_type
 
     ! only update sea surface temperature on first non-restart timestep
     if (firstTimeStep .and. .not. config_do_restart) then

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -231,6 +231,7 @@ contains
 
        ! initialize the column package parameters
        call init_column_package_parameters(domain, ciceTracerObject)
+       call init_icepack_package_parameters(domain, ciceTracerObject)
 
     endif
 
@@ -654,6 +655,7 @@ contains
          colpkg_clear_warnings
 
     use icepack_intfc, only: &
+         icepack_init_orbit, &
          icepack_init_radiation
 
     use seaice_constants, only: &
@@ -741,6 +743,7 @@ contains
        call colpkg_init_orbit(&
             abortFlag, &
             abortMessage)
+       call icepack_init_orbit()
        call column_write_warnings(abortFlag)
 
        if (abortFlag) then
@@ -9483,7 +9486,7 @@ contains
     call init_icepack_package_tracer_indices(tracerObject)
 
     ! set the column parameters
-    call init_column_package_configs(domain)
+    call init_icepack_package_configs(domain)
 
   end subroutine init_icepack_package_parameters
 
@@ -10549,7 +10552,7 @@ contains
          !nt_isoice_in
          nt_aero_in       = tracerObject % index_aerosols, &
          nt_zaero_in      = tracerObject % index_verticalAerosolsConc, & ! name change?nt_zaeros -> nt_zaero
-         nt_bgc_C_in      = tracerObject % index_algalCarbon, &
+         !nt_bgc_C_in      = tracerObject % index_algalCarbon, & ! not supported
          nt_bgc_N_in      = tracerObject % index_algaeConc, &
          nt_bgc_chl_in    = tracerObject % index_algalChlorophyll, &
          nt_bgc_DOC_in    = tracerObject % index_DOCConc, &
@@ -10566,7 +10569,7 @@ contains
          nt_bgc_hum_in    = tracerObject % index_humicsConc, &
          nt_bgc_PON_in    = tracerObject % index_nonreactiveConc, &
          nlt_zaero_in     = tracerObject % index_verticalAerosolsConcLayer, &
-         nlt_bgc_C_in     = tracerObject % index_algalCarbonLayer, &
+         !nlt_bgc_C_in     = tracerObject % index_algalCarbonLayer, & ! not supported
          nlt_bgc_N_in     = tracerObject % index_algaeConcLayer, &
          nlt_bgc_chl_in   = tracerObject % index_algalChlorophyllLayer, &
          nlt_bgc_DOC_in   = tracerObject % index_DOCConcLayer, &
@@ -10588,6 +10591,11 @@ contains
          nlt_zaero_sw_in  = tracerObject % index_verticalAerosolsConcShortwave, &
          bio_index_o_in   = tracerObject % index_LayerIndexToDataArray, &
          bio_index_in     = tracerObject % index_LayerIndexToBioIndex)
+
+    if (seaice_icepack_aborted()) then
+       call seaice_icepack_write_warnings(.true.)
+       call mpas_log_write("init_icepack_package_tracer_indices: icepack aborted", MPAS_LOG_CRIT)
+    endif
 
   end subroutine init_icepack_package_tracer_indices
 
@@ -12387,7 +12395,9 @@ contains
          config_max_dry_snow_radius
 
     integer, pointer :: &
-         config_boundary_layer_iteration_number, &
+         config_boundary_layer_iteration_number
+
+    integer :: &
          config_thermodynamics_type_int, &
          config_ice_strength_formulation_int, &
          config_ridging_participation_function_int, &
@@ -17722,34 +17732,48 @@ contains
 
 !-----------------------------------------------------------------------
 
-  !subroutine seaice_icepack_write_warnings(logAsErrors)
+  subroutine seaice_icepack_write_warnings(logAsErrors)
 
-  !  use icepack_intfc, only: &
-  !       icepack_warnings_getall
+    use icepack_intfc, only: &
+         icepack_warnings_getall
 
-  !  character(len=strKINDWarnings), dimension(:), allocatable :: &
-  !       warnings
+    character(len=strKINDWarnings), dimension(:), allocatable :: &
+         warnings
 
-  !  logical, intent(in) :: &
-  !       logAsErrors
+    logical, intent(in) :: &
+         logAsErrors
 
-  !  integer :: &
-  !       iWarning
+    integer :: &
+         iWarning
 
-  !  call icepack_warnings_getall(warnings)
+    call icepack_warnings_getall(warnings)
 
-  !  if (logAsErrors) then
-  !     do iWarning = 1, size(warnings)
-  !        call mpas_log_write(trim(warnings(iWarning)), messageType=MPAS_LOG_ERR)
-  !     enddo ! iWarning
-  !  else
-  !     do iWarning = 1, size(warnings)
-  !        call mpas_log_write(trim(warnings(iWarning)), messageType=MPAS_LOG_WARN)
-  !     enddo ! iWarning
-  !  endif
+    if (logAsErrors) then
+       do iWarning = 1, size(warnings)
+          call mpas_log_write(trim(warnings(iWarning)), messageType=MPAS_LOG_ERR)
+       enddo ! iWarning
+    else
+       do iWarning = 1, size(warnings)
+          call mpas_log_write(trim(warnings(iWarning)), messageType=MPAS_LOG_WARN)
+       enddo ! iWarning
+    endif
 
-  !end subroutine seaice_icepack_write_warnings
+  end subroutine seaice_icepack_write_warnings
 
-!-----------------------------------------------------------------------
+  !-----------------------------------------------------------------------
+
+  function seaice_icepack_aborted() result(aborted)
+
+    use icepack_intfc, only: &
+         icepack_warnings_aborted
+
+    logical :: &
+         aborted
+
+    aborted = icepack_warnings_aborted()
+
+  end function seaice_icepack_aborted
+
+  !-----------------------------------------------------------------------
 
 end module seaice_icepack

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -725,14 +725,12 @@ contains
          config_shortwave_type
 
     logical, pointer :: &
-         config_do_restart, &
-         config_use_snicar_ad
+         config_do_restart
 
     call icepack_init_radiation()
 
     call MPAS_pool_get_config(domain % configs, "config_shortwave_type", config_shortwave_type)
     call MPAS_pool_get_config(domain % configs, "config_do_restart", config_do_restart)
-    call MPAS_pool_get_config(domain % configs, "config_use_snicar_ad", config_use_snicar_ad)
 
     if (trim(config_shortwave_type) == "dEdd") then
 
@@ -2594,9 +2592,6 @@ contains
        do iCell = 1, nCellsSolve
 
           call icepack_prep_radiation(&
-               ncat=nCategories, &
-               nilyr=nIceLayers, &
-               nslyr=nSnowLayers, &
                aice=iceAreaCell(iCell), &
                aicen=iceAreaCategory(1,:,iCell), &
                swvdr=shortwaveVisibleDirectDown(iCell), &
@@ -2906,10 +2901,7 @@ contains
          atmos_coupling, &
          shortwave, &
          ponds, &
-         aerosols, &
-         biogeochemistry, &
-         snicar, &
-         snow
+         biogeochemistry
 
     ! configs
     real(kind=RKIND), pointer :: &
@@ -2963,30 +2955,11 @@ contains
          effectivePondAreaCategory, &
          pondSnowDepthDifference, &
          pondLidMeltFluxFraction, &
-         aerosolMassExtinctionCrossSection, &
-         aerosolSingleScatterAlbedo, &
-         aerosolAsymmetryParameter, &
-         modalMassExtinctionCrossSection, &
-         modalSingleScatterAlbedo, &
-         modalAsymmetryParameter, &
          albedoVisibleDirectCategory, &
          albedoVisibleDiffuseCategory, &
          albedoIRDirectCategory, &
          albedoIRDiffuseCategory, &
-         snowFractionCategory, &
-         iceAsymmetryParameterDirect, &
-         iceAsymmetryParameterDiffuse, &
-         iceSingleScatterAlbedoDirect, &
-         iceSingleScatterAlbedoDiffuse, &
-         iceMassExtinctionCrossSectionDirect, &
-         iceMassExtinctionCrossSectionDiffuse, &
-         aerosolAsymmetryParameter5band, &
-         aerosolMassExtinctionCrossSection5band, &
-         aerosolSingleScatterAlbedo5band, &
-         modalAsymmetryParameter5band, &
-         modalMassExtinctionCrossSection5band, &
-         modalSingleScatterAlbedo5band, &
-         snowRadiusInStandardRadiationSchemeCategory
+         snowFractionCategory
 
     real(kind=RKIND), dimension(:,:,:), pointer :: &
          iceAreaCategory, &
@@ -3005,9 +2978,7 @@ contains
          iceScatteringAerosol, &
          iceBodyAerosol, &
          brineFraction, &
-         modalBCabsorptionParameter, &
          bioTracerShortwave, &
-         modalBCabsorptionParameter5band, &
          snowGrainRadius
 
     real(kind=RKIND), pointer :: &
@@ -3028,7 +2999,6 @@ contains
          iCell, &
          iCategory, &
          iAerosol, &
-         iTracer, &
          iBioTracers
 
     integer, dimension(:), allocatable :: &
@@ -3070,10 +3040,7 @@ contains
        call MPAS_pool_get_subpool(block % structs, "atmos_coupling", atmos_coupling)
        call MPAS_pool_get_subpool(block % structs, "shortwave", shortwave)
        call MPAS_pool_get_subpool(block % structs, "ponds", ponds)
-       call MPAS_pool_get_subpool(block % structs, "aerosols", aerosols)
        call MPAS_pool_get_subpool(block % structs, "biogeochemistry", biogeochemistry)
-       call MPAS_pool_get_subpool(block % structs, "snicar", snicar)
-       call MPAS_pool_get_subpool(block % structs, "snow", snow)
 
        call MPAS_pool_get_config(block % configs, "config_dt", config_dt)
        call MPAS_pool_get_config(block % configs, "config_snow_redistribution_scheme", config_snow_redistribution_scheme)
@@ -3137,34 +3104,9 @@ contains
        call MPAS_pool_get_array(ponds, "pondSnowDepthDifference", pondSnowDepthDifference)
        call MPAS_pool_get_array(ponds, "pondLidMeltFluxFraction", pondLidMeltFluxFraction)
 
-       call MPAS_pool_get_array(aerosols, "aerosolMassExtinctionCrossSection", aerosolMassExtinctionCrossSection)
-       call MPAS_pool_get_array(aerosols, "aerosolSingleScatterAlbedo", aerosolSingleScatterAlbedo)
-       call MPAS_pool_get_array(aerosols, "aerosolAsymmetryParameter", aerosolAsymmetryParameter)
-       call MPAS_pool_get_array(aerosols, "modalMassExtinctionCrossSection", modalMassExtinctionCrossSection)
-       call MPAS_pool_get_array(aerosols, "modalSingleScatterAlbedo", modalSingleScatterAlbedo)
-       call MPAS_pool_get_array(aerosols, "modalAsymmetryParameter", modalAsymmetryParameter)
-       call MPAS_pool_get_array(aerosols, "modalBCabsorptionParameter", modalBCabsorptionParameter)
-
        call MPAS_pool_get_array(biogeochemistry, "bioTracerShortwave", bioTracerShortwave)
        call MPAS_pool_get_array(biogeochemistry, "verticalShortwaveGrid", verticalShortwaveGrid)
        call MPAS_pool_get_array(biogeochemistry, "verticalGrid", verticalGrid)
-
-       ! snicar 5-band snow IOPs
-       call MPAS_pool_get_array(snicar, "iceAsymmetryParameterDirect", iceAsymmetryParameterDirect)
-       call MPAS_pool_get_array(snicar, "iceAsymmetryParameterDiffuse", iceAsymmetryParameterDiffuse)
-       call MPAS_pool_get_array(snicar, "iceSingleScatterAlbedoDirect", iceSingleScatterAlbedoDirect)
-       call MPAS_pool_get_array(snicar, "iceSingleScatterAlbedoDiffuse", iceSingleScatterAlbedoDiffuse)
-       call MPAS_pool_get_array(snicar, "iceMassExtinctionCrossSectionDirect", iceMassExtinctionCrossSectionDirect)
-       call MPAS_pool_get_array(snicar, "iceMassExtinctionCrossSectionDiffuse", iceMassExtinctionCrossSectionDiffuse)
-       call MPAS_pool_get_array(snicar, "aerosolMassExtinctionCrossSection5band", aerosolMassExtinctionCrossSection5band)
-       call MPAS_pool_get_array(snicar, "aerosolSingleScatterAlbedo5band", aerosolSingleScatterAlbedo5band)
-       call MPAS_pool_get_array(snicar, "aerosolAsymmetryParameter5band", aerosolAsymmetryParameter5band)
-       call MPAS_pool_get_array(snicar, "modalMassExtinctionCrossSection5band", modalMassExtinctionCrossSection5band)
-       call MPAS_pool_get_array(snicar, "modalSingleScatterAlbedo5band", modalSingleScatterAlbedo5band)
-       call MPAS_pool_get_array(snicar, "modalAsymmetryParameter5band", modalAsymmetryParameter5band)
-       call MPAS_pool_get_array(snicar, "modalBCabsorptionParameter5band", modalBCabsorptionParameter5band)
-
-       call MPAS_pool_get_array(snow, "snowRadiusInStandardRadiationSchemeCategory", snowRadiusInStandardRadiationSchemeCategory)
 
        ! calendar type
        call MPAS_pool_get_config(block % configs, "config_calendar_type", config_calendar_type)
@@ -3223,11 +3165,6 @@ contains
           call icepack_warnings_clear()
           call icepack_step_radiation(&
                dt=config_dt, &
-               ncat=nCategories, &
-               nblyr=nBioLayers, &
-               nilyr=nIceLayers, &
-               nslyr=nSnowLayers, &
-               dEdd_algae=config_use_shortwave_bioabsorption, &
                swgrid=verticalShortwaveGrid(:), &
                igrid=verticalGrid(:), &
                fbri=brineFraction(1,:,iCell), &
@@ -3250,14 +3187,6 @@ contains
                nextsw_cday=dayOfNextShortwaveCalculation, &
                yday=dayOfYear, &
                sec=secondsIntoDay, &
-               kaer_3bd=aerosolMassExtinctionCrossSection(:,:), &
-               waer_3bd=aerosolSingleScatterAlbedo(:,:), &
-               gaer_3bd=aerosolAsymmetryParameter(:,:), &
-               kaer_bc_3bd=modalMassExtinctionCrossSection(:,:), &
-               waer_bc_3bd=modalSingleScatterAlbedo(:,:), &
-               gaer_bc_3bd=modalAsymmetryParameter(:,:), &
-               bcenh_3bd=modalBCabsorptionParameter(:,:,:), &
-               modal_aero=config_use_modal_aerosols, &
                swvdr=shortwaveVisibleDirectDown(iCell), &
                swvdf=shortwaveVisibleDiffuseDown(iCell), &
                swidr=shortwaveIRDirectDown(iCell), &
@@ -3288,7 +3217,6 @@ contains
                rsnow=snowGrainRadius(:,:,iCell), &
                l_print_point=.false., &
                initonly=lInitialization)
-
           call column_write_warnings(.false.)
 
           ! set the category tracer array
@@ -9518,6 +9446,7 @@ contains
          config_nIceLayers
 
     character(len=strKIND), pointer :: &
+         config_column_physics_type, &
          config_thermodynamics_type, &
          config_heat_conductivity_type, &
          config_shortwave_type, &
@@ -9558,7 +9487,8 @@ contains
          config_use_DON, &
          config_use_iron, &
          config_use_modal_aerosols, &
-         config_use_column_biogeochemistry
+         config_use_column_biogeochemistry, &
+         config_use_snicar_ad
 
     logical :: &
          use_meltponds
@@ -9574,6 +9504,8 @@ contains
     call MPAS_pool_get_dimension(domain % blocklist % dimensions, "nCategories", nCategories)
     call MPAS_pool_get_dimension(domain % blocklist % dimensions, "nSnowLayers", nSnowLayers)
     call MPAS_pool_get_dimension(domain % blocklist % dimensions, "nIceLayers", nIceLayers)
+
+    call MPAS_pool_get_config(domain % configs, "config_column_physics_type", config_column_physics_type)
 
     call MPAS_pool_get_config(domain % configs, "config_thermodynamics_type", config_thermodynamics_type)
     call MPAS_pool_get_config(domain % configs, "config_heat_conductivity_type", config_heat_conductivity_type)
@@ -9596,6 +9528,7 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_use_cesm_meltponds", config_use_cesm_meltponds)
     call MPAS_pool_get_config(domain % configs, "config_use_level_meltponds", config_use_level_meltponds)
     call MPAS_pool_get_config(domain % configs, "config_use_topo_meltponds", config_use_topo_meltponds)
+    call MPAS_pool_get_config(domain % configs, "config_use_snicar_ad", config_use_snicar_ad)
     call MPAS_pool_get_config(domain % configs, "config_ocean_heat_transfer_type", config_ocean_heat_transfer_type)
     call MPAS_pool_get_config(domain % configs, "config_sea_freezing_temperature_type", config_sea_freezing_temperature_type)
     call MPAS_pool_get_config(domain % configs, "config_use_brine", config_use_brine)
@@ -9707,6 +9640,12 @@ contains
     if (config_nIceLayers /= nIcelayers) &
        call mpas_log_write(&
             'Check for inconsistencies in restart file: config_nIceLayers /= nIceLayers', &
+            messageType=MPAS_LOG_CRIT)
+
+    ! check snicar value
+    if (config_use_snicar_ad .and. trim(config_column_physics_type) == "icepack") &
+       call mpas_log_write(&
+            "Use config_shortwave_type='dEdd_snicar_ad' for Snicar in Icepack", &
             messageType=MPAS_LOG_CRIT)
 
     !-----------------------------------------------------------------------
@@ -12233,8 +12172,8 @@ contains
          config_use_skeletal_biochemistry, &
          config_use_vertical_zsalinity, &
          config_use_modal_aerosols, &
-         config_use_snicar_ad, &
-         config_use_snow_liquid_ponds
+         config_use_snow_liquid_ponds, &
+         config_use_snow_grain_radius
 
     real(kind=RKIND), pointer :: &
          config_min_friction_velocity, &
@@ -12418,7 +12357,6 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_slow_mode_critical_porosity", config_slow_mode_critical_porosity)
     call MPAS_pool_get_config(domain % configs, "config_congelation_ice_porosity", config_congelation_ice_porosity)
     call MPAS_pool_get_config(domain % configs, "config_shortwave_type", config_shortwave_type)
-    call MPAS_pool_get_config(domain % configs, "config_use_snicar_ad", config_use_snicar_ad)
     call MPAS_pool_get_config(domain % configs, "config_albedo_type", config_albedo_type)
     call MPAS_pool_get_config(domain % configs, "config_visible_ice_albedo", config_visible_ice_albedo)
     call MPAS_pool_get_config(domain % configs, "config_infrared_ice_albedo", config_infrared_ice_albedo)
@@ -12605,6 +12543,7 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_minimum_wind_compaction", config_minimum_wind_compaction)
     call MPAS_pool_get_config(domain % configs, "config_wind_compaction_factor", config_wind_compaction_factor)
     call MPAS_pool_get_config(domain % configs, "config_max_dry_snow_radius", config_max_dry_snow_radius)
+    call MPAS_pool_get_config(domain % configs, "config_use_snow_grain_radius", config_use_snow_grain_radius)
 
     config_thermodynamics_type_int = config_cice_int("config_thermodynamics_type", config_thermodynamics_type)
     config_ice_strength_formulation_int = config_cice_int("config_ice_strength_formulation", config_ice_strength_formulation)
@@ -12689,7 +12628,6 @@ contains
          phi_c_slow_mode_in      = config_slow_mode_critical_porosity, &
          phi_i_mushy_in          = config_congelation_ice_porosity, &
          shortwave_in            = config_shortwave_type, &
-         use_snicar_in           = config_use_snicar_ad, &
          albedo_type_in          = config_albedo_type, &
          albsnowi_in             = config_infrared_snow_albedo, &
          albicev_in              = config_visible_ice_albedo, &
@@ -12740,8 +12678,8 @@ contains
          initbio_frac_in         = config_new_ice_fraction_biotracer, &
          grid_oS_in              = config_zsalinity_molecular_sublayer, &
          l_skS_in                = config_zsalinity_gravity_drainage_scale, &
-         !dEdd_algae_in           = , &
-         phi_snow_in             = config_snow_porosity_at_ice_surface &
+         dEdd_algae_in           = config_use_shortwave_bioabsorption, &
+         phi_snow_in             = config_snow_porosity_at_ice_surface, &
          !T_max_in                = , &
          !fsal_in                 = , &
          !fr_resp_in              = , &
@@ -12766,7 +12704,7 @@ contains
          !sw_redist_in            = , &
          !sw_frac_in              = , &
          !sw_dtemp_in             = , &
-         !snwgrain_in             = , &
+         snwgrain_in             = config_use_snow_grain_radius &
          !snwredist_in            = , &
          !use_smliq_pnd_in        = , &
          !rsnw_fall_in            = , &
@@ -12818,7 +12756,6 @@ contains
     !     phi_c_slow_mode       = config_slow_mode_critical_porosity, &
     !     phi_i_mushy           = config_congelation_ice_porosity, &
     !     shortwave             = config_shortwave_type, &
-    !     use_snicar            = config_use_snicar_ad, &
     !     albedo_type           = config_albedo_type, &
     !     albicev               = config_visible_ice_albedo, &
     !     albicei               = config_infrared_ice_albedo, &

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -12345,8 +12345,8 @@ contains
          config_itd_conversion_type_int, &
          config_category_bounds_type_int
 
-    character(len=strKIND) :: &
-         tmp_config_shortwave
+    character(len=strKIND), pointer :: tmp
+    character(len=strKIND), pointer :: tmp_config_shortwave
 
     call MPAS_pool_get_config(domain % configs, "config_thermodynamics_type", config_thermodynamics_type)
     call MPAS_pool_get_config(domain % configs, "config_heat_conductivity_type", config_heat_conductivity_type)
@@ -12556,10 +12556,12 @@ contains
     config_itd_conversion_type_int = config_cice_int("config_itd_conversion_type", config_itd_conversion_type)
     config_category_bounds_type_int = config_cice_int("config_category_bounds_type", config_category_bounds_type)
 
-    if (config_use_snicar_ad .and. trim(config_shortwave_type) == 'dEdd') then
-       tmp_config_shortwave = 'dEdd_snicar_ad'
-    else
-       tmp_config_shortwave = trim(config_shortwave_type)
+    tmp_config_shortwave => config_shortwave_type
+    if (config_use_snicar_ad .and. (trim(config_shortwave_type(1:4)) == "dEdd")) then
+       allocate (tmp)                    !echmod: is tmp necessary?
+       tmp = 'dEdd_snicar_ad'
+       tmp_config_shortwave => tmp
+       deallocate (tmp)
     endif
 
     call icepack_init_parameters(&

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -3113,7 +3113,7 @@ contains
        if (trim(config_calendar_type) == "gregorian") then
           calendarType = "GREGORIAN"
        else
-          calendarType = "GREGORIAN_NOLEAP"
+          calendarType = "NOLEAP"
        endif
 
        ! aerosols array
@@ -4236,7 +4236,7 @@ contains
        else
           daysInYear = sum(daysInMonth)
        endif
-    case ("gregorian_noleap")
+    case ("noleap")
        daysInYear = sum(daysInMonth)
     end select
 

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -10,7 +10,7 @@
 !
 !-----------------------------------------------------------------------
 
-module seaice_column
+module seaice_icepack
 
   use mpas_derived_types
   use mpas_pool_routines
@@ -21,7 +21,7 @@ module seaice_column
   use seaice_error
 
   use ice_kinds_mod, only: &
-       char_len_long
+      char_len_long
 
   implicit none
 
@@ -29,31 +29,31 @@ module seaice_column
   save
 
   public :: &
-       seaice_init_column_physics_package_parameters, &
-       seaice_init_column_physics_package_variables, &
-       seaice_column_predynamics_time_integration, &
-       seaice_column_dynamics_time_integration, &
-       seaice_column_postdynamics_time_integration, &
-       seaice_init_column_shortwave, &
-       seaice_column_aggregate, &
-       seaice_column_aggregate_simple, &
-       seaice_column_initial_air_drag_coefficient, &
-       seaice_column_reinitialize_fluxes, &
-       seaice_column_reinitialize_diagnostics_thermodynamics, &
-       seaice_column_reinitialize_diagnostics_dynamics, &
-       seaice_column_reinitialize_diagnostics_bgc, &
-       seaice_column_coupling_prep, &
-       seaice_column_finalize, &
-       seaice_column_init_trcr, &
-       seaice_column_init_itd, &
-       seaice_column_init_ocean_conc, &
-       seaice_column_ice_strength, &
-       seaice_column_sea_freezing_temperature, &
-       seaice_column_liquidus_temperature, &
-       seaice_column_enthalpy_snow, &
-       seaice_column_enthalpy_ice, &
-       seaice_column_salinity_profile, &
-       seaice_init_column_constants
+       seaice_init_icepack_physics_package_parameters, &
+       seaice_init_icepack_physics_package_variables, &
+       seaice_icepack_predynamics_time_integration, &
+       seaice_icepack_dynamics_time_integration, &
+       seaice_icepack_postdynamics_time_integration, &
+       seaice_init_icepack_shortwave, &
+       seaice_icepack_aggregate, &
+       seaice_icepack_aggregate_simple, &
+       seaice_icepack_initial_air_drag_coefficient, &
+       seaice_icepack_reinitialize_fluxes, &
+       seaice_icepack_reinitialize_diagnostics_thermodynamics, &
+       seaice_icepack_reinitialize_diagnostics_dynamics, &
+       seaice_icepack_reinitialize_diagnostics_bgc, &
+       seaice_icepack_coupling_prep, &
+       seaice_icepack_finalize, &
+       seaice_icepack_init_trcr, &
+       seaice_icepack_init_itd, &
+       seaice_icepack_init_ocean_conc, &
+       seaice_icepack_ice_strength, &
+       seaice_icepack_sea_freezing_temperature, &
+       seaice_icepack_liquidus_temperature, &
+       seaice_icepack_enthalpy_snow, &
+       seaice_icepack_enthalpy_ice, &
+       seaice_icepack_salinity_profile, &
+       seaice_init_icepack_constants
 
   ! tracer object
   type, private :: ciceTracerObjectType
@@ -203,7 +203,7 @@ contains
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!  seaice_init_column_physics_package_parameters
+!  seaice_init_icepack_physics_package_parameters
 !
 !> \brief
 !> \author Adrian K. Turner, LANL
@@ -213,7 +213,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-  subroutine seaice_init_column_physics_package_parameters(domain)
+  subroutine seaice_init_icepack_physics_package_parameters(domain)
 
     type(domain_type), intent(inout) :: domain
 
@@ -232,16 +232,13 @@ contains
        ! initialize the column package parameters
        call init_column_package_parameters(domain, ciceTracerObject)
 
-       ! initialize active column processes
-       call init_column_active_processes(domain)
-
     endif
 
-  end subroutine seaice_init_column_physics_package_parameters
+  end subroutine seaice_init_icepack_physics_package_parameters
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!  seaice_init_column_physics_package_variables
+!  seaice_init_icepack_physics_package_variables
 !
 !> \brief
 !> \author Adrian K. Turner, LANL
@@ -251,7 +248,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-  subroutine seaice_init_column_physics_package_variables(domain, clock)
+  subroutine seaice_init_icepack_physics_package_variables(domain, clock)
 
     type(domain_type), intent(inout) :: domain
 
@@ -295,11 +292,11 @@ contains
        call MPAS_pool_get_config(domain % configs, "config_do_restart", config_do_restart)
        call MPAS_pool_get_config(domain % configs, "config_use_column_shortwave", config_use_column_shortwave)
        if (config_do_restart .and. config_use_column_shortwave) &
-            call seaice_init_column_shortwave(domain, clock)
+            call seaice_init_icepack_shortwave(domain, clock)
 
     endif
 
-  end subroutine seaice_init_column_physics_package_variables
+  end subroutine seaice_init_icepack_physics_package_variables
 
 !-----------------------------------------------------------------------
 ! column package initialization routine wrappers
@@ -350,7 +347,6 @@ contains
 
        call MPAS_pool_get_array(initial, "categoryThicknessLimits", categoryThicknessLimits)
 
-       ! code abort
        abortFlag = .false.
        abortMessage = ""
 
@@ -651,11 +647,14 @@ contains
 !
 !-----------------------------------------------------------------------
 
-  subroutine seaice_init_column_shortwave(domain, clock)
+  subroutine seaice_init_icepack_shortwave(domain, clock)
 
     use ice_colpkg, only: &
          colpkg_init_orbit, &
          colpkg_clear_warnings
+
+    use icepack_intfc, only: &
+         icepack_init_radiation
 
     use seaice_constants, only: &
          seaicePuny
@@ -727,13 +726,14 @@ contains
          config_do_restart, &
          config_use_snicar_ad
 
+    call icepack_init_radiation()
+
     call MPAS_pool_get_config(domain % configs, "config_shortwave_type", config_shortwave_type)
     call MPAS_pool_get_config(domain % configs, "config_do_restart", config_do_restart)
     call MPAS_pool_get_config(domain % configs, "config_use_snicar_ad", config_use_snicar_ad)
 
     if (trim(config_shortwave_type) == "dEdd") then
 
-       ! code abort
        abortFlag = .false.
        abortMessage = ""
 
@@ -743,7 +743,6 @@ contains
             abortMessage)
        call column_write_warnings(abortFlag)
 
-       ! code abort
        if (abortFlag) then
           call mpas_log_write("colpkg_init_orbit: "//trim(abortMessage), messageType=MPAS_LOG_CRIT)
       endif
@@ -862,7 +861,7 @@ contains
        block => block % next
     end do
 
-  end subroutine seaice_init_column_shortwave
+  end subroutine seaice_init_icepack_shortwave
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
@@ -1019,7 +1018,7 @@ contains
 !-----------------------------------------------------------------------
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!  seaice_column_finalize
+!  seaice_icepack_finalize
 !
 !> \brief
 !> \author Adrian K. Turner, LANL
@@ -1029,20 +1028,20 @@ contains
 !
 !-----------------------------------------------------------------------
 
-  subroutine seaice_column_finalize(domain)
+  subroutine seaice_icepack_finalize(domain)
 
     type(domain_type), intent(inout) :: domain
 
     call finalize_column_non_activated_pointers(domain)
 
-  end subroutine seaice_column_finalize
+  end subroutine seaice_icepack_finalize
 
 !-----------------------------------------------------------------------
 ! runtime
 !-----------------------------------------------------------------------
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!  seaice_column_predynamics_time_integration
+!  seaice_icepack_predynamics_time_integration
 !
 !> \brief
 !> \author Adrian K. Turner, LANL
@@ -1052,7 +1051,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-  subroutine seaice_column_predynamics_time_integration(domain, clock)
+  subroutine seaice_icepack_predynamics_time_integration(domain, clock)
 
     type(domain_type), intent(inout) :: domain
 
@@ -1139,11 +1138,11 @@ contains
 
     endif
 
-  end subroutine seaice_column_predynamics_time_integration
+  end subroutine seaice_icepack_predynamics_time_integration
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!  seaice_column_dynamics_time_integration
+!  seaice_icepack_dynamics_time_integration
 !
 !> \brief
 !> \author Adrian K. Turner, LANL
@@ -1153,7 +1152,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-  subroutine seaice_column_dynamics_time_integration(domain, clock)
+  subroutine seaice_icepack_dynamics_time_integration(domain, clock)
 
     type(domain_type), intent(inout) :: domain
 
@@ -1209,16 +1208,16 @@ contains
     else
 
        call mpas_timer_start("Column aggregate")
-       call seaice_column_aggregate_simple(domain)
+       call seaice_icepack_aggregate_simple(domain)
        call mpas_timer_stop("Column aggregate")
 
     endif
 
-  end subroutine seaice_column_dynamics_time_integration
+  end subroutine seaice_icepack_dynamics_time_integration
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!  seaice_column_postdynamics_time_integration
+!  seaice_icepack_postdynamics_time_integration
 !
 !> \brief
 !> \author Adrian K. Turner, LANL
@@ -1228,7 +1227,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-  subroutine seaice_column_postdynamics_time_integration(domain, clock)
+  subroutine seaice_icepack_postdynamics_time_integration(domain, clock)
 
     type(domain_type), intent(inout) :: domain
 
@@ -1272,12 +1271,12 @@ contains
        !-----------------------------------------------------------------
 
        call mpas_timer_start("Column coupling prep")
-       call seaice_column_coupling_prep(domain)
+       call seaice_icepack_coupling_prep(domain)
        call mpas_timer_stop("Column coupling prep")
 
     endif
 
-  end subroutine seaice_column_postdynamics_time_integration
+  end subroutine seaice_icepack_postdynamics_time_integration
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
@@ -1497,8 +1496,7 @@ contains
 
     logical :: &
          northernHemisphereMask, &
-         abortFlag, &
-         anyAbort
+         abortFlag
 
     character(len=strKIND) :: &
          abortMessage, &
@@ -1714,7 +1712,6 @@ contains
        ! code abort
        abortFlag = .false.
        abortMessage = ""
-       anyAbort = .false.
 
        !$omp parallel do default(shared) private(iCategory,iAerosol,northernHemisphereMask,&
        !$omp&  abortMessage) firstprivate(specificSnowAerosol,specificIceAerosol) &
@@ -1896,8 +1893,8 @@ contains
                config_use_prescribed_ice)
           call column_write_warnings(abortFlag)
 
-          ! code abort
-          if (abortFlag .and. .not. anyAbort) then
+          ! cell-specific abort message
+          if (abortFlag) then
              call mpas_log_write("column_vertical_thermodynamics: "//trim(abortMessage) , messageType=MPAS_LOG_ERR)
              call mpas_log_write("iCell: $i", messageType=MPAS_LOG_ERR, intArgs=(/indexToCellID(iCell)/))
 
@@ -2054,9 +2051,6 @@ contains
              call mpas_log_write("freezeOnset: $r", messageType=MPAS_LOG_ERR, realArgs=(/freezeOnset(iCell)/))
              call mpas_log_write("dayOfYear: $r", messageType=MPAS_LOG_ERR, realArgs=(/dayOfYear/))
              call mpas_log_write("config_use_prescribed_ice: $l", messageType=MPAS_LOG_ERR, logicArgs=(/config_use_prescribed_ice/))
-             anyAbort = .true.
-             abortFlag = .false.
-             abortMessage = ""
           endif
 
           ! aerosol
@@ -2086,9 +2080,9 @@ contains
 
        enddo ! iCell
 
-       ! code abort
-       call seaice_critical_error_write_block(domain, block, anyAbort)
-       call seaice_check_critical_error(domain, anyAbort)
+       ! error-checking
+       call seaice_critical_error_write_block(domain, block, abortFlag)
+       call seaice_check_critical_error(domain, abortFlag)
 
        ! aerosols
        deallocate(specificSnowAerosol)
@@ -2228,7 +2222,6 @@ contains
 
     logical :: &
          abortFlag, &
-         anyAbort, &
          setGetPhysicsTracers, &
          setGetBGCTracers, &
          checkCarbon
@@ -2339,7 +2332,6 @@ contains
        ! code abort
        abortFlag = .false.
        abortMessage = ""
-       anyAbort = .false.
 
        !$omp parallel do default(shared) private(iCategory,iBioTracers,iBioData,&
        !$omp&   totalCarbonInitial,abortMessage,oceanBioFluxesTemp,totalCarbonFinal,&
@@ -2462,20 +2454,17 @@ contains
             endif
           endif
 
-          ! code abort
-          if (abortFlag .and. .not. anyAbort) then
+          ! cell-specific abort message
+          if (abortFlag) then
              call mpas_log_write("column_itd_thermodynamics: "//trim(abortMessage) , messageType=MPAS_LOG_ERR)
              call mpas_log_write("iCell: $i", messageType=MPAS_LOG_ERR, intArgs=(/indexToCellID(iCell)/))
-             abortFlag = .false.
-             abortMessage = ""
-             anyAbort = .true.
           endif
 
        enddo ! iCell
 
-       ! code abort
-       call seaice_critical_error_write_block(domain, block, anyAbort)
-       call seaice_check_critical_error(domain, anyAbort)
+       ! error checking
+       call seaice_critical_error_write_block(domain, block, abortFlag)
+       call seaice_check_critical_error(domain, abortFlag)
 
        if (checkCarbon) then
           deallocate(totalCarbonCatFinal)
@@ -2507,7 +2496,8 @@ contains
 
   subroutine column_prep_radiation(domain)
 
-    use ice_colpkg, only: colpkg_prep_radiation
+    use icepack_intfc, only: &
+         icepack_prep_radiation
 
     type(domain_type), intent(inout) :: domain
 
@@ -2543,7 +2533,11 @@ contains
     real(kind=RKIND), dimension(:,:), pointer :: &
          surfaceShortwaveFlux, &
          interiorShortwaveFlux, &
-         penetratingShortwaveFlux
+         penetratingShortwaveFlux, &
+         penetratingShortwaveFluxVisibleDirect, &
+         penetratingShortwaveFluxVisibleDiffuse, &
+         penetratingShortwaveFluxIRDirect, &
+         penetratingShortwaveFluxIRDiffuse
 
     real(kind=RKIND), dimension(:,:,:), pointer :: &
          iceAreaCategory, &
@@ -2586,33 +2580,41 @@ contains
        call MPAS_pool_get_array(shortwave, "surfaceShortwaveFlux", surfaceShortwaveFlux)
        call MPAS_pool_get_array(shortwave, "interiorShortwaveFlux", interiorShortwaveFlux)
        call MPAS_pool_get_array(shortwave, "penetratingShortwaveFlux", penetratingShortwaveFlux)
+       call MPAS_pool_get_array(shortwave, "penetratingShortwaveFluxVisibleDirect", penetratingShortwaveFluxVisibleDirect)
+       call MPAS_pool_get_array(shortwave, "penetratingShortwaveFluxVisibleDiffuse", penetratingShortwaveFluxVisibleDiffuse)
+       call MPAS_pool_get_array(shortwave, "penetratingShortwaveFluxIRDirect", penetratingShortwaveFluxIRDirect)
+       call MPAS_pool_get_array(shortwave, "penetratingShortwaveFluxIRDiffuse", penetratingShortwaveFluxIRDiffuse)
        call MPAS_pool_get_array(shortwave, "shortwaveLayerPenetration", shortwaveLayerPenetration)
        call MPAS_pool_get_array(shortwave, "absorbedShortwaveSnowLayer", absorbedShortwaveSnowLayer)
        call MPAS_pool_get_array(shortwave, "absorbedShortwaveIceLayer", absorbedShortwaveIceLayer)
 
        do iCell = 1, nCellsSolve
 
-          call colpkg_prep_radiation(&
-               nCategories, &
-               nIceLayers, &
-               nSnowLayers, &
-               iceAreaCell(iCell), &
-               iceAreaCategory(1,:,iCell), &
-               shortwaveVisibleDirectDown(iCell), &
-               shortwaveVisibleDiffuseDown(iCell), &
-               shortwaveIRDirectDown(iCell), &
-               shortwaveIRDiffuseDown(iCell), &
-               albedoVisibleDirectArea(iCell), &
-               albedoVisibleDiffuseArea(iCell), &
-               albedoIRDirectArea(iCell), &
-               albedoIRDiffuseArea(iCell), &
-               shortwaveScalingFactor(iCell), &
-               surfaceShortwaveFlux(:,iCell), &
-               interiorShortwaveFlux(:,iCell), &
-               penetratingShortwaveFlux(:,iCell), &
-               shortwaveLayerPenetration(:,:,iCell), &
-               absorbedShortwaveSnowLayer(:,:,iCell), &
-               absorbedShortwaveIceLayer(:,:,iCell))
+          call icepack_prep_radiation(&
+               ncat=nCategories, &
+               nilyr=nIceLayers, &
+               nslyr=nSnowLayers, &
+               aice=iceAreaCell(iCell), &
+               aicen=iceAreaCategory(1,:,iCell), &
+               swvdr=shortwaveVisibleDirectDown(iCell), &
+               swvdf=shortwaveVisibleDiffuseDown(iCell), &
+               swidr=shortwaveIRDirectDown(iCell), &
+               swidf=shortwaveIRDiffuseDown(iCell), &
+               alvdr_ai=albedoVisibleDirectArea(iCell), &
+               alvdf_ai=albedoVisibleDiffuseArea(iCell), &
+               alidr_ai=albedoIRDirectArea(iCell), &
+               alidf_ai=albedoIRDiffuseArea(iCell), &
+               scale_factor=shortwaveScalingFactor(iCell), &
+               fswsfcn=surfaceShortwaveFlux(:,iCell), &
+               fswintn=interiorShortwaveFlux(:,iCell), &
+               fswthrun=penetratingShortwaveFlux(:,iCell), &
+               fswthrun_vdr=penetratingShortwaveFluxVisibleDirect(:,iCell), &
+               fswthrun_vdf=penetratingShortwaveFluxVisibleDiffuse(:,iCell), &
+               fswthrun_idr=penetratingShortwaveFluxIRDirect(:,iCell), &
+               fswthrun_idf=penetratingShortwaveFluxIRDiffuse(:,iCell), &
+               fswpenln=shortwaveLayerPenetration(:,:,iCell), &
+               Sswabsn=absorbedShortwaveSnowLayer(:,:,iCell), &
+               Iswabsn=absorbedShortwaveIceLayer(:,:,iCell))
 
        enddo ! iCell
 
@@ -2807,13 +2809,12 @@ contains
 
        allocate(effectiveSnowDensityCategory(1:nSnowLayers,1:nCategories))
 
-       ! code abort
-       abortFlag = .false.
-       abortMessage = ""
-
        do iCell = 1, nCellsSolve
 
           effectiveSnowDensityCategory(:,:) = 0.0_RKIND
+
+          abortFlag = .false.
+          abortMessage = ""
 
           call colpkg_clear_warnings()
           call colpkg_step_snow (&
@@ -2857,16 +2858,10 @@ contains
                abortMessage)
 
           call column_write_warnings(abortFlag)
-          ! code abort
-          if (abortFlag) exit
 
        enddo !iCell
 
        deallocate(effectiveSnowDensityCategory)
-
-       ! code abort
-       call seaice_critical_error_write_block(domain, block, abortFlag)
-       call seaice_check_critical_error(domain, abortFlag)
 
        block => block % next
     end do
@@ -2887,10 +2882,9 @@ contains
 
   subroutine column_radiation(domain, clock, lInitialization)
 
-    use ice_colpkg, only: &
-         colpkg_step_radiation, &
-         colpkg_clear_warnings
-
+    use icepack_intfc, only: &
+         icepack_step_radiation, &
+         icepack_warnings_clear
     use seaice_constants, only: &
          pii
 
@@ -2956,6 +2950,10 @@ contains
          surfaceShortwaveFlux, &
          interiorShortwaveFlux, &
          penetratingShortwaveFlux, &
+         penetratingShortwaveFluxVisibleDirect, &
+         penetratingShortwaveFluxVisibleDiffuse, &
+         penetratingShortwaveFluxIRDirect, &
+         penetratingShortwaveFluxIRDiffuse, &
          bareIceAlbedoCategory, &
          snowAlbedoCategory, &
          pondAlbedoCategory, &
@@ -3027,10 +3025,13 @@ contains
          iCell, &
          iCategory, &
          iAerosol, &
-         iTracer
+         iTracer, &
+         iBioTracers
 
     integer, dimension(:), allocatable :: &
-         index_shortwaveAerosol
+         index_shortwaveAerosol, &
+         index_verticalAerosolsConc, &
+         index_algaeConc
 
     real(kind=RKIND) :: &
          dayOfYear, &
@@ -3117,6 +3118,10 @@ contains
        call MPAS_pool_get_array(shortwave, "surfaceShortwaveFlux", surfaceShortwaveFlux)
        call MPAS_pool_get_array(shortwave, "interiorShortwaveFlux", interiorShortwaveFlux)
        call MPAS_pool_get_array(shortwave, "penetratingShortwaveFlux", penetratingShortwaveFlux)
+       call MPAS_pool_get_array(shortwave, "penetratingShortwaveFluxVisibleDirect", penetratingShortwaveFluxVisibleDirect)
+       call MPAS_pool_get_array(shortwave, "penetratingShortwaveFluxVisibleDiffuse", penetratingShortwaveFluxVisibleDiffuse)
+       call MPAS_pool_get_array(shortwave, "penetratingShortwaveFluxIRDirect", penetratingShortwaveFluxIRDirect)
+       call MPAS_pool_get_array(shortwave, "penetratingShortwaveFluxIRDiffuse", penetratingShortwaveFluxIRDiffuse)
        call MPAS_pool_get_array(shortwave, "shortwaveLayerPenetration", shortwaveLayerPenetration)
        call MPAS_pool_get_array(shortwave, "absorbedShortwaveSnowLayer", absorbedShortwaveSnowLayer)
        call MPAS_pool_get_array(shortwave, "absorbedShortwaveIceLayer", absorbedShortwaveIceLayer)
@@ -3163,18 +3168,26 @@ contains
        if (trim(config_calendar_type) == "gregorian") then
           calendarType = "GREGORIAN"
        else
-          calendarType = "NOLEAP"
+          calendarType = "GREGORIAN_NOLEAP"
        endif
 
        ! aerosols array
        allocate(aerosolsArray(4*nAerosols,nCategories))
-       allocate(index_shortwaveAerosol(maxAerosolType))
 
+       allocate(index_shortwaveAerosol(maxAerosolType))
+       allocate(index_verticalAerosolsConc(maxAerosolType))
+       allocate(index_algaeConc(nAlgae))
        if (.not. config_use_column_biogeochemistry) then
           index_shortwaveAerosol(1:maxAerosolType) = 1
+          index_verticalAerosolsConc(1:maxAerosolType) = 1
+          index_algaeConc(1:nAlgae) = 1
        else
           do iAerosol = 1, maxAerosolType
-               index_shortwaveAerosol(iAerosol) =  ciceTracerObject % index_verticalAerosolsConcShortwave(iAerosol)
+             index_shortwaveAerosol(iAerosol) =  ciceTracerObject % index_verticalAerosolsConcShortwave(iAerosol)
+             index_verticalAerosolsConc(iAerosol) = ciceTracerObject % index_verticalAerosolsConc(iAerosol)
+          enddo
+          do iBioTracers = 1, nAlgae
+             index_algaeConc(iBioTracers) = ciceTracerObject % index_algaeConc(iBioTracers)
           enddo
        endif
 
@@ -3204,92 +3217,74 @@ contains
           call set_cice_tracer_array_category(block, ciceTracerObject, &
                  tracerArrayCategory, iCell, setGetPhysicsTracers, setGetBGCTracers)
 
-          call colpkg_clear_warnings()
-          call colpkg_step_radiation(&
-               config_dt, &
-               nCategories, &
-               nAlgae, &
-               nBioLayers, &
-               ciceTracerObject % nTracers, &
-               ciceTracerObject % nBioTracers, &
-               ciceTracerObject % nBioTracersShortwave, &
-               nIceLayers, &
-               nSnowLayers, &
-               nAerosols, &
-               nzAerosols, &
-               config_use_shortwave_bioabsorption, &
-               ciceTracerObject % index_chlorophyllShortwave, &
-               index_shortwaveAerosol, &   ! nlt_zaero_sw, dimension(:), intent(in)
-               verticalShortwaveGrid(:), & ! swgrid, dimension (:), intent(in)
-               verticalGrid(:), &          !  igrid, dimension (:), intent(in)
-               brineFraction(1,:,iCell), &
-               iceAreaCategory(1,:,iCell), &
-               iceVolumeCategory(1,:,iCell), &
-               snowVolumeCategory(1,:,iCell), &
-               surfaceTemperature(1,:,iCell), &
-               levelIceArea(1,:,iCell), &
-               pondArea(1,:,iCell), &
-               pondDepth(1,:,iCell), &
-               pondLidThickness(1,:,iCell), &
-               config_snow_redistribution_scheme, &
-               snowGrainRadius(:,:,iCell), &
-               aerosolsArray, &
-               bioTracerShortwave(:,:,iCell), &
-               tracerArrayCategory, & ! trcrn, dimension(:,:), intent(in)
-               latCell(iCell), &
-               lonCellColumn, &
-               calendarType, &
-               daysInYear, &
-               dayOfNextShortwaveCalculation, &
-               dayOfYear, &
-               secondsIntoDay, &
-               aerosolMassExtinctionCrossSection(:,:), & ! kaer_tab,    dimension(:,:), intent(in)
-               aerosolSingleScatterAlbedo(:,:), &        ! waer_tab,    dimension(:,:), intent(in)
-               aerosolAsymmetryParameter(:,:), &         ! gaer_tab,    dimension(:,:), intent(in)
-               modalMassExtinctionCrossSection(:,:), &   ! kaer_bc_tab, dimension(:,:), intent(in)
-               modalSingleScatterAlbedo(:,:), &          ! waer_bc_tab, dimension(:,:), intent(in)
-               modalAsymmetryParameter(:,:), &           ! gaer_bc_tab, dimension(:,:), intent(in)
-               modalBCabsorptionParameter(:,:,:), &      ! bcenh,       dimension(:,:,:), intent(in)
-               config_use_modal_aerosols, &
-               shortwaveVisibleDirectDown(iCell), &
-               shortwaveVisibleDiffuseDown(iCell), &
-               shortwaveIRDirectDown(iCell), &
-               shortwaveIRDiffuseDown(iCell), &
-               solarZenithAngleCosine(iCell), &
-               snowfallRate(iCell), &
-               albedoVisibleDirectCategory(:,iCell), &
-               albedoVisibleDiffuseCategory(:,iCell), &
-               albedoIRDirectCategory(:,iCell), &
-               albedoIRDiffuseCategory(:,iCell), &
-               surfaceShortwaveFlux(:,iCell), &
-               interiorShortwaveFlux(:,iCell), &
-               penetratingShortwaveFlux(:,iCell), &
-               shortwaveLayerPenetration(:,:,iCell), &
-               absorbedShortwaveSnowLayer(:,:,iCell), &
-               absorbedShortwaveIceLayer(:,:,iCell), &
-               bareIceAlbedoCategory(:,iCell), &
-               snowAlbedoCategory(:,iCell), &
-               pondAlbedoCategory(:,iCell), &
-               effectivePondAreaCategory(:,iCell), &
-               snowFractionCategory(:,iCell), &
-               pondSnowDepthDifference(:,iCell), &
-               pondLidMeltFluxFraction(:,iCell), &
-               .false., &
-               lInitialization, &
-               iceAsymmetryParameterDirect(:,:), &
-               iceAsymmetryParameterDiffuse(:,:), &
-               iceSingleScatterAlbedoDirect(:,:), &
-               iceSingleScatterAlbedoDiffuse(:,:), &
-               iceMassExtinctionCrossSectionDirect(:,:), &
-               iceMassExtinctionCrossSectionDiffuse(:,:), &
-               aerosolMassExtinctionCrossSection5band(:,:), &
-               aerosolSingleScatterAlbedo5band(:,:), &
-               aerosolAsymmetryParameter5band(:,:), &
-               modalMassExtinctionCrossSection5band(:,:), &
-               modalSingleScatterAlbedo5band(:,:), &
-               modalAsymmetryParameter5band(:,:), &
-               modalBCabsorptionParameter5band(:,:,:), &
-               snowRadiusInStandardRadiationSchemeCategory(:,iCell))
+          call icepack_warnings_clear()
+          call icepack_step_radiation(&
+               dt=config_dt, &
+               ncat=nCategories, &
+               nblyr=nBioLayers, &
+               nilyr=nIceLayers, &
+               nslyr=nSnowLayers, &
+               dEdd_algae=config_use_shortwave_bioabsorption, &
+               swgrid=verticalShortwaveGrid(:), &
+               igrid=verticalGrid(:), &
+               fbri=brineFraction(1,:,iCell), &
+               aicen=iceAreaCategory(1,:,iCell), &
+               vicen=iceVolumeCategory(1,:,iCell), &
+               vsnon=snowVolumeCategory(1,:,iCell), &
+               Tsfcn=surfaceTemperature(1,:,iCell), &
+               alvln=levelIceArea(1,:,iCell), &
+               apndn=pondArea(1,:,iCell), &
+               hpndn=pondDepth(1,:,iCell), &
+               ipndn=pondLidThickness(1,:,iCell), &
+               aeron=aerosolsArray, &
+               bgcNn=tracerArrayCategory(index_algaeConc(:),:), &
+               zaeron=tracerArrayCategory(index_verticalAerosolsConc(:),:), &
+               trcrn_bgcsw=bioTracerShortwave(:,:,iCell), &
+               TLAT=latCell(iCell), &
+               TLON=lonCellColumn, &
+               calendar_type=calendarType, &
+               days_per_year=daysInYear, &
+               nextsw_cday=dayOfNextShortwaveCalculation, &
+               yday=dayOfYear, &
+               sec=secondsIntoDay, &
+               kaer_3bd=aerosolMassExtinctionCrossSection(:,:), &
+               waer_3bd=aerosolSingleScatterAlbedo(:,:), &
+               gaer_3bd=aerosolAsymmetryParameter(:,:), &
+               kaer_bc_3bd=modalMassExtinctionCrossSection(:,:), &
+               waer_bc_3bd=modalSingleScatterAlbedo(:,:), &
+               gaer_bc_3bd=modalAsymmetryParameter(:,:), &
+               bcenh_3bd=modalBCabsorptionParameter(:,:,:), &
+               modal_aero=config_use_modal_aerosols, &
+               swvdr=shortwaveVisibleDirectDown(iCell), &
+               swvdf=shortwaveVisibleDiffuseDown(iCell), &
+               swidr=shortwaveIRDirectDown(iCell), &
+               swidf=shortwaveIRDiffuseDown(iCell), &
+               coszen=solarZenithAngleCosine(iCell), &
+               fsnow=snowfallRate(iCell), &
+               alvdrn=albedoVisibleDirectCategory(:,iCell), &
+               alvdfn=albedoVisibleDiffuseCategory(:,iCell), &
+               alidrn=albedoIRDirectCategory(:,iCell), &
+               alidfn=albedoIRDiffuseCategory(:,iCell), &
+               fswsfcn=surfaceShortwaveFlux(:,iCell), &
+               fswintn=interiorShortwaveFlux(:,iCell), &
+               fswthrun=penetratingShortwaveFlux(:,iCell), &
+               fswthrun_vdr=penetratingShortwaveFluxVisibleDirect(:,iCell), &
+               fswthrun_vdf=penetratingShortwaveFluxVisibleDiffuse(:,iCell), &
+               fswthrun_idr=penetratingShortwaveFluxIRDirect(:,iCell), &
+               fswthrun_idf=penetratingShortwaveFluxIRDiffuse(:,iCell), &
+               fswpenln=shortwaveLayerPenetration(:,:,iCell), &
+               Sswabsn=absorbedShortwaveSnowLayer(:,:,iCell), &
+               Iswabsn=absorbedShortwaveIceLayer(:,:,iCell), &
+               albicen=bareIceAlbedoCategory(:,iCell), &
+               albsnon=snowAlbedoCategory(:,iCell), &
+               albpndn=pondAlbedoCategory(:,iCell), &
+               apeffn=effectivePondAreaCategory(:,iCell), &
+               snowfracn=snowFractionCategory(:,iCell), &
+               dhsn=pondSnowDepthDifference(:,iCell), &
+               ffracn=pondLidMeltFluxFraction(:,iCell), &
+               rsnow=snowGrainRadius(:,:,iCell), &
+               l_print_point=.false., &
+               initonly=lInitialization)
 
           call column_write_warnings(.false.)
 
@@ -3302,6 +3297,8 @@ contains
        ! aerosols array
        deallocate(aerosolsArray)
        deallocate(index_shortwaveAerosol)
+       deallocate(index_verticalAerosolsConc)
+       deallocate(index_algaeConc)
 
        block => block % next
     end do
@@ -3575,15 +3572,15 @@ contains
                  tracerArrayCategory, iCell, setGetPhysicsTracers, setGetBGCTracers)
 
           ! code abort
-          if (abortFlag) then
-             call mpas_log_write("column_ridging: "//trim(abortMessage) , messageType=MPAS_LOG_ERR)
-             call mpas_log_write("iCell: $i", messageType=MPAS_LOG_ERR, intArgs=(/indexToCellID(iCell)/))
-             exit
-          endif
+          if (abortFlag) exit
 
        enddo ! iCell
 
        ! code abort
+       if (abortFlag) then
+          call mpas_log_write("column_ridging: "//trim(abortMessage) , messageType=MPAS_LOG_ERR)
+          call mpas_log_write("iCell: $i", messageType=MPAS_LOG_ERR, intArgs=(/indexToCellID(iCell)/))
+       endif
        call seaice_critical_error_write_block(domain, block, abortFlag)
        call seaice_check_critical_error(domain, abortFlag)
 
@@ -4021,6 +4018,8 @@ contains
              oceanBioConcentrationsUsed(iBioTracers) = oceanBioConcentrations(iBioData,iCell)
           enddo ! iBioTracers
 
+          abortFlag = .false.
+
           call set_cice_tracer_array_category(block, ciceTracerObject, &
                tracerArrayCategory, iCell, setGetPhysicsTracers, setGetBGCTracers)
 
@@ -4137,11 +4136,7 @@ contains
           endif
 
           ! code abort
-          if (abortFlag) then
-             call mpas_log_write("column_biogeochemistry: "//trim(abortMessage) , messageType=MPAS_LOG_ERR)
-             call mpas_log_write("iCell: $i", messageType=MPAS_LOG_ERR, intArgs=(/indexToCellID(iCell)/))
-             exit
-          endif
+          if (abortFlag) exit
 
           totalSkeletalAlgae(iCell) = 0.0_RKIND
           bioShortwaveFluxCell(:,iCell) = 0.0_RKIND
@@ -4170,6 +4165,10 @@ contains
        enddo ! iCell
 
        ! code abort
+       if (abortFlag) then
+          call mpas_log_write("column_biogeochemistry: "//trim(abortMessage) , messageType=MPAS_LOG_ERR)
+          call mpas_log_write("iCell: $i", messageType=MPAS_LOG_ERR, intArgs=(/indexToCellID(iCell)/))
+       endif
        call seaice_critical_error_write_block(domain, block, abortFlag)
        call seaice_check_critical_error(domain, abortFlag)
 
@@ -4306,7 +4305,7 @@ contains
        else
           daysInYear = sum(daysInMonth)
        endif
-    case ("noleap")
+    case ("gregorian_noleap")
        daysInYear = sum(daysInMonth)
     end select
 
@@ -4364,7 +4363,7 @@ contains
 
     ! aggregate state variables
     call mpas_timer_start("Column aggregate")
-    call seaice_column_aggregate(domain)
+    call seaice_icepack_aggregate(domain)
     call mpas_timer_stop("Column aggregate")
 
     ! get configs
@@ -4430,7 +4429,7 @@ contains
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!  seaice_column_aggregate
+!  seaice_icepack_aggregate
 !
 !> \brief
 !> \author Adrian K. Turner, LANL
@@ -4440,7 +4439,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-  subroutine seaice_column_aggregate(domain)
+  subroutine seaice_icepack_aggregate(domain)
 
     use ice_colpkg, only: colpkg_aggregate
 
@@ -4543,11 +4542,11 @@ contains
        block => block % next
     end do
 
-  end subroutine seaice_column_aggregate
+  end subroutine seaice_icepack_aggregate
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!  seaice_column_aggregate_simple
+!  seaice_icepack_aggregate_simple
 !
 !> \brief
 !> \author Adrian K. Turner, LANL
@@ -4557,7 +4556,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-  subroutine seaice_column_aggregate_simple(domain)
+  subroutine seaice_icepack_aggregate_simple(domain)
 
     type(domain_type), intent(inout) :: domain
 
@@ -4628,11 +4627,11 @@ contains
        block => block % next
     end do
 
-  end subroutine seaice_column_aggregate_simple
+  end subroutine seaice_icepack_aggregate_simple
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!  seaice_column_coupling_prep
+!  seaice_icepack_coupling_prep
 !
 !> \brief
 !> \author Adrian K. Turner, LANL
@@ -4642,7 +4641,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-  subroutine seaice_column_coupling_prep(domain)
+  subroutine seaice_icepack_coupling_prep(domain)
 
     use seaice_constants, only: &
          seaicePuny, &
@@ -5084,7 +5083,7 @@ contains
 
     call seaice_column_scale_fluxes(domain)
 
-  end subroutine seaice_column_coupling_prep
+  end subroutine seaice_icepack_coupling_prep
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
@@ -5387,7 +5386,6 @@ contains
 
     real(kind=RKIND), dimension(:), pointer :: &
          seaSurfaceTemperature, &
-         seaSurfaceSalinity, &
          seaFreezingTemperature, &
          oceanMixedLayerDepth, &
          oceanHeatFluxConvergence, &
@@ -5401,7 +5399,6 @@ contains
          longwaveDown, &
          iceAreaCell, &
          freezingMeltingPotential, &
-         frazilMassAdjust, &
          shortwaveVisibleDirectDown, &
          shortwaveVisibleDiffuseDown, &
          shortwaveIRDirectDown, &
@@ -5410,8 +5407,6 @@ contains
          airOceanDragCoefficientRatio, &
          oceanHeatFlux, &
          oceanShortwaveFlux, &
-         oceanFreshWaterFlux, &
-         oceanSaltFlux, &
          airStressOceanU, &
          airStressOceanV, &
          atmosReferenceTemperature2mOcean, &
@@ -5434,9 +5429,6 @@ contains
     real(kind=RKIND), pointer :: &
          config_dt
 
-    character(len=strKIND), pointer :: &
-         config_ocean_mixed_layer_type
-
     integer :: &
          iCell
 
@@ -5450,7 +5442,6 @@ contains
          config_use_test_ice_shelf
 
     call MPAS_pool_get_config(domain % configs, "config_dt", config_dt)
-    call MPAS_pool_get_config(domain % configs, "config_ocean_mixed_layer_type", config_ocean_mixed_layer_type)
 
     block => domain % blocklist
     do while (associated(block))
@@ -5466,10 +5457,8 @@ contains
        call MPAS_pool_get_dimension(oceanCoupling, "nCellsSolve", nCellsSolve)
 
        call MPAS_pool_get_array(oceanCoupling, "seaSurfaceTemperature", seaSurfaceTemperature)
-       call MPAS_pool_get_array(oceanCoupling, "seaSurfaceSalinity", seaSurfaceSalinity)
        call MPAS_pool_get_array(oceanCoupling, "seaFreezingTemperature", seaFreezingTemperature)
        call MPAS_pool_get_array(oceanCoupling, "freezingMeltingPotential", freezingMeltingPotential)
-       call MPAS_pool_get_array(oceanCoupling, "frazilMassAdjust", frazilMassAdjust)
        call MPAS_pool_get_array(oceanCoupling, "oceanMixedLayerDepth", oceanMixedLayerDepth)
        call MPAS_pool_get_array(oceanCoupling, "oceanHeatFluxConvergence", oceanHeatFluxConvergence)
 
@@ -5494,8 +5483,6 @@ contains
 
        call MPAS_pool_get_array(oceanFluxes, "oceanHeatFlux", oceanHeatFlux)
        call MPAS_pool_get_array(oceanFluxes, "oceanShortwaveFlux", oceanShortwaveFlux)
-       call MPAS_pool_get_array(oceanFluxes, "oceanFreshWaterFlux", oceanFreshWaterFlux)
-       call MPAS_pool_get_array(oceanFluxes, "oceanSaltFlux", oceanSaltFlux)
 
        call MPAS_pool_get_array(oceanAtmosphere, "airStressOceanU", airStressOceanU)
        call MPAS_pool_get_array(oceanAtmosphere, "airStressOceanV", airStressOceanV)
@@ -5510,127 +5497,62 @@ contains
        call MPAS_pool_get_array(oceanAtmosphere, "latentHeatFluxOcean", latentHeatFluxOcean)
        call MPAS_pool_get_array(oceanAtmosphere, "evaporativeWaterFluxOcean", evaporativeWaterFluxOcean)
 
-       if (trim(config_ocean_mixed_layer_type) == "cice") then
+       do iCell = 1, nCellsSolve
+          call colpkg_atm_boundary(&
+               'ocn', &
+               seaSurfaceTemperature(iCell), &
+               airPotentialTemperature(iCell), &
+               uAirVelocity(iCell), &
+               vAirVelocity(iCell), &
+               windSpeed(iCell), &
+               airLevelHeight(iCell), &
+               airSpecificHumidity(iCell), &
+               airDensity(iCell), &
+               airStressOceanU(iCell), &
+               airStressOceanV(iCell), &
+               atmosReferenceTemperature2mOcean(iCell), &
+               atmosReferenceHumidity2mOcean(iCell), &
+               potentialTemperatureDifference, &
+               specificHumidityDifference, &
+               latentTransferCoefficient, &
+               sensibleTransferCoefficient, &
+               airDragCoefficient(iCell), &
+               airOceanDragCoefficientRatio(iCell))
 
-          do iCell = 1, nCellsSolve
+          albedoVisibleDirectOcean(iCell)  = seaiceOceanAlbedo
+          albedoIRDirectOcean(iCell)       = seaiceOceanAlbedo
+          albedoVisibleDiffuseOcean(iCell) = seaiceOceanAlbedo
+          albedoIRDiffuseOcean(iCell)      = seaiceOceanAlbedo
 
-             call colpkg_atm_boundary(&
-                  'ocn', &
-                  seaSurfaceTemperature(iCell), &
-                  airPotentialTemperature(iCell), &
-                  uAirVelocity(iCell), &
-                  vAirVelocity(iCell), &
-                  windSpeed(iCell), &
-                  airLevelHeight(iCell), &
-                  airSpecificHumidity(iCell), &
-                  airDensity(iCell), &
-                  airStressOceanU(iCell), &
-                  airStressOceanV(iCell), &
-                  atmosReferenceTemperature2mOcean(iCell), &
-                  atmosReferenceHumidity2mOcean(iCell), &
-                  potentialTemperatureDifference, &
-                  specificHumidityDifference, &
-                  latentTransferCoefficient, &
-                  sensibleTransferCoefficient, &
-                  airDragCoefficient(iCell), &
-                  airOceanDragCoefficientRatio(iCell))
+          call colpkg_ocn_mixed_layer(&
+               albedoVisibleDirectOcean(iCell), &
+               shortwaveVisibleDirectDown(iCell), &
+               albedoIRDirectOcean(iCell), &
+               shortwaveIRDirectDown(iCell), &
+               albedoVisibleDiffuseOcean(iCell), &
+               shortwaveVisibleDiffuseDown(iCell), &
+               albedoIRDiffuseOcean(iCell), &
+               shortwaveIRDiffuseDown(iCell), &
+               seaSurfaceTemperature(iCell), &
+               longwaveUpOcean(iCell), &
+               sensibleHeatFluxOcean(iCell), &
+               sensibleTransferCoefficient, &
+               latentHeatFluxOcean(iCell), &
+               latentTransferCoefficient, &
+               evaporativeWaterFluxOcean(iCell), &
+               longwaveDown(iCell), &
+               potentialTemperatureDifference, &
+               specificHumidityDifference, &
+               iceAreaCell(iCell), &
+               oceanHeatFlux(iCell), &
+               oceanShortwaveFlux(iCell), &
+               oceanMixedLayerDepth(iCell), &
+               seaFreezingTemperature(iCell), &
+               oceanHeatFluxConvergence(iCell), &
+               freezingMeltingPotential(iCell), &
+               config_dt)
 
-             albedoVisibleDirectOcean(iCell)  = seaiceOceanAlbedo
-             albedoIRDirectOcean(iCell)       = seaiceOceanAlbedo
-             albedoVisibleDiffuseOcean(iCell) = seaiceOceanAlbedo
-             albedoIRDiffuseOcean(iCell)      = seaiceOceanAlbedo
-
-             call colpkg_ocn_mixed_layer(&
-                  albedoVisibleDirectOcean(iCell), &
-                  shortwaveVisibleDirectDown(iCell), &
-                  albedoIRDirectOcean(iCell), &
-                  shortwaveIRDirectDown(iCell), &
-                  albedoVisibleDiffuseOcean(iCell), &
-                  shortwaveVisibleDiffuseDown(iCell), &
-                  albedoIRDiffuseOcean(iCell), &
-                  shortwaveIRDiffuseDown(iCell), &
-                  seaSurfaceTemperature(iCell), &
-                  longwaveUpOcean(iCell), &
-                  sensibleHeatFluxOcean(iCell), &
-                  sensibleTransferCoefficient, &
-                  latentHeatFluxOcean(iCell), &
-                  latentTransferCoefficient, &
-                  evaporativeWaterFluxOcean(iCell), &
-                  longwaveDown(iCell), &
-                  potentialTemperatureDifference, &
-                  specificHumidityDifference, &
-                  iceAreaCell(iCell), &
-                  oceanHeatFlux(iCell), &
-                  oceanShortwaveFlux(iCell), &
-                  oceanMixedLayerDepth(iCell), &
-                  seaFreezingTemperature(iCell), &
-                  oceanHeatFluxConvergence(iCell), &
-                  freezingMeltingPotential(iCell), &
-                  config_dt)
-
-          enddo ! iCell
-
-       else if (trim(config_ocean_mixed_layer_type) == "e3sm") then
-
-          do iCell = 1, nCellsSolve
-
-             call colpkg_atm_boundary(&
-                  'ocn', &
-                  seaSurfaceTemperature(iCell), &
-                  airPotentialTemperature(iCell), &
-                  uAirVelocity(iCell), &
-                  vAirVelocity(iCell), &
-                  windSpeed(iCell), &
-                  airLevelHeight(iCell), &
-                  airSpecificHumidity(iCell), &
-                  airDensity(iCell), &
-                  airStressOceanU(iCell), &
-                  airStressOceanV(iCell), &
-                  atmosReferenceTemperature2mOcean(iCell), &
-                  atmosReferenceHumidity2mOcean(iCell), &
-                  potentialTemperatureDifference, &
-                  specificHumidityDifference, &
-                  latentTransferCoefficient, &
-                  sensibleTransferCoefficient, &
-                  airDragCoefficient(iCell), &
-                  airOceanDragCoefficientRatio(iCell))
-
-             albedoVisibleDirectOcean(iCell)  = seaiceOceanAlbedo
-             albedoIRDirectOcean(iCell)       = seaiceOceanAlbedo
-             albedoVisibleDiffuseOcean(iCell) = seaiceOceanAlbedo
-             albedoIRDiffuseOcean(iCell)      = seaiceOceanAlbedo
-
-             call seaice_ocean_mixed_layer_e3sm(&
-                  oceanMixedLayerDepth(iCell), &
-                  seaSurfaceTemperature(iCell), &
-                  seaSurfaceSalinity(iCell), &
-                  freezingMeltingPotential(iCell), &
-                  frazilMassAdjust(iCell), &
-                  oceanHeatFlux(iCell), &
-                  oceanShortwaveFlux(iCell), &
-                  oceanFreshWaterFlux(iCell), &
-                  oceanSaltFlux(iCell), &
-                  oceanHeatFluxConvergence(iCell), &
-                  albedoVisibleDirectOcean(iCell), &
-                  shortwaveVisibleDirectDown(iCell), &
-                  albedoIRDirectOcean(iCell), &
-                  shortwaveIRDirectDown(iCell), &
-                  albedoVisibleDiffuseOcean(iCell), &
-                  shortwaveVisibleDiffuseDown(iCell), &
-                  albedoIRDiffuseOcean(iCell), &
-                  shortwaveIRDiffuseDown(iCell), &
-                  sensibleTransferCoefficient, &
-                  latentTransferCoefficient, &
-                  longwaveDown(iCell), &
-                  potentialTemperatureDifference, &
-                  specificHumidityDifference, &
-                  iceAreaCell(iCell), &
-                  seaFreezingTemperature(iCell), &
-                  config_dt)
-
-          enddo ! iCell
-
-       endif
+       enddo ! iCell
 
        block => block % next
     enddo
@@ -5665,315 +5587,11 @@ contains
 
   end subroutine seaice_column_ocean_mixed_layer
 
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
-!
-!  seaice_ocean_mixed_layer_e3sm
-!
-!> \brief E3SM ocean coupling proxy
-!> \author Adrian K. Turner, LANL
-!> \date 9th July 2022
-!> \details Representation of ocean processes and coupling in e3sm. This
-!>  routine mimics the ocean/sea ice coupling in e3sm using MPAS-Ocn,
-!>  including updates to ocean thickness, temperature and salinity from
-!>  interactions with sea ice and frazil formation.
-!
-!-----------------------------------------------------------------------
-
-  subroutine seaice_ocean_mixed_layer_e3sm(&
-       oceanMixedLayerDepth, &
-       seaSurfaceTemperature, &
-       seaSurfaceSalinity, &
-       freezingMeltingPotential, &
-       frazilMassAdjust, &
-       oceanHeatFlux, &
-       oceanShortwaveFlux, &
-       oceanFreshWaterFlux, &
-       oceanSaltFlux, &
-       oceanHeatFluxConvergence, &
-       albedoVisibleDirectOcean, &
-       shortwaveVisibleDirectDown, &
-       albedoIRDirectOcean, &
-       shortwaveIRDirectDown, &
-       albedoVisibleDiffuseOcean, &
-       shortwaveVisibleDiffuseDown, &
-       albedoIRDiffuseOcean, &
-       shortwaveIRDiffuseDown, &
-       sensibleTransferCoefficient, &
-       latentTransferCoefficient, &
-       longwaveDown, &
-       potentialTemperatureDifference, &
-       specificHumidityDifference, &
-       iceAreaCell, &
-       seaFreezingTemperature, &
-       timeStep)
-
-    use seaice_constants, only: &
-         seaiceFreshWaterFreezingPoint, &
-         seaiceStefanBoltzmann, &
-         seaiceDensitySeaWater, &
-         seaiceSeaWaterSpecificHeat, &
-         seaiceLatentHeatVaporization, &
-         seaiceReferenceSalinity
-
-    real(kind=RKIND), intent(inout) :: &
-         oceanMixedLayerDepth, &
-         seaSurfaceTemperature, &
-         seaSurfaceSalinity
-
-    real(kind=RKIND), intent(out) :: &
-         freezingMeltingPotential
-
-    real(kind=RKIND), intent(inout) :: &
-         frazilMassAdjust, &
-         oceanFreshWaterFlux, &
-         oceanSaltFlux
-
-    real(kind=RKIND), intent(in) :: &
-         oceanHeatFlux, &
-         oceanShortwaveFlux, &
-         oceanHeatFluxConvergence, &
-         albedoVisibleDirectOcean, &
-         shortwaveVisibleDirectDown, &
-         albedoIRDirectOcean, &
-         shortwaveIRDirectDown, &
-         albedoVisibleDiffuseOcean, &
-         shortwaveVisibleDiffuseDown, &
-         albedoIRDiffuseOcean, &
-         shortwaveIRDiffuseDown, &
-         sensibleTransferCoefficient, &
-         latentTransferCoefficient, &
-         longwaveDown, &
-         potentialTemperatureDifference, &
-         specificHumidityDifference, &
-         iceAreaCell, &
-         seaFreezingTemperature, &
-         timeStep
-
-    real(kind=RKIND) :: &
-         absorbedShortwaveOcean, &
-         seaSurfaceTemperatureKelvin, &
-         longwaveUpOcean, &
-         sensibleHeatFluxOcean, &
-         latentHeatFluxOcean, &
-         evaporativeWaterFluxOcean, &
-         openWaterHeatFlux, &
-         iceHeatFlux, &
-         totalHeatFlux, &
-         fflux_factor, &
-         hflux_factor, &
-         sflux_factor, &
-         maxFreezingMeltingPotential, &
-         changeOceanMixedLayerDepth, &
-         changeSeaSurfaceTemperature, &
-         changeSeaSurfaceSalinity
-
-    real(kind=RKIND) :: &
-         potential, &
-         freezingEnergy, &
-         newFrazilIceThickness, &
-         newThicknessWeightedSaltContent, &
-         frazilLayerThicknessTendency, &
-         frazilSalinityTendency, &
-         frazilTemperatureTendency, &
-         seaIceEnergy, &
-         accumulatedFrazilIceMass, &
-         sumNewFrazilIceThickness, &
-         ocn_cpl_dt, &
-         o2x_Fioo_q, &
-         o2x_Fioo_frazil, &
-         x2i_Fioo_q, &
-         x2i_Fioo_frazil, &
-         frazilMassFlux, &
-         frazilMassFluxRev
-
-    real(kind=RKIND), parameter :: &
-         config_specific_heat_sea_water = 3.996e3_RKIND, &
-         rho_sw = 1.026e3_RKIND, &
-         cp_sw = 3.996e3_RKIND, &
-         config_frazil_heat_of_fusion = 3.337e5_RKIND, &
-         config_frazil_ice_density = 1000.0_RKIND, &
-         config_frazil_fractional_thickness_limit = 0.1_RKIND, &
-         config_frazil_sea_ice_reference_salinity = 4.0_RKIND
-
-    ocn_cpl_dt = timeStep
-
-    !-----------------------------------------------------------------------------------
-    ! ice_comp_mct - export
-    !-----------------------------------------------------------------------------------
-
-    oceanFreshWaterFlux = oceanFreshWaterFlux + frazilMassAdjust/iceAreaCell
-    oceanSaltFlux       = oceanSaltFlux       + seaiceReferenceSalinity*0.001_RKIND*frazilMassAdjust/iceAreaCell
-
-    !-----------------------------------------------------------------------------------
-    ! Ocean surface fluxes
-    !-----------------------------------------------------------------------------------
-
-    ! shortwave radiative flux
-    absorbedShortwaveOcean = &
-         (1.0_RKIND-albedoVisibleDirectOcean)  * shortwaveVisibleDirectDown + &
-         (1.0_RKIND-albedoIRDirectOcean)       * shortwaveIRDirectDown + &
-         (1.0_RKIND-albedoVisibleDiffuseOcean) * shortwaveVisibleDiffuseDown + &
-         (1.0_RKIND-albedoIRDiffuseOcean)      * shortwaveIRDiffuseDown
-
-    ! ocean surface temperature in Kelvin
-    seaSurfaceTemperatureKelvin = seaSurfaceTemperature + seaiceFreshWaterFreezingPoint
-
-    ! longwave radiative flux
-    longwaveUpOcean = -seaiceStefanBoltzmann * seaSurfaceTemperatureKelvin**4
-
-    ! downward latent and sensible heat fluxes
-    sensibleHeatFluxOcean     = sensibleTransferCoefficient * potentialTemperatureDifference
-    latentHeatFluxOcean       = latentTransferCoefficient * specificHumidityDifference
-    evaporativeWaterFluxOcean = -latentHeatFluxOcean / seaiceLatentHeatVaporization
-
-    ! open water heat flux
-    openWaterHeatFlux = &
-         sensibleHeatFluxOcean + &
-         latentHeatFluxOcean + &
-         longwaveUpOcean + &
-         longwaveDown + &
-         absorbedShortwaveOcean
-    openWaterHeatFlux = openWaterHeatFlux * (1.0_RKIND - iceAreaCell)
-
-    ! ice heat flux
-    iceHeatFlux = &
-         oceanHeatFlux + &
-         oceanShortwaveFlux
-
-    ! total heat flux
-    totalHeatFlux = openWaterHeatFlux + iceHeatFlux - oceanHeatFluxConvergence
-
-    !-----------------------------------------------------------------------------------
-    ! MPAS-Ocn frazil formation - mpas_ocn_frazil_forcing.F
-    !-----------------------------------------------------------------------------------
-    potential = oceanMixedLayerDepth * config_specific_heat_sea_water * rho_sw * (seaSurfaceTemperature - seaFreezingTemperature)
-
-    freezingEnergy = max(0.0_RKIND, -potential)
-    newFrazilIceThickness = freezingEnergy / (config_frazil_heat_of_fusion * config_frazil_ice_density)
-    newFrazilIceThickness = min(newFrazilIceThickness, oceanMixedLayerDepth * config_frazil_fractional_thickness_limit)
-    newThicknessWeightedSaltContent = newFrazilIceThickness * config_frazil_sea_ice_reference_salinity * 0.001_RKIND
-
-    frazilLayerThicknessTendency = - newFrazilIceThickness * (config_frazil_ice_density / seaiceDensitySeaWater)
-    frazilSalinityTendency = - newThicknessWeightedSaltContent
-    frazilTemperatureTendency =  + (newFrazilIceThickness * config_frazil_heat_of_fusion * config_frazil_ice_density) / (config_specific_heat_sea_water * rho_sw)
-
-    sumNewFrazilIceThickness = newFrazilIceThickness
-    accumulatedFrazilIceMass = sumNewFrazilIceThickness * config_frazil_ice_density
-
-    !-----------------------------------------------------------------------------------
-    ! Modify ocean state
-    !-----------------------------------------------------------------------------------
-
-    ! change in mixed layer depth
-    changeOceanMixedLayerDepth = (oceanFreshWaterFlux * timeStep) / seaiceDensitySeaWater + frazilLayerThicknessTendency
-    oceanMixedLayerDepth = oceanMixedLayerDepth + changeOceanMixedLayerDepth
-
-    ! change in sea surface temperature
-    changeSeaSurfaceTemperature = (totalHeatFlux * timeStep) / (oceanMixedLayerDepth * seaiceDensitySeaWater * seaiceSeaWaterSpecificHeat) + frazilTemperatureTendency / oceanMixedLayerDepth
-    seaSurfaceTemperature = seaSurfaceTemperature + changeSeaSurfaceTemperature - (changeOceanMixedLayerDepth * seaSurfaceTemperature) / oceanMixedLayerDepth
-
-    ! change in sea surface salinity
-    changeSeaSurfaceSalinity = (oceanSaltFlux * timeStep) / (oceanMixedLayerDepth * seaiceDensitySeaWater * 0.001_RKIND) + frazilSalinityTendency / oceanMixedLayerDepth
-    seaSurfaceSalinity = seaSurfaceSalinity + changeSeaSurfaceSalinity - (changeOceanMixedLayerDepth * seaSurfaceSalinity) / oceanMixedLayerDepth
-
-    ! compute potential to freeze or melt ice
-    !maxFreezingMeltingPotential = 1000.0_RKIND
-    !freezingMeltingPotential = ((seaFreezingTemperature - seaSurfaceTemperature) * seaiceDensitySeaWater * seaiceSeaWaterSpecificHeat * oceanMixedLayerDepth) / timeStep
-    !freezingMeltingPotential = min(max(freezingMeltingPotential,-maxFreezingMeltingPotential),maxFreezingMeltingPotential)
-
-    ! if sst is below freezing, reset sst to Tf
-    !if (seaSurfaceTemperature <= seaFreezingTemperature) seaSurfaceTemperature = seaFreezingTemperature
-
-    !-----------------------------------------------------------------------------------
-    ! ocn_comp_mct - export
-    !-----------------------------------------------------------------------------------
-    if (accumulatedFrazilIceMass > 0.0_RKIND) then
-       seaIceEnergy = accumulatedFrazilIceMass * config_frazil_heat_of_fusion
-    else
-       seaIceEnergy = min(rho_sw*cp_sw*oceanMixedLayerDepth*(seaFreezingTemperature - seaSurfaceTemperature), 0.0_RKIND)
-    endif
-
-    o2x_Fioo_q = seaIceEnergy / ocn_cpl_dt
-    o2x_Fioo_frazil = accumulatedFrazilIceMass / ocn_cpl_dt
-
-    !-----------------------------------------------------------------------------------
-    ! coupler
-    !-----------------------------------------------------------------------------------
-    x2i_Fioo_q = o2x_Fioo_q
-    x2i_Fioo_frazil = o2x_Fioo_frazil
-
-    !-----------------------------------------------------------------------------------
-    ! ice_comp_mct - import
-    !-----------------------------------------------------------------------------------
-    freezingMeltingPotential = x2i_Fioo_q
-    frazilMassFlux = x2i_Fioo_frazil
-
-    call seaice_frazil_mass(freezingMeltingPotential, frazilMassFluxRev, seaSurfaceSalinity)
-    frazilMassAdjust = frazilMassFlux-frazilMassFluxRev
-
-  end subroutine seaice_ocean_mixed_layer_e3sm
-
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
-!
-!  seaice_frazil_mass
-!
-!> \brief Calculate sea ice frazil formation from freezig potential
-!> \author Adrian K. Turner, LANL
-!> \date 9th July 2022
-!> \details Used in ice_comp_mct to determine frazil formation and
-!>  replicated here for use with the e3sm ocean coupling proxy
-!
-!-----------------------------------------------------------------------
-
-  subroutine seaice_frazil_mass(freezingPotential, frazilMassFlux, seaSurfaceSalinity)
-
-    use ice_mushy_physics, only:  &
-         liquidus_temperature_mush, &
-         enthalpy_mush
-
-    use ice_colpkg_shared, only: &
-         dSin0_frazil,             &
-         phi_init
-
-    use seaice_constants, only: &
-         seaiceDensityIce
-
-    real (kind=RKIND),      intent(in)   :: freezingPotential
-    real (kind=RKIND),      intent(in)   :: seaSurfaceSalinity
-
-    real (kind=RKIND),      intent(out)  :: frazilMassFlux
-
-    real(kind=RKIND) :: &
-         Si0new,          &
-         Ti,              &
-         qi0new,          &
-         vi0new
-
-    if (freezingPotential > 0.0_RKIND) then
-
-       if (seaSurfaceSalinity > 2.0_RKIND * dSin0_frazil) then
-          Si0new = seaSurfaceSalinity - dSin0_frazil
-       else
-          Si0new = seaSurfaceSalinity**2 / (4.0_RKIND*dSin0_frazil)
-       endif
-       Ti = liquidus_temperature_mush(Si0new/phi_init)
-       qi0new = enthalpy_mush(Ti, Si0new)
-
-       frazilMassFlux = -freezingPotential*seaiceDensityIce/qi0new
-
-    else
-
-       frazilMassFlux = 0.0_RKIND
-
-    endif
-
-  end subroutine seaice_frazil_mass
-
 !-----------------------------------------------------------------------
 ! Other passthrough functions to column package
 !-----------------------------------------------------------------------
 
-  subroutine seaice_column_init_trcr(&
+  subroutine seaice_icepack_init_trcr(&
        airTemperature, &
        seaFreezingTemperature, &
        initialSalinityProfile, &
@@ -6016,11 +5634,11 @@ contains
          iceEnthalpy, &
          snowEnthalpy)
 
-  end subroutine seaice_column_init_trcr
+  end subroutine seaice_icepack_init_trcr
 
   !-----------------------------------------------------------------------
 
-  subroutine seaice_column_init_itd(&
+  subroutine seaice_icepack_init_itd(&
        nCategories, &
        categoryThicknessLimits, &
        abortFlag, &
@@ -6047,11 +5665,11 @@ contains
          abortFlag, &
          abortMessage)
 
-  end subroutine seaice_column_init_itd
+  end subroutine seaice_icepack_init_itd
 
   !-----------------------------------------------------------------------
 
-  subroutine seaice_column_init_ocean_conc(&
+  subroutine seaice_icepack_init_ocean_conc(&
        oceanAmmoniumConc, &
        oceanDMSPConc, &
        oceanDMSConc, &
@@ -6123,11 +5741,11 @@ contains
          carbonToNitrogenRatioAlgae, &
          carbonToNitrogenRatioDON)
 
-  end subroutine seaice_column_init_ocean_conc
+  end subroutine seaice_icepack_init_ocean_conc
 
   !-----------------------------------------------------------------------
 
-  subroutine seaice_column_ice_strength(&
+  subroutine seaice_icepack_ice_strength(&
        nCategories, &
        iceAreaCell, &
        iceVolumeCell, &
@@ -6163,11 +5781,11 @@ contains
          iceVolumeCategory, &
          icePressure)
 
-  end subroutine seaice_column_ice_strength
+  end subroutine seaice_icepack_ice_strength
 
   !-----------------------------------------------------------------------
 
-  function seaice_column_sea_freezing_temperature(seaSurfaceSalinity) result(seaFreezingTemperature)
+  function seaice_icepack_sea_freezing_temperature(seaSurfaceSalinity) result(seaFreezingTemperature)
 
     use ice_colpkg, only: &
          colpkg_sea_freezing_temperature
@@ -6177,11 +5795,11 @@ contains
 
     seaFreezingTemperature = colpkg_sea_freezing_temperature(seaSurfaceSalinity)
 
-  end function seaice_column_sea_freezing_temperature
+  end function seaice_icepack_sea_freezing_temperature
 
   !-----------------------------------------------------------------------
 
-  function seaice_column_liquidus_temperature(salinity) result(liquidusTemperature)
+  function seaice_icepack_liquidus_temperature(salinity) result(liquidusTemperature)
 
     use ice_colpkg, only: &
          colpkg_liquidus_temperature
@@ -6191,11 +5809,11 @@ contains
 
     liquidusTemperature = colpkg_liquidus_temperature(salinity)
 
-  end function seaice_column_liquidus_temperature
+  end function seaice_icepack_liquidus_temperature
 
   !-----------------------------------------------------------------------
 
-  function seaice_column_enthalpy_snow(snowTemperature) result(snowEnthalpy)
+  function seaice_icepack_enthalpy_snow(snowTemperature) result(snowEnthalpy)
 
     use ice_colpkg, only: &
          colpkg_enthalpy_snow
@@ -6205,11 +5823,11 @@ contains
 
     snowEnthalpy = colpkg_enthalpy_snow(snowTemperature)
 
-  end function seaice_column_enthalpy_snow
+  end function seaice_icepack_enthalpy_snow
 
   !-----------------------------------------------------------------------
 
-  function seaice_column_enthalpy_ice(iceTemperature, iceSalinity) result(iceEnthalpy)
+  function seaice_icepack_enthalpy_ice(iceTemperature, iceSalinity) result(iceEnthalpy)
 
     use ice_colpkg, only: &
          colpkg_enthalpy_ice
@@ -6220,11 +5838,11 @@ contains
 
     iceEnthalpy = colpkg_enthalpy_ice(iceTemperature, iceSalinity)
 
-  end function seaice_column_enthalpy_ice
+  end function seaice_icepack_enthalpy_ice
 
   !-----------------------------------------------------------------------
 
-  function seaice_column_salinity_profile(depth) result(iceSalinity)
+  function seaice_icepack_salinity_profile(depth) result(iceSalinity)
 
     use ice_colpkg, only: &
          colpkg_salinity_profile
@@ -6237,13 +5855,13 @@ contains
 
     iceSalinity = colpkg_salinity_profile(depth)
 
-  end function seaice_column_salinity_profile
+  end function seaice_icepack_salinity_profile
 
 !-----------------------------------------------------------------------
 ! initialize constants
 !-----------------------------------------------------------------------
 
-  subroutine seaice_init_column_constants()
+  subroutine seaice_init_icepack_constants()
 
     use seaice_constants, only: &
          seaiceGravity, &
@@ -6320,7 +5938,7 @@ contains
     iceThicknessMinimum  = seaicePuny
     snowThicknessMinimum = seaicePuny
 
-  end subroutine seaice_init_column_constants
+  end subroutine seaice_init_icepack_constants
 
 !-----------------------------------------------------------------------
 ! CICE tracer object
@@ -9835,6 +9453,42 @@ contains
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
+!  init_icepack_package_parameters
+!
+!> \brief
+!> \author Adrian K. Turner, LANL
+!> \date 2nd Feburary 2015
+!> \details
+!>
+!
+!-----------------------------------------------------------------------
+
+  subroutine init_icepack_package_parameters(domain, tracerObject)
+
+    type(domain_type), intent(inout) :: domain
+
+    type(ciceTracerObjectType), intent(in) :: &
+         tracerObject
+
+    ! check column configs
+    call check_column_package_configs(domain)
+
+    ! set the tracer flags
+    call init_icepack_package_tracer_flags(domain)
+
+    ! set the tracer numbers
+    call init_icepack_package_tracer_sizes(domain, tracerObject)
+
+    ! set the tracers indices
+    call init_icepack_package_tracer_indices(tracerObject)
+
+    ! set the column parameters
+    call init_column_package_configs(domain)
+
+  end subroutine init_icepack_package_parameters
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
 !  check_column_package_configs
 !
 !> \brief
@@ -10236,41 +9890,6 @@ contains
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!  init_column_active_processes
-!
-!> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 14th September 2022
-!> \details
-!>
-!
-!-----------------------------------------------------------------------
-
-  subroutine init_column_active_processes(domain)
-
-    use ice_colpkg, only: &
-         colpkg_init_active_processes
-
-    type(domain_type), intent(inout) :: domain
-
-    logical, pointer :: &
-         config_use_latent_processes, &
-         config_use_lateral_melt, &
-         config_use_congelation_basal_melt
-
-    call MPAS_pool_get_config(domain % configs, "config_use_latent_processes", config_use_latent_processes)
-    call MPAS_pool_get_config(domain % configs, "config_use_lateral_melt", config_use_lateral_melt)
-    call MPAS_pool_get_config(domain % configs, "config_use_congelation_basal_melt", config_use_congelation_basal_melt)
-
-    call colpkg_init_active_processes(&
-         config_use_latent_processes, &
-         config_use_lateral_melt, &
-         config_use_congelation_basal_melt)
-
-  end subroutine init_column_active_processes
-
-!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
-!
 !  init_column_package_tracer_flags
 !
 !> \brief
@@ -10415,6 +10034,114 @@ contains
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
+!  init_icepack_package_tracer_flags
+!
+!> \brief
+!> \author Adrian K. Turner, LANL
+!> \date 2nd Feburary 2015
+!> \details
+!>
+!
+!-----------------------------------------------------------------------
+
+  subroutine init_icepack_package_tracer_flags(domain)
+
+    use icepack_intfc, only: &
+         icepack_init_tracer_flags
+
+    type(domain_type), intent(inout) :: domain
+
+    logical, pointer :: &
+         config_use_ice_age, &
+         config_use_first_year_ice, &
+         config_use_level_ice, &
+         config_use_cesm_meltponds, &
+         config_use_level_meltponds, &
+         config_use_topo_meltponds, &
+         config_use_aerosols, &
+         config_use_brine, &
+         config_use_vertical_zsalinity, &
+         config_use_zaerosols, &
+         config_use_nitrate, &
+         config_use_DON, &
+         config_use_carbon, &
+         config_use_chlorophyll, &
+         config_use_ammonium, &
+         config_use_silicate, &
+         config_use_DMS, &
+         config_use_iron, &
+         config_use_humics, &
+         config_use_nonreactive, &
+         config_use_vertical_biochemistry, &
+         config_use_skeletal_biochemistry, &
+         config_use_effective_snow_density, &
+         config_use_snow_grain_radius
+
+    logical :: &
+         use_meltponds, &
+         use_nitrogen
+
+    call MPAS_pool_get_config(domain % configs, "config_use_ice_age", config_use_ice_age)
+    call MPAS_pool_get_config(domain % configs, "config_use_first_year_ice", config_use_first_year_ice)
+    call MPAS_pool_get_config(domain % configs, "config_use_level_ice", config_use_level_ice)
+    call MPAS_pool_get_config(domain % configs, "config_use_cesm_meltponds", config_use_cesm_meltponds)
+    call MPAS_pool_get_config(domain % configs, "config_use_level_meltponds", config_use_level_meltponds)
+    call MPAS_pool_get_config(domain % configs, "config_use_topo_meltponds", config_use_topo_meltponds)
+    call MPAS_pool_get_config(domain % configs, "config_use_aerosols", config_use_aerosols)
+    call MPAS_pool_get_config(domain % configs, "config_use_brine", config_use_brine)
+    call MPAS_pool_get_config(domain % configs, "config_use_vertical_zsalinity", config_use_vertical_zsalinity)
+    call MPAS_pool_get_config(domain % configs, "config_use_zaerosols", config_use_zaerosols)
+    call MPAS_pool_get_config(domain % configs, "config_use_nitrate", config_use_nitrate)
+    call MPAS_pool_get_config(domain % configs, "config_use_DON", config_use_DON)
+    call MPAS_pool_get_config(domain % configs, "config_use_carbon", config_use_carbon)
+    call MPAS_pool_get_config(domain % configs, "config_use_chlorophyll", config_use_chlorophyll)
+    call MPAS_pool_get_config(domain % configs, "config_use_ammonium", config_use_ammonium)
+    call MPAS_pool_get_config(domain % configs, "config_use_silicate", config_use_silicate)
+    call MPAS_pool_get_config(domain % configs, "config_use_DMS", config_use_DMS)
+    call MPAS_pool_get_config(domain % configs, "config_use_iron", config_use_iron)
+    call MPAS_pool_get_config(domain % configs, "config_use_humics", config_use_humics)
+    call MPAS_pool_get_config(domain % configs, "config_use_nonreactive", config_use_nonreactive)
+    call MPAS_pool_get_config(domain % configs, "config_use_skeletal_biochemistry", config_use_skeletal_biochemistry)
+    call MPAS_pool_get_config(domain % configs, "config_use_vertical_biochemistry", config_use_vertical_biochemistry)
+    call MPAS_pool_get_config(domain % configs, "config_use_effective_snow_density", config_use_effective_snow_density)
+    call MPAS_pool_get_config(domain % configs, "config_use_snow_grain_radius", config_use_snow_grain_radius)
+
+    use_nitrogen = .false.
+    if (config_use_skeletal_biochemistry .or. config_use_vertical_biochemistry) &
+         use_nitrogen = .true.
+
+    use_meltponds = (config_use_cesm_meltponds .or. config_use_level_meltponds .or. config_use_topo_meltponds)
+
+    call icepack_init_tracer_flags(&
+         tr_iage_in      = config_use_ice_age, &
+         tr_FY_in        = config_use_first_year_ice, &
+         tr_lvl_in       = config_use_level_ice, &
+         tr_snow_in      = config_use_effective_snow_density, &
+         tr_pond_in      = use_meltponds, &
+         !tr_pond_cesm_in = config_use_cesm_meltponds, & ! deprecated
+         tr_pond_lvl_in  = config_use_level_meltponds, &
+         tr_pond_topo_in = config_use_topo_meltponds, &
+         !tr_fsd_in       = , &
+         tr_aero_in      = config_use_aerosols, &
+         !tr_iso_in       = , &
+         tr_brine_in     = config_use_brine, &
+         tr_zaero_in     = config_use_zaerosols, &
+         tr_bgc_Nit_in   = config_use_nitrate, &
+         tr_bgc_N_in     = use_nitrogen, &
+         tr_bgc_DON_in   = config_use_DON, &
+         tr_bgc_C_in     = config_use_carbon, &
+         tr_bgc_chl_in   = config_use_chlorophyll, &
+         tr_bgc_Am_in    = config_use_ammonium, &
+         tr_bgc_Sil_in   = config_use_silicate, &
+         tr_bgc_DMS_in   = config_use_DMS, &
+         tr_bgc_Fe_in    = config_use_iron, &
+         tr_bgc_hum_in   = config_use_humics, &
+         tr_bgc_PON_in   = config_use_nonreactive)
+
+  end subroutine init_icepack_package_tracer_flags
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
 !  init_column_package_tracer_numbers
 !
 !> \brief
@@ -10448,6 +10175,60 @@ contains
     !nbtrcr_sw = tracerObject % nBioTracersShortwave
 
   end subroutine init_column_package_tracer_numbers
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  init_icepack_package_tracer_numbers
+!
+!> \brief
+!> \author Adrian K. Turner, LANL
+!> \date 9th Feburary 2015
+!> \details
+!>
+!
+!-----------------------------------------------------------------------
+
+  subroutine init_icepack_package_tracer_sizes(domain, tracerObject)
+
+    use icepack_intfc, only: &
+         icepack_init_tracer_sizes
+
+    type(domain_type), intent(in) :: &
+         domain
+
+    type(ciceTracerObjectType), intent(in) :: &
+         tracerObject
+
+    integer, pointer :: &
+         nCategories, &
+         nIceLayers, &
+         nSnowLayers
+
+    call MPAS_pool_get_dimension(domain % blocklist % dimensions, "nCategories", nCategories)
+    call MPAS_pool_get_dimension(domain % blocklist % dimensions, "nIceLayers", nIceLayers)
+    call MPAS_pool_get_dimension(domain % blocklist % dimensions, "nSnowLayers", nSnowLayers)
+
+    call icepack_init_tracer_sizes(&
+         ncat_in      = nCategories, &
+         nilyr_in     = nIceLayers, &
+         nslyr_in     = nSnowLayers, &
+         !nblyr_in     = , &
+         !nfsd_in      = , &
+         !n_algae_in   = , &
+         !n_DOC_in     = , &
+         !n_aero_in    = , &
+         !n_iso_in     = , &
+         !n_DON_in     = , &
+         !n_DIC_in     = , &
+         !n_fed_in     = , &
+         !n_fep_in     = , &
+         !n_zaero_in   = , &
+         ntrcr_in     = tracerObject % nTracers, &
+         !ntrcr_o_in   = , &
+         nbtrcr_in    = tracerObject % nBioTracers, &
+         nbtrcr_sw_in = tracerObject % nBioTracersShortwave)
+
+  end subroutine init_icepack_package_tracer_sizes
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
@@ -10666,6 +10447,149 @@ contains
     !nbtrcr        = tracerObject % nBioTracers
 
   end subroutine init_column_package_tracer_indices
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  init_icepack_package_tracer_indices
+!
+!> \brief
+!> \author Adrian K. Turner, LANL
+!> \date 5th Feburary 2015
+!> \details
+!>
+!
+!-----------------------------------------------------------------------
+
+  subroutine init_icepack_package_tracer_indices(tracerObject)
+
+    !use ice_colpkg_tracers, only: &
+    !     nt_Tsfc, &       ! ice/snow temperature
+    !     nt_qice, &       ! volume-weighted ice enthalpy (in layers)
+    !     nt_qsno, &       ! volume-weighted snow enthalpy (in layers)
+    !     nt_sice, &       ! volume-weighted ice bulk salinity (CICE grid layers)
+    !     nt_fbri, &       ! volume fraction of ice with dynamic salt (hinS/vicen*aicen)
+    !     nt_iage, &       ! volume-weighted ice age
+    !     nt_FY, &         ! area-weighted first-year ice area
+    !     nt_alvl, &       ! level ice area fraction
+    !     nt_vlvl, &       ! level ice volume fraction
+    !     nt_apnd, &       ! melt pond area fraction
+    !     nt_hpnd, &       ! melt pond depth
+    !     nt_ipnd, &       ! melt pond refrozen lid thickness
+    !     nt_aero, &       ! starting index for aerosols in ice
+    !     nt_smice, &      ! snow ice mass
+    !     nt_smliq, &      ! snow liquid mass
+    !     nt_rsnw, &       ! snow grain radius
+    !     nt_rhos, &       ! snow density tracer
+    !     nt_fbri, &       ! volume fraction of ice with dynamic salt (hinS/vicen*aicen)
+    !     nt_bgc_Nit, &    ! nutrients
+    !     nt_bgc_Am, &     !
+    !     nt_bgc_Sil, &    !
+    !     nt_bgc_DMSPp, &  ! trace gases (skeletal layer)
+    !     nt_bgc_DMSPd, &  !
+    !     nt_bgc_DMS, &    !
+    !     nt_bgc_PON, &    ! zooplankton and detritus
+    !     nt_bgc_hum, &    ! humic material
+    !                      ! bio layer indicess
+    !     nlt_bgc_Nit, &   ! nutrients
+    !     nlt_bgc_Am, &    !
+    !     nlt_bgc_Sil, &   !
+    !     nlt_bgc_DMSPp, & ! trace gases (skeletal layer)
+    !     nlt_bgc_DMSPd, & !
+    !     nlt_bgc_DMS, &   !
+    !     nlt_bgc_PON, &   ! zooplankton and detritus
+    !     nlt_bgc_hum, &   ! humic material
+    !     nlt_chl_sw, &    ! points to total chla in trcrn_sw
+    !     nt_zbgc_frac, &  ! fraction of tracer in the mobile phase
+    !     nt_bgc_S, &      ! Bulk salinity in fraction ice with dynamic salinity (Bio grid)
+    !     nt_bgc_N, &      ! diatoms, phaeocystis, pico/small
+    !     nt_bgc_C, &      ! diatoms, phaeocystis, pico/small
+    !     nt_bgc_chl, &    ! diatoms, phaeocystis, pico/small
+    !     nlt_bgc_N, &     ! diatoms, phaeocystis, pico/small
+    !     nlt_bgc_C, &     ! diatoms, phaeocystis, pico/small
+    !     nlt_bgc_chl, &   ! diatoms, phaeocystis, pico/small
+    !     nt_bgc_DOC, &    ! dissolved organic carbon
+    !     nlt_bgc_DOC, &   ! dissolved organic carbon
+    !     nt_bgc_DON, &    ! dissolved organic nitrogen
+    !     nlt_bgc_DON, &   ! dissolved organic nitrogen
+    !     nt_bgc_DIC, &    ! dissolved inorganic carbon
+    !     nlt_bgc_DIC, &   ! dissolved inorganic carbon
+    !     nt_bgc_Fed, &    ! dissolved iron
+    !     nt_bgc_Fep, &    ! particulate iron
+    !     nlt_bgc_Fed, &   ! dissolved iron
+    !     nlt_bgc_Fep, &   ! particulate iron
+    !     nt_zaero, &      ! black carbon and other aerosols
+    !     nlt_zaero, &     ! black carbon and other aerosols
+    !     nlt_zaero_sw     ! black carbon and other aerosols
+
+    use icepack_intfc, only: &
+         icepack_init_tracer_indices
+
+    type(ciceTracerObjectType), intent(in) :: &
+         tracerObject
+
+    call icepack_init_tracer_indices(&
+         nt_Tsfc_in       = tracerObject % index_surfaceTemperature, &
+         nt_qice_in       = tracerObject % index_iceEnthalpy, &
+         nt_qsno_in       = tracerObject % index_snowEnthalpy, &
+         nt_sice_in       = tracerObject % index_iceSalinity, &
+         nt_fbri_in       = tracerObject % index_brineFraction, &
+         nt_iage_in       = tracerObject % index_iceAge, &
+         nt_FY_in         = tracerObject % index_firstYearIceArea, &
+         nt_alvl_in       = tracerObject % index_levelIceArea, &
+         nt_vlvl_in       = tracerObject % index_levelIceVolume, &
+         nt_apnd_in       = tracerObject % index_pondArea, &
+         nt_hpnd_in       = tracerObject % index_pondDepth, &
+         nt_ipnd_in       = tracerObject % index_pondLidThickness, &
+         nt_smice_in      = tracerObject % index_snowIceMass, &
+         nt_smliq_in      = tracerObject % index_snowLiquidMass, &
+         nt_rhos_in       = tracerObject % index_snowDensity, &
+         nt_rsnw_in       = tracerObject % index_snowGrainRadius, &
+         !nt_fsd
+         !nt_isosno_in
+         !nt_isoice_in
+         nt_aero_in       = tracerObject % index_aerosols, &
+         nt_zaero_in      = tracerObject % index_verticalAerosolsConc, & ! name change?nt_zaeros -> nt_zaero
+         nt_bgc_C_in      = tracerObject % index_algalCarbon, &
+         nt_bgc_N_in      = tracerObject % index_algaeConc, &
+         nt_bgc_chl_in    = tracerObject % index_algalChlorophyll, &
+         nt_bgc_DOC_in    = tracerObject % index_DOCConc, &
+         nt_bgc_DON_in    = tracerObject % index_DONConc, &
+         nt_bgc_DIC_in    = tracerObject % index_DICConc, &
+         nt_bgc_Fed_in    = tracerObject % index_dissolvedIronConc, &
+         nt_bgc_Fep_in    = tracerObject % index_particulateIronConc, &
+         nt_bgc_Nit_in    = tracerObject % index_nitrateConc, &
+         nt_bgc_Am_in     = tracerObject % index_ammoniumConc, &
+         nt_bgc_Sil_in    = tracerObject % index_silicateConc, &
+         nt_bgc_DMSPp_in  = tracerObject % index_DMSPpConc, &
+         nt_bgc_DMSPd_in  = tracerObject % index_DMSPdConc, &
+         nt_bgc_DMS_in    = tracerObject % index_DMSConc, &
+         nt_bgc_hum_in    = tracerObject % index_humicsConc, &
+         nt_bgc_PON_in    = tracerObject % index_nonreactiveConc, &
+         nlt_zaero_in     = tracerObject % index_verticalAerosolsConcLayer, &
+         nlt_bgc_C_in     = tracerObject % index_algalCarbonLayer, &
+         nlt_bgc_N_in     = tracerObject % index_algaeConcLayer, &
+         nlt_bgc_chl_in   = tracerObject % index_algalChlorophyllLayer, &
+         nlt_bgc_DOC_in   = tracerObject % index_DOCConcLayer, &
+         nlt_bgc_DON_in   = tracerObject % index_DONConcLayer, &
+         nlt_bgc_DIC_in   = tracerObject % index_DICConcLayer, &
+         nlt_bgc_Fed_in   = tracerObject % index_dissolvedIronConcLayer, &
+         nlt_bgc_Fep_in   = tracerObject % index_particulateIronConcLayer, &
+         nlt_bgc_Nit_in   = tracerObject % index_nitrateConcLayer, &
+         nlt_bgc_Am_in    = tracerObject % index_ammoniumConcLayer, &
+         nlt_bgc_Sil_in   = tracerObject % index_silicateConcLayer, &
+         nlt_bgc_DMSPp_in = tracerObject % index_DMSPpConcLayer, &
+         nlt_bgc_DMSPd_in = tracerObject % index_DMSPdConcLayer, &
+         nlt_bgc_DMS_in   = tracerObject % index_DMSConcLayer, &
+         nlt_bgc_hum_in   = tracerObject % index_humicsConcLayer, &
+         nlt_bgc_PON_in   = tracerObject % index_nonreactiveConcLayer, &
+         nt_zbgc_frac_in  = tracerObject % index_mobileFraction, &
+         nt_bgc_S_in      = tracerObject % index_verticalSalinity, & ! name change nt_zbgc_S->nt_bgc_S_in
+         nlt_chl_sw_in    = tracerObject % index_chlorophyllShortwave, &
+         nlt_zaero_sw_in  = tracerObject % index_verticalAerosolsConcShortwave, &
+         bio_index_o_in   = tracerObject % index_LayerIndexToDataArray, &
+         bio_index_in     = tracerObject % index_LayerIndexToBioIndex)
+
+  end subroutine init_icepack_package_tracer_indices
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
@@ -12252,6 +12176,1621 @@ contains
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
+!  init_icepack_package_configs
+!
+!> \brief
+!> \author Adrian K. Turner, LANL
+!> \date 2nd Feburary 2015
+!> \details
+!>
+!
+!-----------------------------------------------------------------------
+
+  subroutine init_icepack_package_configs(domain)
+
+    use icepack_intfc, only: &
+         icepack_init_parameters
+
+    type(domain_type), intent(inout) :: &
+         domain
+
+    character(len=strKIND), pointer :: &
+         config_thermodynamics_type, &
+         config_heat_conductivity_type, &
+         config_shortwave_type, &
+         config_albedo_type, &
+         config_ice_strength_formulation, &
+         config_ridging_participation_function, &
+         config_ridging_redistribution_function, &
+         config_atmos_boundary_method, &
+         config_itd_conversion_type, &
+         config_category_bounds_type, &
+         config_pond_refreezing_type, &
+         config_ocean_heat_transfer_type, &
+         config_sea_freezing_temperature_type, &
+         config_skeletal_bgc_flux_type, &
+         config_snow_redistribution_scheme
+
+    logical, pointer :: &
+         config_calc_surface_temperature, &
+         config_update_ocean_fluxes, &
+         config_use_form_drag, &
+         config_use_high_frequency_coupling, &
+         config_use_ocean_mixed_layer, &
+         config_calc_surface_stresses, &
+         config_use_vertical_tracers, &
+         config_scale_initial_vertical_bgc, &
+         config_use_vertical_biochemistry, &
+         config_use_shortwave_bioabsorption, &
+         config_use_skeletal_biochemistry, &
+         config_use_vertical_zsalinity, &
+         config_use_modal_aerosols, &
+         config_use_snicar_ad, &
+         config_use_snow_liquid_ponds
+
+    real(kind=RKIND), pointer :: &
+         config_min_friction_velocity, &
+         config_rapid_mode_channel_radius, &
+         config_rapid_model_critical_Ra, &
+         config_rapid_mode_aspect_ratio, &
+         config_slow_mode_drainage_strength, &
+         config_slow_mode_critical_porosity, &
+         config_congelation_ice_porosity, &
+         config_visible_ice_albedo, &
+         config_infrared_ice_albedo, &
+         config_visible_snow_albedo, &
+         config_infrared_snow_albedo, &
+         config_variable_albedo_thickness_limit, &
+         config_ice_shortwave_tuning_parameter, &
+         config_pond_shortwave_tuning_parameter, &
+         config_snow_shortwave_tuning_parameter, &
+         config_temp_change_snow_grain_radius_change, &
+         config_max_melting_snow_grain_radius, &
+         config_algae_absorption_coefficient, &
+         config_ridiging_efolding_scale, &
+         config_ratio_ridging_work_to_PE, &
+         config_snow_to_ice_transition_depth, &
+         config_pond_flushing_timescale, &
+         config_min_meltwater_retained_fraction, &
+         config_max_meltwater_retained_fraction, &
+         config_pond_depth_to_fraction_ratio, &
+         config_snow_on_pond_ice_tapering_parameter, &
+         config_critical_pond_ice_thickness, &
+         config_biogrid_bottom_molecular_sublayer, &
+         config_bio_gravity_drainage_length_scale, &
+         config_biogrid_top_molecular_sublayer, &
+         config_new_ice_fraction_biotracer, &
+         config_fraction_biotracer_in_frazil, &
+         config_zsalinity_molecular_sublayer, &
+         config_zsalinity_gravity_drainage_scale, &
+         config_snow_porosity_at_ice_surface, &
+         config_ratio_Si_to_N_diatoms, &
+         config_ratio_Si_to_N_small_plankton, &
+         config_ratio_Si_to_N_phaeocystis, &
+         config_ratio_S_to_N_diatoms, &
+         config_ratio_S_to_N_small_plankton, &
+         config_ratio_S_to_N_phaeocystis, &
+         config_ratio_Fe_to_C_diatoms, &
+         config_ratio_Fe_to_C_small_plankton, &
+         config_ratio_Fe_to_C_phaeocystis, &
+         config_ratio_Fe_to_N_diatoms, &
+         config_ratio_Fe_to_N_small_plankton, &
+         config_ratio_Fe_to_N_phaeocystis, &
+         config_ratio_Fe_to_DON, &
+         config_ratio_Fe_to_DOC_saccharids, &
+         config_ratio_Fe_to_DOC_lipids, &
+         config_respiration_fraction_of_growth, &
+         config_rapid_mobile_to_stationary_time, &
+         config_long_mobile_to_stationary_time, &
+         config_algal_maximum_velocity, &
+         config_ratio_Fe_to_dust, &
+         config_solubility_of_Fe_in_dust, &
+         config_chla_absorptivity_of_diatoms, &
+         config_chla_absorptivity_of_small_plankton, &
+         config_chla_absorptivity_of_phaeocystis, &
+         config_light_attenuation_diatoms, &
+         config_light_attenuation_small_plankton, &
+         config_light_attenuation_phaeocystis, &
+         config_light_inhibition_diatoms, &
+         config_light_inhibition_small_plankton, &
+         config_light_inhibition_phaeocystis, &
+         config_maximum_growth_rate_diatoms, &
+         config_maximum_growth_rate_small_plankton, &
+         config_maximum_growth_rate_phaeocystis, &
+         config_temperature_growth_diatoms, &
+         config_temperature_growth_small_plankton, &
+         config_temperature_growth_phaeocystis, &
+         config_grazed_fraction_diatoms, &
+         config_grazed_fraction_small_plankton, &
+         config_grazed_fraction_phaeocystis, &
+         config_mortality_diatoms, &
+         config_mortality_small_plankton, &
+         config_mortality_phaeocystis, &
+         config_temperature_mortality_diatoms, &
+         config_temperature_mortality_small_plankton, &
+         config_temperature_mortality_phaeocystis, &
+         config_exudation_diatoms, &
+         config_exudation_small_plankton, &
+         config_exudation_phaeocystis, &
+         config_nitrate_saturation_diatoms, &
+         config_nitrate_saturation_small_plankton, &
+         config_nitrate_saturation_phaeocystis, &
+         config_ammonium_saturation_diatoms, &
+         config_ammonium_saturation_small_plankton, &
+         config_ammonium_saturation_phaeocystis, &
+         config_silicate_saturation_diatoms, &
+         config_silicate_saturation_small_plankton, &
+         config_silicate_saturation_phaeocystis, &
+         config_iron_saturation_diatoms, &
+         config_iron_saturation_small_plankton, &
+         config_iron_saturation_phaeocystis, &
+         config_fraction_spilled_to_DON, &
+         config_degredation_of_DON, &
+         config_fraction_DON_ammonium, &
+         config_fraction_loss_to_saccharids, &
+         config_fraction_loss_to_lipids, &
+         config_fraction_exudation_to_saccharids, &
+         config_fraction_exudation_to_lipids, &
+         config_remineralization_saccharids, &
+         config_remineralization_lipids, &
+         config_maximum_brine_temperature, &
+         config_salinity_dependence_of_growth, &
+         config_minimum_optical_depth, &
+         config_slopped_grazing_fraction, &
+         config_excreted_fraction, &
+         config_fraction_mortality_to_ammonium, &
+         config_fraction_iron_remineralized, &
+         config_nitrification_rate, &
+         config_desorption_loss_particulate_iron, &
+         config_maximum_loss_fraction, &
+         config_maximum_ratio_iron_to_saccharids, &
+         config_respiration_loss_to_DMSPd, &
+         config_DMSP_to_DMS_conversion_fraction, &
+         config_DMSP_to_DMS_conversion_time, &
+         config_DMS_oxidation_time, &
+         config_mobility_type_diatoms, &
+         config_mobility_type_small_plankton, &
+         config_mobility_type_phaeocystis, &
+         config_mobility_type_nitrate, &
+         config_mobility_type_ammonium, &
+         config_mobility_type_silicate, &
+         config_mobility_type_DMSPp, &
+         config_mobility_type_DMSPd, &
+         config_mobility_type_humics, &
+         config_mobility_type_saccharids, &
+         config_mobility_type_lipids, &
+         config_mobility_type_inorganic_carbon, &
+         config_mobility_type_proteins, &
+         config_mobility_type_dissolved_iron, &
+         config_mobility_type_particulate_iron, &
+         config_mobility_type_black_carbon1, &
+         config_mobility_type_black_carbon2, &
+         config_mobility_type_dust1, &
+         config_mobility_type_dust2, &
+         config_mobility_type_dust3, &
+         config_mobility_type_dust4, &
+         config_ratio_C_to_N_diatoms, &
+         config_ratio_C_to_N_small_plankton, &
+         config_ratio_C_to_N_phaeocystis, &
+         config_ratio_chla_to_N_diatoms, &
+         config_ratio_chla_to_N_small_plankton, &
+         config_ratio_chla_to_N_phaeocystis, &
+         config_scales_absorption_diatoms, &
+         config_scales_absorption_small_plankton, &
+         config_scales_absorption_phaeocystis, &
+         config_ratio_C_to_N_proteins, &
+         config_fallen_snow_radius, &
+         config_new_snow_density, &
+         config_max_snow_density, &
+         config_minimum_wind_compaction, &
+         config_wind_compaction_factor, &
+         config_max_dry_snow_radius
+
+    integer, pointer :: &
+         config_boundary_layer_iteration_number, &
+         config_thermodynamics_type_int, &
+         config_ice_strength_formulation_int, &
+         config_ridging_participation_function_int, &
+         config_ridging_redistribution_function_int, &
+         config_itd_conversion_type_int, &
+         config_category_bounds_type_int
+
+    call MPAS_pool_get_config(domain % configs, "config_thermodynamics_type", config_thermodynamics_type)
+    call MPAS_pool_get_config(domain % configs, "config_heat_conductivity_type", config_heat_conductivity_type)
+    call MPAS_pool_get_config(domain % configs, "config_ocean_heat_transfer_type", config_ocean_heat_transfer_type)
+    call MPAS_pool_get_config(domain % configs, "config_calc_surface_temperature", config_calc_surface_temperature)
+    call MPAS_pool_get_config(domain % configs, "config_update_ocean_fluxes", config_update_ocean_fluxes)
+    call MPAS_pool_get_config(domain % configs, "config_min_friction_velocity", config_min_friction_velocity)
+    call MPAS_pool_get_config(domain % configs, "config_rapid_mode_channel_radius", config_rapid_mode_channel_radius)
+    call MPAS_pool_get_config(domain % configs, "config_rapid_model_critical_Ra", config_rapid_model_critical_Ra)
+    call MPAS_pool_get_config(domain % configs, "config_rapid_mode_aspect_ratio", config_rapid_mode_aspect_ratio)
+    call MPAS_pool_get_config(domain % configs, "config_slow_mode_drainage_strength", config_slow_mode_drainage_strength)
+    call MPAS_pool_get_config(domain % configs, "config_slow_mode_critical_porosity", config_slow_mode_critical_porosity)
+    call MPAS_pool_get_config(domain % configs, "config_congelation_ice_porosity", config_congelation_ice_porosity)
+    call MPAS_pool_get_config(domain % configs, "config_shortwave_type", config_shortwave_type)
+    call MPAS_pool_get_config(domain % configs, "config_use_snicar_ad", config_use_snicar_ad)
+    call MPAS_pool_get_config(domain % configs, "config_albedo_type", config_albedo_type)
+    call MPAS_pool_get_config(domain % configs, "config_visible_ice_albedo", config_visible_ice_albedo)
+    call MPAS_pool_get_config(domain % configs, "config_infrared_ice_albedo", config_infrared_ice_albedo)
+    call MPAS_pool_get_config(domain % configs, "config_visible_snow_albedo", config_visible_snow_albedo)
+    call MPAS_pool_get_config(domain % configs, "config_infrared_snow_albedo", config_infrared_snow_albedo)
+    call MPAS_pool_get_config(domain % configs, "config_variable_albedo_thickness_limit", config_variable_albedo_thickness_limit)
+    call MPAS_pool_get_config(domain % configs, "config_ice_shortwave_tuning_parameter", config_ice_shortwave_tuning_parameter)
+    call MPAS_pool_get_config(domain % configs, "config_pond_shortwave_tuning_parameter", config_pond_shortwave_tuning_parameter)
+    call MPAS_pool_get_config(domain % configs, "config_snow_shortwave_tuning_parameter", config_snow_shortwave_tuning_parameter)
+    call MPAS_pool_get_config(domain % configs, "config_temp_change_snow_grain_radius_change", &
+                                                 config_temp_change_snow_grain_radius_change)
+    call MPAS_pool_get_config(domain % configs, "config_max_melting_snow_grain_radius", config_max_melting_snow_grain_radius)
+    call MPAS_pool_get_config(domain % configs, "config_algae_absorption_coefficient", config_algae_absorption_coefficient)
+    call MPAS_pool_get_config(domain % configs, "config_ice_strength_formulation", config_ice_strength_formulation)
+    call MPAS_pool_get_config(domain % configs, "config_ridging_participation_function", config_ridging_participation_function)
+    call MPAS_pool_get_config(domain % configs, "config_ridging_redistribution_function", config_ridging_redistribution_function)
+    call MPAS_pool_get_config(domain % configs, "config_ridiging_efolding_scale", config_ridiging_efolding_scale)
+    call MPAS_pool_get_config(domain % configs, "config_ratio_ridging_work_to_PE", config_ratio_ridging_work_to_PE)
+    call MPAS_pool_get_config(domain % configs, "config_atmos_boundary_method", config_atmos_boundary_method)
+    call MPAS_pool_get_config(domain % configs, "config_calc_surface_stresses", config_calc_surface_stresses)
+    call MPAS_pool_get_config(domain % configs, "config_use_form_drag", config_use_form_drag)
+    call MPAS_pool_get_config(domain % configs, "config_use_high_frequency_coupling", config_use_high_frequency_coupling)
+    call MPAS_pool_get_config(domain % configs, "config_boundary_layer_iteration_number", config_boundary_layer_iteration_number)
+    call MPAS_pool_get_config(domain % configs, "config_use_ocean_mixed_layer", config_use_ocean_mixed_layer)
+    call MPAS_pool_get_config(domain % configs, "config_sea_freezing_temperature_type", config_sea_freezing_temperature_type)
+    call MPAS_pool_get_config(domain % configs, "config_itd_conversion_type", config_itd_conversion_type)
+    call MPAS_pool_get_config(domain % configs, "config_category_bounds_type", config_category_bounds_type)
+    call MPAS_pool_get_config(domain % configs, "config_snow_to_ice_transition_depth", config_snow_to_ice_transition_depth)
+    call MPAS_pool_get_config(domain % configs, "config_pond_refreezing_type", config_pond_refreezing_type)
+    call MPAS_pool_get_config(domain % configs, "config_pond_flushing_timescale", config_pond_flushing_timescale)
+    call MPAS_pool_get_config(domain % configs, "config_min_meltwater_retained_fraction", config_min_meltwater_retained_fraction)
+    call MPAS_pool_get_config(domain % configs, "config_max_meltwater_retained_fraction", config_max_meltwater_retained_fraction)
+    call MPAS_pool_get_config(domain % configs, "config_pond_depth_to_fraction_ratio", config_pond_depth_to_fraction_ratio)
+    call MPAS_pool_get_config(domain % configs, "config_snow_on_pond_ice_tapering_parameter", &
+                                                 config_snow_on_pond_ice_tapering_parameter)
+    call MPAS_pool_get_config(domain % configs, "config_critical_pond_ice_thickness", config_critical_pond_ice_thickness)
+    call MPAS_pool_get_config(domain % configs, "config_skeletal_bgc_flux_type", config_skeletal_bgc_flux_type)
+    call MPAS_pool_get_config(domain % configs, "config_use_vertical_tracers", config_use_vertical_tracers)
+    call MPAS_pool_get_config(domain % configs, "config_scale_initial_vertical_bgc", config_scale_initial_vertical_bgc)
+    call MPAS_pool_get_config(domain % configs, "config_use_vertical_biochemistry", config_use_vertical_biochemistry)
+    call MPAS_pool_get_config(domain % configs, "config_use_shortwave_bioabsorption", config_use_shortwave_bioabsorption)
+    call MPAS_pool_get_config(domain % configs, "config_use_modal_aerosols", config_use_modal_aerosols)
+    call MPAS_pool_get_config(domain % configs, "config_use_skeletal_biochemistry", config_use_skeletal_biochemistry)
+    call MPAS_pool_get_config(domain % configs, "config_use_vertical_zsalinity", config_use_vertical_zsalinity)
+    call MPAS_pool_get_config(domain % configs, "config_biogrid_bottom_molecular_sublayer", &
+                                                 config_biogrid_bottom_molecular_sublayer)
+    call MPAS_pool_get_config(domain % configs, "config_bio_gravity_drainage_length_scale", &
+                                                 config_bio_gravity_drainage_length_scale)
+    call MPAS_pool_get_config(domain % configs, "config_biogrid_top_molecular_sublayer", config_biogrid_top_molecular_sublayer)
+    call MPAS_pool_get_config(domain % configs, "config_zsalinity_gravity_drainage_scale", config_zsalinity_gravity_drainage_scale)
+    call MPAS_pool_get_config(domain % configs, "config_new_ice_fraction_biotracer", config_new_ice_fraction_biotracer)
+    call MPAS_pool_get_config(domain % configs, "config_fraction_biotracer_in_frazil", config_fraction_biotracer_in_frazil)
+    call MPAS_pool_get_config(domain % configs, "config_zsalinity_molecular_sublayer", config_zsalinity_molecular_sublayer)
+    call MPAS_pool_get_config(domain % configs, "config_snow_porosity_at_ice_surface", config_snow_porosity_at_ice_surface)
+    call MPAS_pool_get_config(domain % configs, "config_ratio_Si_to_N_diatoms", config_ratio_Si_to_N_diatoms)
+    call MPAS_pool_get_config(domain % configs, "config_ratio_Si_to_N_small_plankton", config_ratio_Si_to_N_small_plankton)
+    call MPAS_pool_get_config(domain % configs, "config_ratio_Si_to_N_phaeocystis", config_ratio_Si_to_N_phaeocystis)
+    call MPAS_pool_get_config(domain % configs, "config_ratio_S_to_N_diatoms", config_ratio_S_to_N_diatoms)
+    call MPAS_pool_get_config(domain % configs, "config_ratio_S_to_N_small_plankton", config_ratio_S_to_N_small_plankton)
+    call MPAS_pool_get_config(domain % configs, "config_ratio_S_to_N_phaeocystis", config_ratio_S_to_N_phaeocystis)
+    call MPAS_pool_get_config(domain % configs, "config_ratio_Fe_to_C_diatoms", config_ratio_Fe_to_C_diatoms)
+    call MPAS_pool_get_config(domain % configs, "config_ratio_Fe_to_C_small_plankton", config_ratio_Fe_to_C_small_plankton)
+    call MPAS_pool_get_config(domain % configs, "config_ratio_Fe_to_C_phaeocystis", config_ratio_Fe_to_C_phaeocystis)
+    call MPAS_pool_get_config(domain % configs, "config_ratio_Fe_to_N_diatoms", config_ratio_Fe_to_N_diatoms)
+    call MPAS_pool_get_config(domain % configs, "config_ratio_Fe_to_N_small_plankton", config_ratio_Fe_to_N_small_plankton)
+    call MPAS_pool_get_config(domain % configs, "config_ratio_Fe_to_N_phaeocystis", config_ratio_Fe_to_N_phaeocystis)
+    call MPAS_pool_get_config(domain % configs, "config_ratio_Fe_to_DON", config_ratio_Fe_to_DON)
+    call MPAS_pool_get_config(domain % configs, "config_ratio_Fe_to_DOC_saccharids", config_ratio_Fe_to_DOC_saccharids)
+    call MPAS_pool_get_config(domain % configs, "config_ratio_Fe_to_DOC_lipids", config_ratio_Fe_to_DOC_lipids)
+    call MPAS_pool_get_config(domain % configs, "config_respiration_fraction_of_growth", config_respiration_fraction_of_growth)
+    call MPAS_pool_get_config(domain % configs, "config_rapid_mobile_to_stationary_time", config_rapid_mobile_to_stationary_time)
+    call MPAS_pool_get_config(domain % configs, "config_long_mobile_to_stationary_time", config_long_mobile_to_stationary_time)
+    call MPAS_pool_get_config(domain % configs, "config_algal_maximum_velocity", config_algal_maximum_velocity)
+    call MPAS_pool_get_config(domain % configs, "config_ratio_Fe_to_dust", config_ratio_Fe_to_dust)
+    call MPAS_pool_get_config(domain % configs, "config_solubility_of_Fe_in_dust", config_solubility_of_Fe_in_dust)
+    call MPAS_pool_get_config(domain % configs, "config_chla_absorptivity_of_diatoms", config_chla_absorptivity_of_diatoms)
+    call MPAS_pool_get_config(domain % configs, "config_chla_absorptivity_of_small_plankton", &
+                                                 config_chla_absorptivity_of_small_plankton)
+    call MPAS_pool_get_config(domain % configs, "config_chla_absorptivity_of_phaeocystis", config_chla_absorptivity_of_phaeocystis)
+    call MPAS_pool_get_config(domain % configs, "config_light_attenuation_diatoms", config_light_attenuation_diatoms)
+    call MPAS_pool_get_config(domain % configs, "config_light_attenuation_small_plankton", config_light_attenuation_small_plankton)
+    call MPAS_pool_get_config(domain % configs, "config_light_attenuation_phaeocystis", config_light_attenuation_phaeocystis)
+    call MPAS_pool_get_config(domain % configs, "config_light_inhibition_diatoms", config_light_inhibition_diatoms)
+    call MPAS_pool_get_config(domain % configs, "config_light_inhibition_small_plankton", config_light_inhibition_small_plankton)
+    call MPAS_pool_get_config(domain % configs, "config_light_inhibition_phaeocystis", config_light_inhibition_phaeocystis)
+    call MPAS_pool_get_config(domain % configs, "config_maximum_growth_rate_diatoms", config_maximum_growth_rate_diatoms)
+    call MPAS_pool_get_config(domain % configs, "config_maximum_growth_rate_small_plankton", &
+                                                 config_maximum_growth_rate_small_plankton)
+    call MPAS_pool_get_config(domain % configs, "config_maximum_growth_rate_phaeocystis", config_maximum_growth_rate_phaeocystis)
+    call MPAS_pool_get_config(domain % configs, "config_temperature_growth_diatoms", config_temperature_growth_diatoms)
+    call MPAS_pool_get_config(domain % configs, "config_temperature_growth_small_plankton", &
+                                                 config_temperature_growth_small_plankton)
+    call MPAS_pool_get_config(domain % configs, "config_temperature_growth_phaeocystis", config_temperature_growth_phaeocystis)
+    call MPAS_pool_get_config(domain % configs, "config_grazed_fraction_diatoms", config_grazed_fraction_diatoms)
+    call MPAS_pool_get_config(domain % configs, "config_grazed_fraction_small_plankton", config_grazed_fraction_small_plankton)
+    call MPAS_pool_get_config(domain % configs, "config_grazed_fraction_phaeocystis", config_grazed_fraction_phaeocystis)
+    call MPAS_pool_get_config(domain % configs, "config_mortality_diatoms", config_mortality_diatoms)
+    call MPAS_pool_get_config(domain % configs, "config_mortality_small_plankton", config_mortality_small_plankton)
+    call MPAS_pool_get_config(domain % configs, "config_mortality_phaeocystis", config_mortality_phaeocystis)
+    call MPAS_pool_get_config(domain % configs, "config_temperature_mortality_diatoms", config_temperature_mortality_diatoms)
+    call MPAS_pool_get_config(domain % configs, "config_temperature_mortality_small_plankton", &
+                                                 config_temperature_mortality_small_plankton)
+    call MPAS_pool_get_config(domain % configs, "config_temperature_mortality_phaeocystis", &
+                                                 config_temperature_mortality_phaeocystis)
+    call MPAS_pool_get_config(domain % configs, "config_exudation_diatoms", config_exudation_diatoms)
+    call MPAS_pool_get_config(domain % configs, "config_exudation_small_plankton", config_exudation_small_plankton)
+    call MPAS_pool_get_config(domain % configs, "config_exudation_phaeocystis", config_exudation_phaeocystis)
+    call MPAS_pool_get_config(domain % configs, "config_nitrate_saturation_diatoms", config_nitrate_saturation_diatoms)
+    call MPAS_pool_get_config(domain % configs, "config_nitrate_saturation_small_plankton", &
+                                                 config_nitrate_saturation_small_plankton)
+    call MPAS_pool_get_config(domain % configs, "config_nitrate_saturation_phaeocystis", config_nitrate_saturation_phaeocystis)
+    call MPAS_pool_get_config(domain % configs, "config_ammonium_saturation_diatoms", config_ammonium_saturation_diatoms)
+    call MPAS_pool_get_config(domain % configs, "config_ammonium_saturation_small_plankton", &
+                                                 config_ammonium_saturation_small_plankton)
+    call MPAS_pool_get_config(domain % configs, "config_ammonium_saturation_phaeocystis", &
+                                                 config_ammonium_saturation_phaeocystis)
+    call MPAS_pool_get_config(domain % configs, "config_silicate_saturation_diatoms", config_silicate_saturation_diatoms)
+    call MPAS_pool_get_config(domain % configs, "config_silicate_saturation_small_plankton", &
+                                                 config_silicate_saturation_small_plankton)
+    call MPAS_pool_get_config(domain % configs, "config_silicate_saturation_phaeocystis", config_silicate_saturation_phaeocystis)
+    call MPAS_pool_get_config(domain % configs, "config_iron_saturation_diatoms", config_iron_saturation_diatoms)
+    call MPAS_pool_get_config(domain % configs, "config_iron_saturation_small_plankton", config_iron_saturation_small_plankton)
+    call MPAS_pool_get_config(domain % configs, "config_iron_saturation_phaeocystis", config_iron_saturation_phaeocystis)
+    call MPAS_pool_get_config(domain % configs, "config_fraction_spilled_to_DON", config_fraction_spilled_to_DON)
+    call MPAS_pool_get_config(domain % configs, "config_degredation_of_DON", config_degredation_of_DON)
+    call MPAS_pool_get_config(domain % configs, "config_fraction_DON_ammonium", config_fraction_DON_ammonium)
+    call MPAS_pool_get_config(domain % configs, "config_fraction_loss_to_saccharids", config_fraction_loss_to_saccharids)
+    call MPAS_pool_get_config(domain % configs, "config_fraction_loss_to_lipids",  config_fraction_loss_to_lipids)
+    call MPAS_pool_get_config(domain % configs, "config_fraction_exudation_to_saccharids", config_fraction_exudation_to_saccharids)
+    call MPAS_pool_get_config(domain % configs, "config_fraction_exudation_to_lipids", config_fraction_exudation_to_lipids)
+    call MPAS_pool_get_config(domain % configs, "config_remineralization_saccharids", config_remineralization_saccharids)
+    call MPAS_pool_get_config(domain % configs, "config_remineralization_lipids", config_remineralization_lipids)
+    call MPAS_pool_get_config(domain % configs, "config_maximum_brine_temperature", config_maximum_brine_temperature)
+    call MPAS_pool_get_config(domain % configs, "config_salinity_dependence_of_growth", config_salinity_dependence_of_growth)
+    call MPAS_pool_get_config(domain % configs, "config_minimum_optical_depth", config_minimum_optical_depth)
+    call MPAS_pool_get_config(domain % configs, "config_slopped_grazing_fraction", config_slopped_grazing_fraction)
+    call MPAS_pool_get_config(domain % configs, "config_excreted_fraction", config_excreted_fraction)
+    call MPAS_pool_get_config(domain % configs, "config_fraction_mortality_to_ammonium", config_fraction_mortality_to_ammonium)
+    call MPAS_pool_get_config(domain % configs, "config_fraction_iron_remineralized", config_fraction_iron_remineralized)
+    call MPAS_pool_get_config(domain % configs, "config_nitrification_rate", config_nitrification_rate)
+    call MPAS_pool_get_config(domain % configs, "config_desorption_loss_particulate_iron", config_desorption_loss_particulate_iron)
+    call MPAS_pool_get_config(domain % configs, "config_maximum_loss_fraction", config_maximum_loss_fraction)
+    call MPAS_pool_get_config(domain % configs, "config_maximum_ratio_iron_to_saccharids", config_maximum_ratio_iron_to_saccharids)
+    call MPAS_pool_get_config(domain % configs, "config_respiration_loss_to_DMSPd", config_respiration_loss_to_DMSPd)
+    call MPAS_pool_get_config(domain % configs, "config_DMSP_to_DMS_conversion_fraction", config_DMSP_to_DMS_conversion_fraction)
+    call MPAS_pool_get_config(domain % configs, "config_DMSP_to_DMS_conversion_time", config_DMSP_to_DMS_conversion_time)
+    call MPAS_pool_get_config(domain % configs, "config_DMS_oxidation_time", config_DMS_oxidation_time)
+    call MPAS_pool_get_config(domain % configs, "config_mobility_type_diatoms", config_mobility_type_diatoms)
+    call MPAS_pool_get_config(domain % configs, "config_mobility_type_small_plankton", config_mobility_type_small_plankton)
+    call MPAS_pool_get_config(domain % configs, "config_mobility_type_phaeocystis", config_mobility_type_phaeocystis)
+    call MPAS_pool_get_config(domain % configs, "config_mobility_type_nitrate", config_mobility_type_nitrate)
+    call MPAS_pool_get_config(domain % configs, "config_mobility_type_ammonium", config_mobility_type_ammonium)
+    call MPAS_pool_get_config(domain % configs, "config_mobility_type_silicate", config_mobility_type_silicate)
+    call MPAS_pool_get_config(domain % configs, "config_mobility_type_DMSPp", config_mobility_type_DMSPp)
+    call MPAS_pool_get_config(domain % configs, "config_mobility_type_DMSPd", config_mobility_type_DMSPd)
+    call MPAS_pool_get_config(domain % configs, "config_mobility_type_humics", config_mobility_type_humics)
+    call MPAS_pool_get_config(domain % configs, "config_mobility_type_saccharids", config_mobility_type_saccharids)
+    call MPAS_pool_get_config(domain % configs, "config_mobility_type_lipids", config_mobility_type_lipids)
+    call MPAS_pool_get_config(domain % configs, "config_mobility_type_inorganic_carbon", config_mobility_type_inorganic_carbon)
+    call MPAS_pool_get_config(domain % configs, "config_mobility_type_proteins", config_mobility_type_proteins)
+    call MPAS_pool_get_config(domain % configs, "config_mobility_type_dissolved_iron", config_mobility_type_dissolved_iron)
+    call MPAS_pool_get_config(domain % configs, "config_mobility_type_particulate_iron", config_mobility_type_particulate_iron)
+    call MPAS_pool_get_config(domain % configs, "config_mobility_type_black_carbon1", config_mobility_type_black_carbon1)
+    call MPAS_pool_get_config(domain % configs, "config_mobility_type_black_carbon2", config_mobility_type_black_carbon2)
+    call MPAS_pool_get_config(domain % configs, "config_mobility_type_dust1", config_mobility_type_dust1)
+    call MPAS_pool_get_config(domain % configs, "config_mobility_type_dust2", config_mobility_type_dust2)
+    call MPAS_pool_get_config(domain % configs, "config_mobility_type_dust3", config_mobility_type_dust3)
+    call MPAS_pool_get_config(domain % configs, "config_mobility_type_dust4", config_mobility_type_dust4)
+    call MPAS_pool_get_config(domain % configs, "config_ratio_C_to_N_diatoms", config_ratio_C_to_N_diatoms)
+    call MPAS_pool_get_config(domain % configs, "config_ratio_C_to_N_small_plankton", config_ratio_C_to_N_small_plankton)
+    call MPAS_pool_get_config(domain % configs, "config_ratio_C_to_N_phaeocystis", config_ratio_C_to_N_phaeocystis)
+    call MPAS_pool_get_config(domain % configs, "config_ratio_chla_to_N_diatoms", config_ratio_chla_to_N_diatoms)
+    call MPAS_pool_get_config(domain % configs, "config_ratio_chla_to_N_small_plankton", config_ratio_chla_to_N_small_plankton)
+    call MPAS_pool_get_config(domain % configs, "config_ratio_chla_to_N_phaeocystis", config_ratio_chla_to_N_phaeocystis)
+    call MPAS_pool_get_config(domain % configs, "config_scales_absorption_diatoms", config_scales_absorption_diatoms)
+    call MPAS_pool_get_config(domain % configs, "config_scales_absorption_small_plankton", config_scales_absorption_small_plankton)
+    call MPAS_pool_get_config(domain % configs, "config_scales_absorption_phaeocystis", config_scales_absorption_phaeocystis)
+    call MPAS_pool_get_config(domain % configs, "config_ratio_C_to_N_proteins", config_ratio_C_to_N_proteins)
+    call MPAS_pool_get_config(domain % configs, "config_snow_redistribution_scheme", config_snow_redistribution_scheme)
+    call MPAS_pool_get_config(domain % configs, "config_fallen_snow_radius", config_fallen_snow_radius)
+    call MPAS_pool_get_config(domain % configs, "config_use_snow_liquid_ponds", config_use_snow_liquid_ponds)
+    call MPAS_pool_get_config(domain % configs, "config_new_snow_density", config_new_snow_density)
+    call MPAS_pool_get_config(domain % configs, "config_max_snow_density", config_max_snow_density)
+    call MPAS_pool_get_config(domain % configs, "config_minimum_wind_compaction", config_minimum_wind_compaction)
+    call MPAS_pool_get_config(domain % configs, "config_wind_compaction_factor", config_wind_compaction_factor)
+    call MPAS_pool_get_config(domain % configs, "config_max_dry_snow_radius", config_max_dry_snow_radius)
+
+    config_thermodynamics_type_int = config_cice_int("config_thermodynamics_type", config_thermodynamics_type)
+    config_ice_strength_formulation_int = config_cice_int("config_ice_strength_formulation", config_ice_strength_formulation)
+    config_ridging_participation_function_int = config_cice_int("config_ridging_participation_function", config_ridging_participation_function)
+    config_ridging_redistribution_function_int = config_cice_int("config_ridging_redistribution_function", config_ridging_redistribution_function)
+    config_itd_conversion_type_int = config_cice_int("config_itd_conversion_type", config_itd_conversion_type)
+    config_category_bounds_type_int = config_cice_int("config_category_bounds_type", config_category_bounds_type)
+
+    call icepack_init_parameters(&
+         !argcheck_in             = , &
+         !puny_in                 = , &
+         !bignum_in               = , &
+         !pi_in                   = , &
+         !secday_in               = , &
+         !rhos_in                 = , &
+         !rhoi_in                 = , &
+         !rhow_in                 = , &
+         !cp_air_in               = , &
+         !emissivity_in           = , &
+         !cp_ice_in               = , &
+         !cp_ocn_in               = , &
+         !hfrazilmin_in           = , &
+         !floediam_in             = , &
+         !depressT_in             = , &
+         !dragio_in               = , &
+         !thickness_ocn_layer1_in = , &
+         !iceruf_ocn_in           = , &
+         !albocn_in               = , &
+         !gravit_in               = , &
+         !viscosity_dyn_in        = , &
+         !Tocnfrz_in              = , &
+         !rhofresh_in             = , &
+         !zvir_in                 = , &
+         !vonkar_in               = , &
+         !cp_wv_in                = , &
+         !stefan_boltzmann_in     = , &
+         !ice_ref_salinity_in     = , &
+         !Tffresh_in              = , &
+         !Lsub_in                 = , &
+         !Lvap_in                 = , &
+         !Timelt_in               = , &
+         !Tsmelt_in               = , &
+         !iceruf_in               = , &
+         Cf_in                   = config_ratio_ridging_work_to_PE, &
+         !Pstar_in                = , &
+         !Cstar_in                = , &
+         !kappav_in               = , &
+         !kice_in                 = , &
+         !ksno_in                 = , &
+         !zref_in                 = , &
+         !hs_min_in               = , &
+         !snowpatch_in            = , &
+         !rhosi_in                = , &
+         !sk_l_in                 = , &
+         !saltmax_in              = , &
+         !phi_init_in             = , &
+         !min_salin_in            = , &
+         !salt_loss_in            = , &
+         !min_bgc_in              = , &
+         !dSin0_frazil_in         = , &
+         !hi_ssl_in               = , &
+         !hs_ssl_in               = , &
+         !awtvdr_in               = , &
+         !awtidr_in               = , &
+         !awtvdf_in               = , &
+         !awtidf_in               = , &
+         !qqqice_in               = , &
+         !TTTice_in               = , &
+         !qqqocn_in               = , &
+         !TTTocn_in               = , &
+         ktherm_in               = config_thermodynamics_type_int, &
+         conduct_in              = config_heat_conductivity_type, &
+         fbot_xfer_type_in       = config_ocean_heat_transfer_type, &
+         calc_Tsfc_in            = config_calc_surface_temperature, &
+         !dts_b_in                = , &
+         update_ocn_f_in         = config_update_ocean_fluxes, &
+         ustar_min_in            = config_min_friction_velocity, &
+         a_rapid_mode_in         = config_rapid_mode_channel_radius, &
+         Rac_rapid_mode_in       = config_rapid_model_critical_Ra, &
+         aspect_rapid_mode_in    = config_rapid_mode_aspect_ratio, &
+         dSdt_slow_mode_in       = config_slow_mode_drainage_strength, &
+         phi_c_slow_mode_in      = config_slow_mode_critical_porosity, &
+         phi_i_mushy_in          = config_congelation_ice_porosity, &
+         shortwave_in            = config_shortwave_type, &
+         use_snicar_in           = config_use_snicar_ad, &
+         albedo_type_in          = config_albedo_type, &
+         albsnowi_in             = config_infrared_snow_albedo, &
+         albicev_in              = config_visible_ice_albedo, &
+         albicei_in              = config_infrared_ice_albedo, &
+         albsnowv_in             = config_visible_snow_albedo, &
+         ahmax_in                = config_variable_albedo_thickness_limit, &
+         R_ice_in                = config_ice_shortwave_tuning_parameter, &
+         R_pnd_in                = config_pond_shortwave_tuning_parameter, &
+         R_snw_in                = config_snow_shortwave_tuning_parameter, &
+         dT_mlt_in               = config_temp_change_snow_grain_radius_change, &
+         rsnw_mlt_in             = config_max_melting_snow_grain_radius, &
+         kalg_in                 = config_algae_absorption_coefficient, &
+         kstrength_in            = config_ice_strength_formulation_int, &
+         krdg_partic_in          = config_ridging_participation_function_int, &
+         krdg_redist_in          = config_ridging_redistribution_function_int, &
+         mu_rdg_in               = config_ridiging_efolding_scale, &
+         atmbndy_in              = config_atmos_boundary_method, &
+         calc_strair_in          = config_calc_surface_stresses, &
+         formdrag_in             = config_use_form_drag, &
+         highfreq_in             = config_use_high_frequency_coupling, &
+         natmiter_in             = config_boundary_layer_iteration_number, &
+         !atmiter_conv_in         = , &
+         !calc_dragio_in          = , &
+         tfrz_option_in          = config_sea_freezing_temperature_type, &
+         kitd_in                 = config_itd_conversion_type_int, &
+         kcatbound_in            = config_category_bounds_type_int, &
+         hs0_in                  = config_snow_to_ice_transition_depth, &
+         frzpnd_in               = config_pond_refreezing_type, &
+         !floeshape_in            = , &
+         !wave_spec_in            = , &
+         !wave_spec_type_in       = , &
+         !nfreq_in                = , &
+         dpscale_in              = config_pond_flushing_timescale, &
+         rfracmin_in             = config_min_meltwater_retained_fraction, &
+         rfracmax_in             = config_max_meltwater_retained_fraction, &
+         pndaspect_in            = config_pond_depth_to_fraction_ratio, &
+         hs1_in                  = config_snow_on_pond_ice_tapering_parameter, &
+         hp1_in                  = config_critical_pond_ice_thickness, &
+         bgc_flux_type_in        = config_skeletal_bgc_flux_type, &
+         z_tracers_in            = config_use_vertical_tracers, &
+         scale_bgc_in            = config_scale_initial_vertical_bgc, &
+         solve_zbgc_in           = config_use_vertical_biochemistry, &
+         modal_aero_in           = config_use_modal_aerosols, &
+         skl_bgc_in              = config_use_skeletal_biochemistry, &
+         solve_zsal_in           = config_use_vertical_zsalinity, &
+         grid_o_in               = config_biogrid_bottom_molecular_sublayer, &
+         l_sk_in                 = config_bio_gravity_drainage_length_scale, &
+         initbio_frac_in         = config_new_ice_fraction_biotracer, &
+         grid_oS_in              = config_zsalinity_molecular_sublayer, &
+         l_skS_in                = config_zsalinity_gravity_drainage_scale, &
+         !dEdd_algae_in           = , &
+         phi_snow_in             = config_snow_porosity_at_ice_surface &
+         !T_max_in                = , &
+         !fsal_in                 = , &
+         !fr_resp_in              = , &
+         !algal_vel_in            = , &
+         !R_dFe2dust_in           = , &
+         !dustFe_sol_in           = , &
+         !op_dep_min_in           = , &
+         !fr_graze_s_in           = , &
+         !fr_graze_e_in           = , &
+         !fr_mort2min_in          = , &
+         !fr_dFe_in               = , &
+         !k_nitrif_in             = , &
+         !t_iron_conv_in          = , &
+         !max_loss_in             = , &
+         !max_dfe_doc1_in         = , &
+         !fr_resp_s_in            = , &
+         !conserv_check_in        = , &
+         !y_sk_DMS_in             = , &
+         !t_sk_conv_in            = , &
+         !t_sk_ox_in              = , &
+         !frazil_scav_in          = , &
+         !sw_redist_in            = , &
+         !sw_frac_in              = , &
+         !sw_dtemp_in             = , &
+         !snwgrain_in             = , &
+         !snwredist_in            = , &
+         !use_smliq_pnd_in        = , &
+         !rsnw_fall_in            = , &
+         !rsnw_tmax_in            = , &
+         !rhosnew_in              = , &
+         !rhosmin_in              = , &
+         !rhosmax_in              = , &
+         !windmin_in              = , &
+         !drhosdwind_in           = , &
+         !snwlvlfac_in            = , &
+         !isnw_T_in               = , &
+         !isnw_Tgrd_in            = , &
+         !isnw_rhos_in            = , &
+         !snowage_rhos_in         = , &
+         !snowage_Tgrd_in         = , &
+         !snowage_T_in            = , &
+         !snowage_tau_in          = , &
+         !snowage_kappa_in        = , &
+         !snowage_drdt0_in        = , &
+         !snw_aging_table_in      = , &
+         !snw_ssp_table_in        = , &
+         !ssp_snwextdr_in         = , &
+         !ssp_snwextdf_in         = , &
+         !ssp_snwalbdr_in         = , &
+         !ssp_snwalbdf_in         = , &
+         !ssp_sasymmdr_in         = , &
+         !ssp_sasymmdf_in         = , &
+         !ssp_aasymmmd_in         = , &
+         !ssp_aerextmd_in         = , &
+         !ssp_aeralbmd_in         = , &
+         !ssp_abcenhmd_in         = , &
+         !ssp_aasymm_in           = , &
+         !ssp_aerext_in           = , &
+         !ssp_aeralb_in           =
+         )
+
+
+
+    !call icepack_init_parameters(&
+    !     ktherm                = config_thermodynamics_type_int, &
+    !     conduct               = config_heat_conductivity_type, &
+    !     fbot_xfer_type        = config_ocean_heat_transfer_type, &
+    !     calc_Tsfc             = config_calc_surface_temperature, &
+    !     ustar_min             = config_min_friction_velocity, &
+    !     a_rapid_mode          = config_rapid_mode_channel_radius, &
+    !     Rac_rapid_mode        = config_rapid_model_critical_Ra, &
+    !     aspect_rapid_mode     = config_rapid_mode_aspect_ratio, &
+    !     dSdt_slow_mode        = config_slow_mode_drainage_strength, &
+    !     phi_c_slow_mode       = config_slow_mode_critical_porosity, &
+    !     phi_i_mushy           = config_congelation_ice_porosity, &
+    !     shortwave             = config_shortwave_type, &
+    !     use_snicar            = config_use_snicar_ad, &
+    !     albedo_type           = config_albedo_type, &
+    !     albicev               = config_visible_ice_albedo, &
+    !     albicei               = config_infrared_ice_albedo, &
+    !     albsnowv              = config_visible_snow_albedo, &
+    !     albsnowi              = config_infrared_snow_albedo, &
+    !     ahmax                 = config_variable_albedo_thickness_limit, &
+    !     R_ice                 = config_ice_shortwave_tuning_parameter, &
+    !     R_pnd                 = config_pond_shortwave_tuning_parameter, &
+    !     R_snw                 = config_snow_shortwave_tuning_parameter, &
+    !     dT_mlt                = config_temp_change_snow_grain_radius_change, &
+    !     rsnw_mlt              = config_max_melting_snow_grain_radius, &
+    !     kalg                  = config_algae_absorption_coefficient, &
+    !     kstrength             = config_ice_strength_formulation_int, &
+    !     krdg_partic           = config_ridging_participation_function_int, &
+    !     krdg_redist           = config_ridging_redistribution_function_int, &
+    !     mu_rdg                = config_ridiging_efolding_scale, &
+    !     Cf                    = config_ratio_ridging_work_to_PE, &
+    !     atmbndy               = config_atmos_boundary_method, &
+    !     calc_strair           = config_calc_surface_stresses, &
+    !     formdrag              = config_use_form_drag, &
+    !     highfreq              = config_use_high_frequency_coupling, &
+    !     natmiter              = config_boundary_layer_iteration_number, &
+    !     oceanmixed_ice        = config_use_ocean_mixed_layer, &
+    !     tfrz_option           = config_sea_freezing_temperature_type, &!
+    !     kitd                  = config_itd_conversion_type_int, &
+    !     kcatbound             = config_category_bounds_type_int, &
+    !     hs0                   = config_snow_to_ice_transition_depth, &
+    !     frzpnd                = config_pond_refreezing_type, &
+    !     dpscale               = config_pond_flushing_timescale, &
+    !     rfracmin              = config_min_meltwater_retained_fraction, &
+    !     rfracmax              = config_max_meltwater_retained_fraction, &
+    !     pndaspect             = config_pond_depth_to_fraction_ratio, &
+    !     hs1                   = config_snow_on_pond_ice_tapering_parameter, &
+    !     hp1                   = config_critical_pond_ice_thickness, &
+    !     bgc_flux_type         = config_skeletal_bgc_flux_type, &
+    !     z_tracers             = config_use_vertical_tracers, &
+    !     scale_bgc             = config_scale_initial_vertical_bgc, &
+    !     solve_zbgc            = config_use_vertical_biochemistry, &
+    !     dEdd_algae            = config_use_shortwave_bioabsorption, &
+    !     modal_aero            = config_use_modal_aerosols, &!
+    !     skl_bgc               = config_use_skeletal_biochemistry, &
+    !     solve_zsal            = config_use_vertical_zsalinity, &
+    !     grid_o                = config_biogrid_bottom_molecular_sublayer, &
+    !     l_sk                  = config_bio_gravity_drainage_length_scale, &
+    !     grid_o_t              = config_biogrid_top_molecular_sublayer, &
+    !     initbio_frac          = config_new_ice_fraction_biotracer, &
+    !     frazil_scav           = config_fraction_biotracer_in_frazil, &
+    !     grid_oS               = config_zsalinity_molecular_sublayer, &!
+    !     l_skS                 = config_zsalinity_gravity_drainage_scale, &!
+    !     phi_snow              = config_snow_porosity_at_ice_surface, &!
+    !     ratio_Si2N_diatoms    = config_ratio_Si_to_N_diatoms, &
+    !     ratio_Si2N_sp         = config_ratio_Si_to_N_small_plankton, &
+    !     ratio_Si2N_phaeo      = config_ratio_Si_to_N_phaeocystis, &
+    !     ratio_S2N_diatoms     = config_ratio_S_to_N_diatoms, &
+    !     ratio_S2N_sp          = config_ratio_S_to_N_small_plankton, &
+    !     ratio_S2N_phaeo       = config_ratio_S_to_N_phaeocystis, &
+    !     ratio_Fe2C_diatoms    = config_ratio_Fe_to_C_diatoms, &
+    !     ratio_Fe2C_sp         = config_ratio_Fe_to_C_small_plankton, &
+    !     ratio_Fe2C_phaeo      = config_ratio_Fe_to_C_phaeocystis, &
+    !     ratio_Fe2N_diatoms    = config_ratio_Fe_to_N_diatoms, &
+    !     ratio_Fe2N_sp         = config_ratio_Fe_to_N_small_plankton, &
+    !     ratio_Fe2N_phaeo      = config_ratio_Fe_to_N_phaeocystis, &
+    !     ratio_Fe2DON          = config_ratio_Fe_to_DON, &
+    !     ratio_Fe2DOC_s        = config_ratio_Fe_to_DOC_saccharids, &
+    !     ratio_Fe2DOC_l        = config_ratio_Fe_to_DOC_lipids, &
+    !     fr_resp               = config_respiration_fraction_of_growth, &
+    !     tau_min               = config_rapid_mobile_to_stationary_time, &
+    !     tau_max               = config_long_mobile_to_stationary_time, &
+    !     algal_vel             = config_algal_maximum_velocity, &
+    !     R_dFe2dust            = config_ratio_Fe_to_dust, &
+    !     dustFe_sol            = config_solubility_of_Fe_in_dust, &
+    !     chlabs_diatoms        = config_chla_absorptivity_of_diatoms, &
+    !     chlabs_sp             = config_chla_absorptivity_of_small_plankton, &
+    !     chlabs_phaeo          = config_chla_absorptivity_of_phaeocystis, &
+    !     alpha2max_low_diatoms = config_light_attenuation_diatoms, &
+    !     alpha2max_low_sp      = config_light_attenuation_small_plankton, &
+    !     alpha2max_low_phaeo   = config_light_attenuation_phaeocystis, &
+    !     beta2max_diatoms      = config_light_inhibition_diatoms, &
+    !     beta2max_sp           = config_light_inhibition_small_plankton, &
+    !     beta2max_phaeo        = config_light_inhibition_phaeocystis, &
+    !     mu_max_diatoms        = config_maximum_growth_rate_diatoms, &
+    !     mu_max_sp             = config_maximum_growth_rate_small_plankton, &
+    !     mu_max_phaeo          = config_maximum_growth_rate_phaeocystis, &
+    !     mu_max_diatoms        = config_temperature_growth_diatoms, & ! rename
+    !     mu_max_sp             = config_temperature_growth_small_plankton, &
+    !     mu_max_phaeo          = config_temperature_growth_phaeocystis, &
+    !     fr_graze_diatoms      = config_grazed_fraction_diatoms, &
+    !     fr_graze_sp           = config_grazed_fraction_small_plankton, &
+    !     fr_graze_phaeo        = config_grazed_fraction_phaeocystis, &
+    !     mort_pre_diatoms      = config_mortality_diatoms, &
+    !     mort_pre_sp           = config_mortality_small_plankton, &
+    !     mort_pre_phaeo        = config_mortality_phaeocystis, &
+    !     mort_Tdep_diatoms     = config_temperature_mortality_diatoms, &
+    !     mort_Tdep_sp          = config_temperature_mortality_small_plankton, &
+    !     mort_Tdep_phaeo       = config_temperature_mortality_phaeocystis, &
+    !     k_exude_diatoms       = config_exudation_diatoms, &
+    !     k_exude_sp            = config_exudation_small_plankton, &
+    !     k_exude_phaeo         = config_exudation_phaeocystis, &
+    !     K_Nit_diatoms         = config_nitrate_saturation_diatoms, &
+    !     K_Nit_sp              = config_nitrate_saturation_small_plankton, &
+    !     K_Nit_phaeo           = config_nitrate_saturation_phaeocystis, &
+    !     K_Am_diatoms          = config_ammonium_saturation_diatoms, &
+    !     K_Am_sp               = config_ammonium_saturation_small_plankton, &
+    !     K_Am_phaeo            = config_ammonium_saturation_phaeocystis, &
+    !     K_Sil_diatoms         = config_silicate_saturation_diatoms, &
+    !     K_Sil_sp              = config_silicate_saturation_small_plankton, &
+    !     K_Sil_phaeo           = config_silicate_saturation_phaeocystis, &
+    !     K_Fe_diatoms          = config_iron_saturation_diatoms, &
+    !     K_Fe_sp               = config_iron_saturation_small_plankton, &
+    !     K_Fe_phaeo            = config_iron_saturation_phaeocystis, &
+    !     f_don_protein         = config_fraction_spilled_to_DON, &
+    !     kn_bac_protein        = config_degredation_of_DON, &
+    !     f_don_Am_protein      = config_fraction_DON_ammonium, &
+    !     f_doc_s               = config_fraction_loss_to_saccharids, &
+    !     f_doc_l               = config_fraction_loss_to_lipids, &
+    !     f_exude_s             = config_fraction_exudation_to_saccharids, &
+    !     f_exude_l             = config_fraction_exudation_to_lipids, &
+    !     k_bac_s               = config_remineralization_saccharids, &
+    !     k_bac_l               = config_remineralization_lipids, &
+    !     T_max                 = config_maximum_brine_temperature, &
+    !     fsal                  = config_salinity_dependence_of_growth, &
+    !     op_dep_min            = config_minimum_optical_depth, &
+    !     fr_graze_s            = config_slopped_grazing_fraction, &
+    !     fr_graze_e            = config_excreted_fraction, &
+    !     fr_mort2min           = config_fraction_mortality_to_ammonium, &
+    !     fr_dFe                = config_fraction_iron_remineralized, &
+    !     k_nitrif              = config_nitrification_rate, &
+    !     t_iron_conv           = config_desorption_loss_particulate_iron, &
+    !     max_loss              = config_maximum_loss_fraction, &
+    !     max_dfe_doc1          = config_maximum_ratio_iron_to_saccharids, &
+    !     fr_resp_s             = config_respiration_loss_to_DMSPd, &
+    !     y_sk_DMS              = config_DMSP_to_DMS_conversion_fraction, &
+    !     t_sk_conv             = config_DMSP_to_DMS_conversion_time, &
+    !     t_sk_ox               = config_DMS_oxidation_time, &
+    !     algaltype_diatoms     = config_mobility_type_diatoms, &
+    !     algaltype_sp          = config_mobility_type_small_plankton, &
+    !     algaltype_phaeo       = config_mobility_type_phaeocystis, &
+    !     nitratetype           = config_mobility_type_nitrate, &
+    !     ammoniumtype          = config_mobility_type_ammonium, &
+    !     silicatetype          = config_mobility_type_silicate, &
+    !     dmspptype             = config_mobility_type_DMSPp, &
+    !     dmspdtype             = config_mobility_type_DMSPd, &
+    !     humicstype            = config_mobility_type_humics, &
+    !     doctype_s             = config_mobility_type_saccharids, &
+    !     dictype_1             = config_mobility_type_lipids, &
+    !     dictype_1             = config_mobility_type_inorganic_carbon, &
+    !     dontype_protein       = config_mobility_type_proteins, &
+    !     fedtype_1             = config_mobility_type_dissolved_iron, &
+    !     feptype_1             = config_mobility_type_particulate_iron, &
+    !     zaerotype_bc1         = config_mobility_type_black_carbon1, &
+    !     zaerotype_bc2         = config_mobility_type_black_carbon2, &
+    !     zaerotype_dust1       = config_mobility_type_dust1, &
+    !     zaerotype_dust2       = config_mobility_type_dust2, &
+    !     zaerotype_dust3       = config_mobility_type_dust3, &
+    !     zaerotype_dust4       = config_mobility_type_dust4, &
+    !     ratio_C2N_diatoms     = config_ratio_C_to_N_diatoms, &
+    !     ratio_C2N_sp          = config_ratio_C_to_N_small_plankton, &
+    !     ratio_C2N_phaeo       = config_ratio_C_to_N_phaeocystis, &
+    !     ratio_chl2N_diatoms   = config_ratio_chla_to_N_diatoms, &
+    !     ratio_chl2N_sp        = config_ratio_chla_to_N_small_plankton, &
+    !     ratio_chl2N_phaeo     = config_ratio_chla_to_N_phaeocystis, &
+    !     F_abs_chl_diatoms     = config_scales_absorption_diatoms, &
+    !     F_abs_chl_sp          = config_scales_absorption_small_plankton, &
+    !     F_abs_chl_phaeo       = config_scales_absorption_phaeocystis, &
+    !     ratio_C2N_proteins    = config_ratio_C_to_N_proteins, &
+    !     snwredist             = config_snow_redistribution_scheme, &
+    !     use_smliq_pnd         = config_use_snow_liquid_ponds, &
+    !     rsnw_fall             = config_fallen_snow_radius, &
+    !     rsnw_tmax             = config_max_dry_snow_radius, &
+    !     rhosnew               = config_new_snow_density, &
+    !     rhosmax               = config_max_snow_density, &
+    !     windmin               = config_minimum_wind_compaction, &
+    !     drhosdwind            = config_wind_compaction_factor)
+
+    !-----------------------------------------------------------------------
+    ! Parameters for thermodynamics
+    !-----------------------------------------------------------------------
+
+    ! ktherm:
+    ! type of thermodynamics
+    ! 0 = 0-layer approximation
+    ! 1 = Bitz and Lipscomb 1999
+    ! 2 = mushy layer theory
+    !ktherm = config_cice_int("config_thermodynamics_type", config_thermodynamics_type)
+
+    ! conduct:
+    ! 'MU71' or 'bubbly'
+    !conduct = config_heat_conductivity_type
+
+    ! fbot_xfer_type:
+    ! transfer coefficient type for ice-ocean heat flux
+    !fbot_xfer_type = config_ocean_heat_transfer_type
+
+    ! calc_Tsfc:
+    ! if true, calculate surface temperature
+    ! if false, Tsfc is computed elsewhere and
+    ! atmos-ice fluxes are provided to CICE
+    !calc_Tsfc = config_calc_surface_temperature
+
+    ! ustar_min:
+    ! minimum friction velocity for ice-ocean heat flux
+    !ustar_min = config_min_friction_velocity
+
+    ! mushy thermodynamics:
+
+    ! a_rapid_mode:
+    ! channel radius for rapid drainage mode (m)
+    !a_rapid_mode = config_rapid_mode_channel_radius
+
+    ! Rac_rapid_mode:
+    ! critical rayleigh number for rapid drainage mode
+    !Rac_rapid_mode = config_rapid_model_critical_Ra
+
+    ! aspect_rapid_mode:
+    ! aspect ratio for rapid drainage mode (larger=wider)
+    !aspect_rapid_mode = config_rapid_mode_aspect_ratio
+
+    ! dSdt_slow_mode:
+    ! slow mode drainage strength (m s-1 K-1)
+    !dSdt_slow_mode = config_slow_mode_drainage_strength
+
+    ! phi_c_slow_mode:
+    ! liquid fraction porosity cutoff for slow mode
+    !phi_c_slow_mode = config_slow_mode_critical_porosity
+
+    ! phi_i_mushy:
+    ! liquid fraction of congelation ice
+    !phi_i_mushy = config_congelation_ice_porosity
+
+    !-----------------------------------------------------------------------
+    ! Parameters for radiation
+    !-----------------------------------------------------------------------
+
+    ! shortwave:
+    ! shortwave method, 'default' ('ccsm3') or 'dEdd'
+    !shortwave = config_shortwave_type
+
+    ! albedo_type:
+    ! albedo parameterization, 'default' ('ccsm3') or 'constant'
+    ! shortwave='dEdd' overrides this parameter
+    !albedo_type = config_albedo_type
+
+    ! baseline albedos for ccsm3 shortwave, set in namelist
+
+    ! albicev:
+    ! visible ice albedo for h > ahmax
+    !albicev = config_visible_ice_albedo
+
+    ! albicei:
+    ! near-ir ice albedo for h > ahmax
+    !albicei = config_infrared_ice_albedo
+
+    ! albsnowv:
+    ! cold snow albedo, visible
+    !albsnowv = config_visible_snow_albedo
+
+    ! albsnowi:
+    ! cold snow albedo, near IR
+    !albsnowi = config_infrared_snow_albedo
+
+    ! ahmax:
+    ! thickness above which ice albedo is constant (m)
+    !ahmax = config_variable_albedo_thickness_limit
+
+    ! dEdd tuning parameters, set in namelist
+
+    ! R_ice:
+    ! sea ice tuning parameter; +1 > 1sig increase in albedo
+    !R_ice = config_ice_shortwave_tuning_parameter
+
+    ! R_pnd:
+    ! ponded ice tuning parameter; +1 > 1sig increase in albedo
+    !R_pnd = config_pond_shortwave_tuning_parameter
+
+    ! R_snw:
+    ! snow tuning parameter; +1 > ~.01 change in broadband albedo
+    !R_snw = config_snow_shortwave_tuning_parameter
+
+    ! dT_mlt:
+    ! change in temp for non-melt to melt snow grain radius change (C)
+    !dT_mlt = config_temp_change_snow_grain_radius_change
+
+    ! rsnw_mlt:
+    ! maximum melting snow grain radius (10^-6 m)
+    !rsnw_mlt = config_max_melting_snow_grain_radius
+
+    ! kalg:
+    ! algae absorption coefficient for 0.5 m thick layer
+    !kalg = config_algae_absorption_coefficient
+
+    !-----------------------------------------------------------------------
+    ! Parameters for ridging and strength
+    !-----------------------------------------------------------------------
+
+    ! kstrength:
+    ! 0 for simple Hibler (1979) formulation
+    ! 1 for Rothrock (1975) pressure formulation
+    !kstrength = config_cice_int("config_ice_strength_formulation", config_ice_strength_formulation)
+
+    ! krdg_partic:
+    ! 0 for Thorndike et al. (1975) formulation
+    ! 1 for exponential participation function
+    !krdg_partic = config_cice_int("config_ridging_participation_function", config_ridging_participation_function)
+
+    ! krdg_redist:
+    ! 0 for Hibler (1980) formulation
+    ! 1 for exponential redistribution function
+    !krdg_redist = config_cice_int("config_ridging_redistribution_function", config_ridging_redistribution_function)
+
+    ! mu_rdg:
+    ! gives e-folding scale of ridged ice (m^.5)
+    ! (krdg_redist = 1)
+    !mu_rdg = config_ridiging_efolding_scale
+
+    ! Cf
+    ! ratio of ridging work to PE change in ridging (kstrength = 1)
+    !Cf = config_ratio_ridging_work_to_PE
+
+    !-----------------------------------------------------------------------
+    ! Parameters for atmosphere
+    !-----------------------------------------------------------------------
+
+    ! atmbndy:
+    ! atmo boundary method, 'default' ('ccsm3') or 'constant'
+    !atmbndy = config_atmos_boundary_method
+
+    ! calc_strair:
+    ! if true, calculate wind stress components
+    !calc_strair = config_calc_surface_stresses
+
+    ! formdrag:
+    ! if true, calculate form drag
+    !formdrag = config_use_form_drag
+
+    ! highfreq:
+    ! if true, use high frequency coupling
+    !highfreq = config_use_high_frequency_coupling
+
+    ! natmiter:
+    ! number of iterations for boundary layer calculations
+    !natmiter = config_boundary_layer_iteration_number
+
+    !-----------------------------------------------------------------------
+    ! Parameters for ocean
+    !-----------------------------------------------------------------------
+
+    ! oceanmixed_ice:
+    ! if true, use ocean mixed layer
+    !oceanmixed_ice = config_use_ocean_mixed_layer
+
+    ! fbot_xfer_type:
+    ! transfer coefficient type for ice-ocean heat flux
+    !fbot_xfer_type = config_ocean_heat_transfer_type
+
+    ! tfrz_option:
+    ! form of ocean freezing temperature
+    ! 'minus1p8' = -1.8 C
+    ! 'linear_salt' = -depressT * sss
+    ! 'mushy' conforms with ktherm=2
+    !tfrz_option = config_sea_freezing_temperature_type
+
+    !-----------------------------------------------------------------------
+    ! Parameters for the ice thickness distribution
+    !-----------------------------------------------------------------------
+
+    ! kitd:
+    ! type of itd conversions
+    !   0 = delta function
+    !   1 = linear remap
+    !kitd = config_cice_int("config_itd_conversion_type", config_itd_conversion_type)
+
+    ! kcatbound:
+    !   0 = old category boundary formula
+    !   1 = new formula giving round numbers
+    !   2 = WMO standard
+    !   3 = asymptotic formula
+    !kcatbound = config_cice_int("config_category_bounds_type", config_category_bounds_type)
+
+    !-----------------------------------------------------------------------
+    ! Parameters for melt ponds
+    !-----------------------------------------------------------------------
+
+    ! hs0:
+    ! snow depth for transition to bare sea ice (m)
+    !hs0 = config_snow_to_ice_transition_depth
+
+    ! level-ice ponds
+
+    ! frzpnd:
+    ! pond refreezing parameterization
+    !frzpnd = config_pond_refreezing_type
+
+    ! dpscale:
+    ! alter e-folding time scale for flushing
+    !dpscale = config_pond_flushing_timescale
+
+    ! rfracmin:
+    ! minimum retained fraction of meltwater
+    !rfracmin = config_min_meltwater_retained_fraction
+
+    ! rfracmax:
+    ! maximum retained fraction of meltwater
+    !rfracmax = config_max_meltwater_retained_fraction
+
+    ! pndaspect:
+    ! ratio of pond depth to pond fraction
+    !pndaspect = config_pond_depth_to_fraction_ratio
+
+    ! hs1:
+    ! tapering parameter for snow on pond ice
+    !hs1 = config_snow_on_pond_ice_tapering_parameter
+
+    ! topo ponds
+
+    ! hp1
+    ! critical parameter for pond ice thickness
+    !hp1 = config_critical_pond_ice_thickness
+
+    !-----------------------------------------------------------------------
+    ! Parameters for biogeochemistry
+    !-----------------------------------------------------------------------
+
+    ! bgc_flux_type:
+    ! bgc_flux_type = config_skeletal_bgc_flux_type
+
+    ! z_tracers:
+    ! if .true., bgc or aerosol tracers are vertically resolved
+    !z_tracers = config_use_vertical_tracers
+
+    ! scale_bgc:
+    ! if .true., initialize bgc tracers proportionally with salinity
+    !scale_bgc = config_scale_initial_vertical_bgc
+
+    ! solve_zbgc:
+    ! if .true., solve vertical biochemistry portion of code
+    !solve_zbgc = config_use_vertical_biochemistry
+
+    ! dEdd_algae:
+    ! if .true., algal absorption of Shortwave is computed in the
+    !dEdd_algae = config_use_shortwave_bioabsorption
+
+    ! skl_bgc:
+    ! if true, solve skeletal biochemistry
+    !skl_bgc = config_use_skeletal_biochemistry
+
+    ! solve_zsal:
+    ! if true, update salinity profile from solve_S_dt
+    !solve_zsal = config_use_vertical_zsalinity
+
+    ! modal_aero:
+    ! if true, use modal aerosal optical properties
+    ! only for use with tr_aero or tr_zaero
+    !modal_aero = config_use_shortwave_bioabsorption
+
+    ! grid_o:
+    ! for bottom flux
+    !grid_o = config_biogrid_bottom_molecular_sublayer
+
+    ! l_sk:
+    ! characteristic diffusive scale (zsalinity) (m)
+    !l_sk =config_bio_gravity_drainage_length_scale
+
+    ! grid_o_t:
+    ! top grid point length scale
+    !grid_o_t = config_biogrid_top_molecular_sublayer
+
+    ! phi_snow:
+    ! porosity of snow
+    !phi_snow = config_snow_porosity_at_ice_surface
+
+    ! initbio_frac:
+    ! fraction of ocean tracer concentration used to initialize tracer
+    !initbio_frac = config_new_ice_fraction_biotracer
+
+    ! frazil_scav:
+    ! multiple of ocean tracer concentration due to frazil scavenging
+    !frazil_scav = config_fraction_biotracer_in_frazil
+
+    ! ratio_Si2N_diatoms:
+    ! ratio of algal Silicate to Nitrate (mol/mol)
+    ! ratio_Si2N_diatoms = config_ratio_Si_to_N_diatoms
+
+    ! ratio_Si2N_sp:
+    ! ratio of algal Silicate to Nitrogen (mol/mol)
+    ! ratio_Si2N_sp = config_ratio_Si_to_N_small_plankton
+
+    ! ratio_Si2N_phaeo:
+    ! ratio of algal Silicate to Nitrogen (mol/mol)
+    ! ratio_Si2N_phaeo = config_ratio_Si_to_N_phaeocystis
+
+    ! ratio_S2N_diatoms:
+    ! ratio of algal Sulphur to Nitrogen (mol/mol)
+    ! ratio_S2N_diatoms = config_ratio_S_to_N_diatoms
+
+    ! ratio_S2N_sp:
+    ! ratio of algal Sulphur to Nitrogen (mol/mol)
+    ! ratio_S2N_sp = config_ratio_S_to_N_small_plankton
+
+    ! ratio_S2N_phaeo:
+    ! ratio of algal Sulphur to Nitrogen (mol/mol)
+    ! ratio_S2N_phaeo = config_ratio_S_to_N_phaeocystis
+
+    ! ratio_Fe2C_diatoms:
+    ! ratio of algal iron to carbon (umol/mol)
+    ! ratio_Fe2C_diatoms = config_ratio_Fe_to_C_diatoms
+
+    ! ratio_Fe2C_sp:
+    ! ratio of algal iron to carbon (umol/mol)
+    ! ratio_Fe2C_sp = config_ratio_Fe_to_C_small_plankton
+
+    ! ratio_Fe2C_phaeo:
+    ! ratio of algal iron to carbon (umol/mol)
+    ! ratio_Fe2C_phaeo = config_ratio_Fe_to_C_phaeocystis
+
+    ! ratio_Fe2N_diatoms:
+    ! ratio of algal iron to nitrogen (umol/mol)
+    ! ratio_Fe2N_diatoms = config_ratio_Fe_to_N_diatoms
+
+    ! ratio_Fe2N_sp:
+    ! ratio of algal iron to nitrogen (umol/mol)
+    ! ratio_Fe2N_sp = config_ratio_Fe_to_N_small_plankton
+
+    ! ratio_Fe2N_phaeo:
+    ! ratio of algal iron to nitrogen (umol/mol)
+    ! ratio_Fe2N_phaeo = config_ratio_Fe_to_N_phaeocystis
+
+    ! ratio_Fe2DON:
+    ! ratio of iron to nitrogen of DON (nmol/umol)
+    ! ratio_Fe2DON = config_ratio_Fe_to_DON
+
+    ! ratio_Fe2DOC_s:
+    ! ratio of iron to carbon of DOC (nmol/umol) saccharids
+    ! ratio_Fe2DOC_s = config_ratio_Fe_to_DOC_saccharids
+
+    ! ratio_Fe2DOC_l:
+    ! ratio of iron to carbon of DOC (nmol/umol) lipids
+    ! ratio_Fe2DOC_l = config_ratio_Fe_to_DOC_lipids
+
+    ! fr_resp:
+    ! fraction of algal growth lost due to respiration
+    ! fr_resp = config_respiration_fraction_of_growth
+
+    ! tau_min:
+    ! rapid mobile to stationary exchanges (s) = 1.5 hours
+    ! tau_min = config_rapid_mobile_to_stationary_time
+
+    ! tau_max:
+    ! long time mobile to stationary exchanges (s) = 2 days
+    ! tau_max = config_long_mobile_to_stationary_time
+
+    ! algal_vel:
+    ! 0.5 cm/d(m/s) Lavoie 2005  1.5 cm/day
+    ! algal_vel = config_algal_maximum_velocity
+
+    ! R_dFe2dust:
+    !  g/g (3.5% content) Tagliabue 2009
+    ! R_dFe2dust = config_ratio_Fe_to_dust
+
+    ! dustFe_sol;
+    ! solubility fraction
+    ! dustFe_sol = config_solubility_of_Fe_in_dust
+
+    ! chlabs_diatoms:
+    ! chl absorption (1/m/(mg/m^3))
+    ! chlabs_diatoms = config_chla_absorptivity_of_diatoms
+
+    ! chlabs_sp:
+    ! chl absorption (1/m/(mg/m^3))
+    ! chlabs_sp = config_chla_absorptivity_of_small_plankton
+
+    ! chlabs_phaeo:
+    ! chl absorption (1/m/(mg/m^3))
+    ! chlabs_phaeo = config_chla_absorptivity_of_phaeocystis
+
+    ! alpha2max_low_diatoms:
+    ! light limitation diatoms (1/(W/m^2))
+    ! alpha2max_low_diatoms = config_light_attenuation_diatoms
+
+    ! alpha2max_low_sp:
+    ! light limitation small plankton (1/(W/m^2))
+    ! alpha2max_low_sp = config_light_attenuation_small_plankton
+
+    ! alpha2max_low_phaeo:
+    ! light limitation phaeocystis (1/(W/m^2))
+    ! alpha2max_low_phaeo = config_light_attenuation_phaeocystis
+
+    ! beta2max_diatoms:
+    ! light inhibition diatoms(1/(W/m^2))
+    ! beta2max_diatoms = config_light_inhibition_diatoms
+
+    ! beta2max_sp:
+    ! light inhibition small plankton(1/(W/m^2))
+    ! beta2max_sp = config_light_inhibition_small_plankton
+
+    ! beta2max_phaeo:
+    ! light inhibition phaeocystis (1/(W/m^2))
+    ! beta2max_phaeo = config_light_inhibition_phaeocystis
+
+    ! mu_max_diatoms:
+    ! maximum growth rate diatoms (1/day)
+    ! mu_max_diatoms = config_maximum_growth_rate_diatoms
+
+    ! mu_max_sp:
+    ! maximum growth rate small plankton (1/day)
+    ! mu_max_sp = config_maximum_growth_rate_small plankton
+
+    ! mu_max_phaeo:
+    ! maximum growth rate phaeocystis (1/day)
+    ! mu_max_phaeo = config_maximum_growth_rate_phaeocystis
+
+    ! grow_Tdep_sp:
+    ! Temperature dependence of growth small plankton (1/C)
+    ! grow_Tdep_sp = config_temperature_growth_small_plankton
+
+    ! grow_Tdep_phaeo:
+    ! Temperature dependence of growth phaeocystis (1/C)
+    ! grow_Tdep_phaeo = config_temperature_growth_phaeocystis
+
+    ! fr_graze_diatoms:
+    ! Fraction grazed diatoms
+    ! fr_graze_diatoms = config_grazed_fraction_diatoms
+
+    ! fr_graze_sp:
+    ! Fraction grazed small_plankton
+    ! fr_graze_sp = config_grazed_fraction_small_plankton
+
+    ! fr_graze_phaeo:
+    ! Fraction grazed phaeocystis
+    ! fr_graze_phaeo = config_grazed_fraction_phaeocystis
+
+    ! mort_pre_diatoms:
+    ! Mortality diatoms (1/day)
+    ! mort_pre_diatoms = config_mortality_diatoms
+
+    ! mort_pre_sp:
+    ! Mortality small_plankton (1/day)
+    ! mort_pre_sp = config_mortality_small_plankton
+
+    ! mort_pre_phaeo:
+    ! Mortality phaeocystis (1/day)
+    ! mort_pre_phaeo = config_mortality_phaeocystis
+
+    ! mort_Tdep_diatoms:
+    ! T dependence of mortality diatoms (1/C)
+    ! mort_Tdep_diatoms = config_temperature_mortality_diatoms
+
+    ! mort_Tdep_sp:
+    ! T dependence of mortality small plankton (1/C)
+    ! mort_Tdep_sp = config_temperature_mortality_small_plankton
+
+    ! mort_Tdep_phaeo:
+    ! T dependence of mortality phaeocystis (1/C)
+    ! mort_Tdep_phaeo = config_temperature_mortality_phaeocystis
+
+    ! k_exude_diatoms:
+    ! algal exudation diatoms (1/d)
+    ! k_exude_diatoms = config_exudation_diatoms
+
+    ! k_exude_sp:
+    ! algal exudation small_plankton (1/d)
+    ! k_exude_sp = config_exudation_small_plankton
+
+    ! k_exude_phaeo:
+    ! algal exudation phaeocystis (1/d)
+    ! k_exude_phaeo = config_exudation_phaeocystis
+
+    ! K_Nit_diatoms:
+    ! nitrate half saturation diatoms (mmol/m^3)
+    ! K_Nit_diatoms = config_nitrate_saturation_diatoms
+
+    ! K_Nit_sp:
+    ! nitrate half saturation small_plankton (mmol/m^3)
+    ! K_Nit_sp = config_nitrate_saturation_small_plankton
+
+    ! K_Nit_phaeo:
+    ! nitrate half saturation phaeocystis (mmol/m^3)
+    ! K_Nit_phaeocystis = config_nitrate_saturation_phaeocystis
+
+    ! K_Am_diatoms:
+    ! ammonium half saturation diatoms (mmol/m^3)
+    ! K_Am_diatoms = config_ammonium_saturation_diatoms
+
+    ! K_Am_sp:
+    ! ammonium half saturation small_plankton (mmol/m^3)
+    ! K_Am_sp = config_ammonium_saturation_small_plankton
+
+    ! K_Am_phaeo:
+    ! ammonium half saturation phaeocystis (mmol/m^3)
+    ! K_Am_phaeocystis = config_ammonium_saturation_phaeocystis
+
+    ! K_Sil_diatoms:
+    ! silicate half saturation diatoms (mmol/m^3)
+    ! K_Sil_diatoms = config_silicate_saturation_diatoms
+
+    ! K_Sil_sp:
+    ! silicate half saturation small_plankton (mmol/m^3)
+    ! K_Sil_sp = config_silicate_saturation_small_plankton
+
+    ! K_Sil_phaeo:
+    ! silicate half saturation phaeocystis (mmol/m^3)
+    ! K_Sil_phaeocystis = config_silicate_saturation_phaeocystis
+
+    ! K_Fe_diatoms:
+    ! iron half saturation diatoms (nM)
+    ! K_Fe_diatoms = config_iron_saturation_diatoms
+
+    ! K_Fe_sp:
+    ! iron half saturation small_plankton (nM)
+    ! K_Fe_sp = config_iron_saturation_small_plankton
+
+    ! K_Fe_phaeo:
+    ! iron half saturation phaeocystis (nM)
+    ! K_Fe_phaeocystis = config_iron_saturation_phaeocystis
+
+    ! f_don_protein:
+    ! fraction of spilled grazing to proteins    !
+    ! f_don_protein = config_fraction_spilled_to_DON
+
+    ! kn_bac_protein:
+    ! Bacterial degredation of DON (1/d)    !     !
+    ! kn_bac_protein = config_degredation_of_DON
+
+    ! f_don_Am_protein:
+    ! fraction of remineralized DON to ammonium    !
+    ! f_don_Am_protein = config_fraction_DON_ammonium
+
+    ! f_doc_s:
+    ! fraction of mortality to DOC saccharids
+    ! f_doc_s = config_fraction_loss_to_saccharids
+
+    ! f_doc_l:
+    ! fraction of mortality to DOC lipids
+    ! f_doc_l = config_fraction_loss_to_lipids
+
+    ! f_exude_s:
+    ! fraction of exudation to DOC saccharids
+    ! f_exude_s = config_fraction_exudation_to_saccharids
+
+    ! f_exude_l:
+    ! fraction of exudation to DOC lipids
+    ! f_exude_l = config_fraction_exudation_to_lipids
+
+    ! k_bac_s:
+    ! Bacterial degredation of DOC (1/d) saccharids
+    ! k_bac_s = config_remineralization_saccharids
+
+    ! k_bac_l:
+    ! Bacterial degredation of DOC (1/d) lipids
+    ! k_bac_l = config_remineralization_lipids
+
+    ! T_max:
+    ! maximum temperature (C)
+    ! T_max = config_maximum_brine_temperature
+
+    ! fsal:
+    ! Salinity limitation (ppt)
+    ! fsal = config_salinity_dependence_of_growth
+
+    ! op_dep_min:
+    ! Light attenuates for optical depths exceeding min
+    ! op_dep_min = config_minimum_optical_depth
+
+    ! fr_graze_s:
+    ! fraction of grazing spilled or slopped
+    ! fr_graze_s = config_slopped_grazing_fraction
+
+    ! fr_graze_e:
+    ! fraction of assimilation excreted
+    ! fr_graze_e = config_excreted_fraction
+
+    ! fr_mort2min:
+    ! fractionation of mortality to Am
+    ! fr_mort2min = config_fraction_mortality_to_ammonium
+
+    ! fr_dFe:
+    ! remineralized nitrogen (in units of algal iron)
+    ! fr_dFe = config_fraction_iron_remineralized
+
+    ! k_nitrif:
+    ! nitrification rate (1/day)
+    ! k_nitrif = config_nitrification_rate
+
+    ! t_iron_conv:
+    ! desorption loss pFe to dFe (day)
+    ! t_iron_conv = config_desorption_loss_particulate_iron
+
+    ! max_loss:
+    ! restrict uptake to % of remaining value
+    ! max_loss = config_maximum_loss_fraction
+
+    ! max_dfe_doc1:
+    ! max ratio of dFe to saccharides in the ice  (nM Fe/muM C)
+    ! max_dfe_doc1 = config_maximum_ratio_iron_to_saccharids
+
+    ! fr_resp_s:
+    ! DMSPd fraction of respiration loss as DMSPd
+    ! fr_resp_s = config_respiration_loss_to_DMSPd
+
+    ! y_sk_DMS:
+    ! fraction conversion given high yield
+    ! y_sk_DMS = config_DMSP_to_DMS_conversion_fraction
+
+    ! t_sk_conv:
+    ! Stefels conversion time (d)
+    ! t_sk_conv = config_DMSP_to_DMS_conversion_time
+
+    ! t_sk_ox:
+    ! DMS oxidation time (d)
+    ! t_sk_ox = config_DMS_oxidation_time
+
+    ! algaltype_diatoms:
+    ! mobility type diatoms
+    ! algaltype_diatoms = config_mobility_type_diatoms
+
+    ! algaltype_sp:
+    ! mobility type small_plankton
+    ! algaltype_sp = config_mobility_type_small_plankton
+
+    ! algaltype_phaeo:
+    ! mobility type phaeocystis
+    ! algaltype_phaeo = config_mobility_type_phaeocystis
+
+    ! nitratetype:
+    ! mobility type nitrate
+    ! nitratetype = config_mobility_type_nitrate
+
+    ! ammoniumtype:
+    ! mobility type ammonium
+    ! ammoniumtype = config_mobility_type_ammonium
+
+    ! silicatetype:
+    ! mobility type silicate
+    ! silicatetype = config_mobility_type_silicate
+
+    ! dmspptype:
+    ! mobility type DMSPp
+    ! dmspptype = config_mobility_type_DMSPp
+
+    ! dmspdtype:
+    ! mobility type DMSPd
+    ! dmspdtype = config_mobility_type_DMSPd
+
+    ! humicstype:
+    ! mobility type humics
+    ! humicstype = config_mobility_type_humics
+
+    ! doctype_s:
+    ! mobility type sachharids
+    ! doctype_s = config_mobility_type_saccharids
+
+    ! doctype_l:
+    ! mobility type lipids
+    ! doctype_l = config_mobility_type_lipids
+
+    ! dictype_1:
+    ! mobility type dissolved inorganic carbon
+    ! dictype_1 = config_mobility_type_inorganic_carbon
+
+    ! dontype_protein:
+    ! mobility type proteins
+    ! dontype_protein = config_mobility_type_proteins
+
+    ! fedtype_1:
+    ! mobility type dissolved iron
+    ! fedtype_1 =  config_mobility_type_dissolved_iron
+
+    ! feptype_1:
+    ! mobility type particulate iron
+    ! feptype_1 =  config_mobility_type_particulate_iron
+
+    ! zaerotype_bc1:
+    ! mobility type for black carbon 1
+    ! zaerotype_bc1 = config_mobility_type_black_carbon1
+
+    ! zaerotype_bc2:
+    ! mobility type for black carbon 2
+    ! zaerotype_bc2 = config_mobility_type_black_carbon2
+
+    ! zaerotype_dust1:
+    ! mobility type for dust 1
+    ! zaerotype_dust1 = config_mobility_type_dust1
+
+    ! zaerotype_dust2:
+    ! mobility type for dust 2
+    ! zaerotype_dust2 = config_mobility_type_dust2
+
+    ! zaerotype_dust3:
+    ! mobility type for dust 3
+    ! zaerotype_dust3 = config_mobility_type_dust3
+
+    ! zaerotype_dust4:
+    ! mobility type for dust 4
+    ! zaerotype_dust4 = config_mobility_type_dust4
+
+    ! ratio_C2N_diatoms:
+    ! algal C to N ratio (mol/mol) diatoms
+    ! ratio_C2N_diatoms = config_ratio_C_to_N_diatoms
+
+    ! ratio_C2N_sp:
+    ! algal C to N ratio (mol/mol) small_plankton
+    ! ratio_C2N_sp = config_ratio_C_to_N_small_plankton
+
+    ! ratio_C2N_phaeo:
+    ! algal C to N ratio (mol/mol) phaeocystis
+    ! ratio_C2N_phaeo = config_ratio_C_to_N_phaeocystis
+
+    ! ratio_chl2N_diatoms:
+    ! algal chla to N ratio (mol/mol) diatoms
+    ! ratio_chl2N_diatoms = config_ratio_chla_to_N_diatoms
+
+    ! ratio_chl2N_sp:
+    ! algal chla to N ratio (mol/mol) small_plankton
+    ! ratio_chl2N_sp = config_ratio_chla_to_N_small_plankton
+
+    ! ratio_chl2N_phaeo:
+    ! algal chla to N ratio (mol/mol) phaeocystis
+    ! ratio_chl2N_phaeo = config_ratio_chla_to_N_phaeocystis
+
+    ! F_abs_chl_diatoms:
+    ! scales absorbed radiation for dEdd diatoms
+    ! F_abs_chl_diatoms = config_scales_absorption_diatoms
+
+    ! F_abs_chl_sp:
+    ! scales absorbed radiation for dEdd small_plankton
+    ! F_abs_chl_sp = config_scales_absorption_small_plankton
+
+    ! F_abs_chl_phaeo:
+    ! scales absorbed radiation for dEdd phaeocystis
+    ! F_abs_chl_phaeo = config_scales_absorption_phaeocystis
+
+    ! ratio_C2N_proteins:
+    ! ratio of C to N in proteins (mol/mol)
+    ! ratio_C2N_proteins = config_ratio_C_to_N_proteins
+
+    ! grid_oS:
+    ! for bottom flux (zsalinity)
+    !grid_oS = config_zsalinity_molecular_sublayer
+
+    ! l_skS:
+    ! 0.02 characteristic skeletal layer thickness (m) (zsalinity)
+    !l_skS = config_zsalinity_gravity_drainage_scale
+
+    !-----------------------------------------------------------------------
+    ! Parameters for snow
+    !-----------------------------------------------------------------------
+
+    ! snwredist:
+    ! snow redistribution type
+    ! snwredist = config_snow_redistribution_scheme
+
+    ! use_smliq_pnd:
+    ! convert excess snow liquid to ponds
+    ! use_smliq_pnd = config_use_snow_liquid_ponds
+
+    ! rsnw_fall:
+    ! fallen snow grain radius (um)
+    ! rsnw_fall = config_fallen_snow_radius
+
+    ! rsnw_tmax:
+    ! maximum dry metamorphism snow grain radius (um)
+    ! rsnw_tmax = config_max_dry_snow_radius
+
+    ! rhosnew:
+    ! new snow density (kg/m^3)
+    ! rhosnew = config_new_snow_density
+
+    ! rhosmax:
+    ! maximum snow density (kg/m^3)
+    ! rhosmax = config_max_snow_density
+
+    ! windmin:
+    ! minimum wind speed to compact snow (m/s)
+    ! windmin = config_minimum_wind_compaction 
+
+    ! drhosdwind:
+    ! wind compaction factor (kg s/m^4)
+    ! drhosdwind = config_wind_compaction_factor
+
+  end subroutine init_icepack_package_configs
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
 !  config_error
 !
 !> \brief
@@ -13146,7 +14685,7 @@ contains
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!  seaice_column_initial_air_drag_coefficient
+!  seaice_icepack_initial_air_drag_coefficient
 !
 !> \brief
 !> \author Adrian K. Turner, LANL
@@ -13156,7 +14695,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-  function seaice_column_initial_air_drag_coefficient() result(airDragCoefficient)
+  function seaice_icepack_initial_air_drag_coefficient() result(airDragCoefficient)
 
     use seaice_constants, only: &
          seaiceVonKarmanConstant, &
@@ -13169,11 +14708,11 @@ contains
     airDragCoefficient = (seaiceVonKarmanConstant/log(seaiceStabilityReferenceHeight/seaiceIceSurfaceRoughness)) &
                        * (seaiceVonKarmanConstant/log(seaiceStabilityReferenceHeight/seaiceIceSurfaceRoughness))
 
-  end function seaice_column_initial_air_drag_coefficient
+  end function seaice_icepack_initial_air_drag_coefficient
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!  seaice_column_reinitialize_fluxes
+!  seaice_icepack_reinitialize_fluxes
 !
 !> \brief
 !> \author Adrian K. Turner, LANL
@@ -13183,7 +14722,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-  subroutine seaice_column_reinitialize_fluxes(domain)
+  subroutine seaice_icepack_reinitialize_fluxes(domain)
 
     type(domain_type) :: domain
 
@@ -13193,7 +14732,7 @@ contains
     ! oceanic fluxes
     call seaice_column_reinitialize_oceanic_fluxes(domain)
 
-  end subroutine seaice_column_reinitialize_fluxes
+  end subroutine seaice_icepack_reinitialize_fluxes
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
@@ -14027,6 +15566,8 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_snow_porosity_at_ice_surface", config_snow_porosity_at_ice_surface)
     call MPAS_pool_get_config(domain % configs, "config_use_macromolecules", config_use_macromolecules)
 
+    abortFlag = .false.
+
     setGetPhysicsTracers = .false.
     setGetBGCTracers     = .true.
 
@@ -14100,10 +15641,6 @@ contains
             nIceLayers, &
             config_snow_porosity_at_ice_surface)
 
-       ! code abort
-       abortFlag = .false.
-       abortMessage = ""
-
        do iCell = 1, nCellsSolve
           if (.not. config_do_restart_hbrine) then
              ! initialize newly formed ice
@@ -14171,14 +15708,11 @@ contains
                   abortFlag, &
                   abortMessage)
 
-             ! code abort
              if (abortFlag) then
                 call mpas_log_write(&
                      "init_column_biogeochemistry_profiles: colpkg_init_bgc: "//trim(abortMessage), &
                      messageType=MPAS_LOG_CRIT)
-                exit
              endif
-
           endif ! biogeochemistry
 
           ! get the category tracer array
@@ -14187,10 +15721,6 @@ contains
 
        enddo ! iCell
 
-       ! code abort
-       call seaice_critical_error_write_block(domain, block, abortFlag)
-       call seaice_check_critical_error(domain, abortFlag)
-
        block => block % next
     end do
 
@@ -14198,7 +15728,7 @@ contains
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!  seaice_column_reinitialize_diagnostics_thermodynamics
+!  seaice_icepack_reinitialize_diagnostics_thermodynamics
 !
 !> \brief Reinitialize thermodynamics diagnostics
 !> \author Adrian K. Turner, LANL
@@ -14208,7 +15738,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-  subroutine seaice_column_reinitialize_diagnostics_thermodynamics(domain)
+  subroutine seaice_icepack_reinitialize_diagnostics_thermodynamics(domain)
 
     use seaice_constants, only: &
          seaiceIceOceanDragCoefficient
@@ -14405,7 +15935,7 @@ contains
           call MPAS_pool_get_array(dragPool, "airDragCoefficient", airDragCoefficient)
 
           oceanDragCoefficient = seaiceIceOceanDragCoefficient
-          airDragCoefficient   = seaice_column_initial_air_drag_coefficient()
+          airDragCoefficient   = seaice_icepack_initial_air_drag_coefficient()
 
           call MPAS_pool_get_config(block % configs, "config_use_form_drag", config_use_form_drag)
 
@@ -14475,11 +16005,11 @@ contains
 
     endif ! config_use_column_package
 
-  end subroutine seaice_column_reinitialize_diagnostics_thermodynamics
+  end subroutine seaice_icepack_reinitialize_diagnostics_thermodynamics
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!  seaice_column_reinitialize_diagnostics_dynamics
+!  seaice_icepack_reinitialize_diagnostics_dynamics
 !
 !> \brief Reinitialize dynamics diagnostics
 !> \author Adrian K. Turner, LANL
@@ -14489,7 +16019,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-  subroutine seaice_column_reinitialize_diagnostics_dynamics(domain)
+  subroutine seaice_icepack_reinitialize_diagnostics_dynamics(domain)
 
     type(domain_type) :: domain
 
@@ -14643,11 +16173,11 @@ contains
 
     endif ! config_use_column_package
 
-  end subroutine seaice_column_reinitialize_diagnostics_dynamics
+  end subroutine seaice_icepack_reinitialize_diagnostics_dynamics
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!  seaice_column_reinitialize_diagnostics_bgc
+!  seaice_icepack_reinitialize_diagnostics_bgc
 !
 !> \brief Reinitialize BGC diagnostics
 !> \author Adrian K. Turner, LANL
@@ -14657,7 +16187,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-  subroutine seaice_column_reinitialize_diagnostics_bgc(domain)
+  subroutine seaice_icepack_reinitialize_diagnostics_bgc(domain)
 
     type(domain_type) :: domain
 
@@ -14774,7 +16304,7 @@ contains
 
     endif ! config_use_column_package
 
-  end subroutine seaice_column_reinitialize_diagnostics_bgc
+  end subroutine seaice_icepack_reinitialize_diagnostics_bgc
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
@@ -16192,4 +17722,34 @@ contains
 
 !-----------------------------------------------------------------------
 
-end module seaice_column
+  !subroutine seaice_icepack_write_warnings(logAsErrors)
+
+  !  use icepack_intfc, only: &
+  !       icepack_warnings_getall
+
+  !  character(len=strKINDWarnings), dimension(:), allocatable :: &
+  !       warnings
+
+  !  logical, intent(in) :: &
+  !       logAsErrors
+
+  !  integer :: &
+  !       iWarning
+
+  !  call icepack_warnings_getall(warnings)
+
+  !  if (logAsErrors) then
+  !     do iWarning = 1, size(warnings)
+  !        call mpas_log_write(trim(warnings(iWarning)), messageType=MPAS_LOG_ERR)
+  !     enddo ! iWarning
+  !  else
+  !     do iWarning = 1, size(warnings)
+  !        call mpas_log_write(trim(warnings(iWarning)), messageType=MPAS_LOG_WARN)
+  !     enddo ! iWarning
+  !  endif
+
+  !end subroutine seaice_icepack_write_warnings
+
+!-----------------------------------------------------------------------
+
+end module seaice_icepack

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -9887,6 +9887,7 @@ contains
          config_use_snow_grain_radius
 
     logical :: &
+         use_snow, &
          use_meltponds, &
          use_nitrogen
 
@@ -9914,6 +9915,10 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_use_vertical_biochemistry", config_use_vertical_biochemistry)
     call MPAS_pool_get_config(domain % configs, "config_use_effective_snow_density", config_use_effective_snow_density)
     call MPAS_pool_get_config(domain % configs, "config_use_snow_grain_radius", config_use_snow_grain_radius)
+
+    use_snow = .false.
+    if (config_use_effective_snow_density .or. config_use_snow_grain_radius) &
+         use_snow = .true.
 
     use_nitrogen = .false.
     if (config_use_skeletal_biochemistry .or. config_use_vertical_biochemistry) &
@@ -10058,7 +10063,7 @@ contains
          tr_iage_in      = config_use_ice_age, &
          tr_FY_in        = config_use_first_year_ice, &
          tr_lvl_in       = config_use_level_ice, &
-         tr_snow_in      = config_use_effective_snow_density, &
+         tr_snow_in      = use_snow, &
          tr_pond_in      = use_meltponds, &
          !tr_pond_cesm_in = config_use_cesm_meltponds, & ! deprecated
          tr_pond_lvl_in  = config_use_level_meltponds, &

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -12366,6 +12366,7 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_slow_mode_critical_porosity", config_slow_mode_critical_porosity)
     call MPAS_pool_get_config(domain % configs, "config_congelation_ice_porosity", config_congelation_ice_porosity)
     call MPAS_pool_get_config(domain % configs, "config_shortwave_type", config_shortwave_type)
+    call MPAS_pool_get_config(domain % configs, "config_use_snicar_ad", config_use_snicar_ad)
     call MPAS_pool_get_config(domain % configs, "config_albedo_type", config_albedo_type)
     call MPAS_pool_get_config(domain % configs, "config_visible_ice_albedo", config_visible_ice_albedo)
     call MPAS_pool_get_config(domain % configs, "config_infrared_ice_albedo", config_infrared_ice_albedo)

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -732,7 +732,7 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_shortwave_type", config_shortwave_type)
     call MPAS_pool_get_config(domain % configs, "config_do_restart", config_do_restart)
 
-    if (trim(config_shortwave_type) == "dEdd") then
+    if (trim(config_shortwave_type(1:4)) == "dEdd") then
 
        abortFlag = .false.
        abortMessage = ""
@@ -9572,7 +9572,7 @@ contains
 
     ! check config_shortwave_type value
     if (.not. (trim(config_shortwave_type) == "ccsm3" .or. &
-               trim(config_shortwave_type) == "dEdd")) then
+               trim(config_shortwave_type(1:4)) == "dEdd")) then
        call config_error("config_shortwave_type", config_shortwave_type, "'ccsm3' or 'dEdd'")
     endif
 
@@ -9643,10 +9643,10 @@ contains
             messageType=MPAS_LOG_CRIT)
 
     ! check snicar value
-    if (config_use_snicar_ad .and. trim(config_column_physics_type) == "icepack") &
-       call mpas_log_write(&
-            "Use config_shortwave_type='dEdd_snicar_ad' for Snicar in Icepack", &
-            messageType=MPAS_LOG_CRIT)
+!    if (config_use_snicar_ad .and. trim(config_column_physics_type) == "icepack") &
+!       call mpas_log_write(&
+!            "Use config_shortwave_type='dEdd_snicar_ad' for Snicar in Icepack", &
+!            messageType=MPAS_LOG_CRIT)
 
     !-----------------------------------------------------------------------
     ! Check combinations
@@ -9699,9 +9699,9 @@ contains
 
     ! check dEdd shortwave if using ponds
     use_meltponds = (config_use_cesm_meltponds .or. config_use_level_meltponds .or. config_use_topo_meltponds)
-    if (trim(config_shortwave_type) /= 'dEdd' .and. use_meltponds .and. config_calc_surface_temperature) then
+    if (trim(config_shortwave_type(1:4)) /= 'dEdd' .and. use_meltponds .and. config_calc_surface_temperature) then
        call mpas_log_write(&
-            "check_column_package_configs: config_shortwave_type) /= 'dEdd' .and. use_meltponds = .true.", &
+            "check_column_package_configs: config_shortwave_type(1:4)) /= 'dEdd' .and. use_meltponds = .true.", &
             messageType=MPAS_LOG_ERR)
        call mpas_log_write(&
             ".and. config_calc_surface_temperature ==.true.", &
@@ -9815,9 +9815,9 @@ contains
     endif
 
     ! check that the shortwave scheme and bioabsorption is consistent
-    if (config_use_shortwave_bioabsorption .and. .not. (trim(config_shortwave_type) == "dEdd")) then
+    if (config_use_shortwave_bioabsorption .and. .not. (trim(config_shortwave_type(1:4)) == "dEdd")) then
        call mpas_log_write(&
-            "check_column_package_configs: shortwave bioabsorption requires config_shortwave_type ==  'dEdd'", &
+            "check_column_package_configs: shortwave bioabsorption requires config_shortwave_type(1:4) ==  'dEdd'", &
             messageType=MPAS_LOG_CRIT)
     endif
 
@@ -12159,6 +12159,7 @@ contains
          config_snow_redistribution_scheme
 
     logical, pointer :: &
+         config_use_snicar_ad, &
          config_calc_surface_temperature, &
          config_update_ocean_fluxes, &
          config_use_form_drag, &
@@ -12343,6 +12344,9 @@ contains
          config_ridging_redistribution_function_int, &
          config_itd_conversion_type_int, &
          config_category_bounds_type_int
+
+    character(len=strKIND) :: &
+         tmp_config_shortwave
 
     call MPAS_pool_get_config(domain % configs, "config_thermodynamics_type", config_thermodynamics_type)
     call MPAS_pool_get_config(domain % configs, "config_heat_conductivity_type", config_heat_conductivity_type)
@@ -12552,6 +12556,12 @@ contains
     config_itd_conversion_type_int = config_cice_int("config_itd_conversion_type", config_itd_conversion_type)
     config_category_bounds_type_int = config_cice_int("config_category_bounds_type", config_category_bounds_type)
 
+    if (config_use_snicar_ad .and. trim(config_shortwave_type) == 'dEdd') then
+       tmp_config_shortwave = 'dEdd_snicar_ad'
+    else
+       tmp_config_shortwave = trim(config_shortwave_type)
+    endif
+
     call icepack_init_parameters(&
          !argcheck_in             = , &
          !puny_in                 = , &
@@ -12627,7 +12637,8 @@ contains
          dSdt_slow_mode_in       = config_slow_mode_drainage_strength, &
          phi_c_slow_mode_in      = config_slow_mode_critical_porosity, &
          phi_i_mushy_in          = config_congelation_ice_porosity, &
-         shortwave_in            = config_shortwave_type, &
+!         shortwave_in            = config_shortwave_type, &
+         shortwave_in            = tmp_config_shortwave, &
          albedo_type_in          = config_albedo_type, &
          albsnowi_in             = config_infrared_snow_albedo, &
          albicev_in              = config_visible_ice_albedo, &

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -9487,8 +9487,7 @@ contains
          config_use_DON, &
          config_use_iron, &
          config_use_modal_aerosols, &
-         config_use_column_biogeochemistry, &
-         config_use_snicar_ad
+         config_use_column_biogeochemistry
 
     logical :: &
          use_meltponds
@@ -9528,7 +9527,6 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_use_cesm_meltponds", config_use_cesm_meltponds)
     call MPAS_pool_get_config(domain % configs, "config_use_level_meltponds", config_use_level_meltponds)
     call MPAS_pool_get_config(domain % configs, "config_use_topo_meltponds", config_use_topo_meltponds)
-    call MPAS_pool_get_config(domain % configs, "config_use_snicar_ad", config_use_snicar_ad)
     call MPAS_pool_get_config(domain % configs, "config_ocean_heat_transfer_type", config_ocean_heat_transfer_type)
     call MPAS_pool_get_config(domain % configs, "config_sea_freezing_temperature_type", config_sea_freezing_temperature_type)
     call MPAS_pool_get_config(domain % configs, "config_use_brine", config_use_brine)
@@ -9641,12 +9639,6 @@ contains
        call mpas_log_write(&
             'Check for inconsistencies in restart file: config_nIceLayers /= nIceLayers', &
             messageType=MPAS_LOG_CRIT)
-
-    ! check snicar value
-!    if (config_use_snicar_ad .and. trim(config_column_physics_type) == "icepack") &
-!       call mpas_log_write(&
-!            "Use config_shortwave_type='dEdd_snicar_ad' for Snicar in Icepack", &
-!            messageType=MPAS_LOG_CRIT)
 
     !-----------------------------------------------------------------------
     ! Check combinations
@@ -9916,10 +9908,6 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_use_effective_snow_density", config_use_effective_snow_density)
     call MPAS_pool_get_config(domain % configs, "config_use_snow_grain_radius", config_use_snow_grain_radius)
 
-    use_snow = .false.
-    if (config_use_effective_snow_density .or. config_use_snow_grain_radius) &
-         use_snow = .true.
-
     use_nitrogen = .false.
     if (config_use_skeletal_biochemistry .or. config_use_vertical_biochemistry) &
          use_nitrogen = .true.
@@ -10025,6 +10013,7 @@ contains
          config_use_snow_grain_radius
 
     logical :: &
+         use_snow, &
          use_meltponds, &
          use_nitrogen
 
@@ -10052,6 +10041,10 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_use_vertical_biochemistry", config_use_vertical_biochemistry)
     call MPAS_pool_get_config(domain % configs, "config_use_effective_snow_density", config_use_effective_snow_density)
     call MPAS_pool_get_config(domain % configs, "config_use_snow_grain_radius", config_use_snow_grain_radius)
+
+    use_snow = .false.
+    if (config_use_effective_snow_density .or. config_use_snow_grain_radius) &
+         use_snow = .true.
 
     use_nitrogen = .false.
     if (config_use_skeletal_biochemistry .or. config_use_vertical_biochemistry) &

--- a/components/mpas-seaice/src/shared/mpas_seaice_initialize.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_initialize.F
@@ -214,15 +214,11 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_column_physics_type", config_column_physics_type)
 
     if (config_use_column_package .and. config_use_column_shortwave .and. .not. config_do_restart) then
-#ifdef icepackON
        if (trim(config_column_physics_type) == "icepack") then
           call seaice_init_icepack_shortwave(domain, clock)
        else if (trim(config_column_physics_type) == "column_package") then
-#endif
           call seaice_init_column_shortwave(domain, clock)
-#ifdef icepackON
        endif ! config_column_physics_type
-#endif
     endif
 
   end subroutine seaice_init_post_clock_advance

--- a/components/mpas-seaice/src/shared/mpas_seaice_initialize.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_initialize.F
@@ -57,13 +57,9 @@ contains
          seaice_init_icepack_constants, &
          seaice_init_icepack_physics_package_parameters, &
          seaice_init_icepack_physics_package_variables
-    use seaice_icepack, only: &
-         seaice_init_icepack_physics_package_variables
     use seaice_column, only: &
          seaice_init_column_constants, &
          seaice_init_column_physics_package_parameters, &
-         seaice_init_column_physics_package_variables
-    use seaice_column, only: &
          seaice_init_column_physics_package_variables
     use seaice_forcing, only: seaice_forcing_init, seaice_reset_coupler_fluxes
     use seaice_diagnostics, only: &

--- a/components/mpas-seaice/src/shared/mpas_seaice_initialize.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_initialize.F
@@ -59,6 +59,12 @@ contains
          seaice_init_icepack_physics_package_variables
     use seaice_icepack, only: &
          seaice_init_icepack_physics_package_variables
+    use seaice_column, only: &
+         seaice_init_column_constants, &
+         seaice_init_column_physics_package_parameters, &
+         seaice_init_column_physics_package_variables
+    use seaice_column, only: &
+         seaice_init_column_physics_package_variables
     use seaice_forcing, only: seaice_forcing_init, seaice_reset_coupler_fluxes
     use seaice_diagnostics, only: &
          seaice_set_testing_system_test_arrays
@@ -79,13 +85,21 @@ contains
     real(kind=RKIND), intent(in) :: &
          dt !< Input:
 
-    type(block_type), pointer :: &
-         block
+    character(len=strKIND), pointer :: &
+         config_column_physics_type
 
     call mpas_log_write("seaice_init: Initialize sea-ice model")
 
+    call mpas_pool_get_config(domain % configs, "config_column_physics_type", config_column_physics_type)
+
     ! set column constants
-    call seaice_init_icepack_constants()
+    if (trim(config_column_physics_type) == "icepack") then
+       call seaice_init_icepack_constants()
+    else if (trim(config_column_physics_type) == "column_package") then
+       call seaice_init_column_constants()
+    else
+       call MPAS_log_write("Unknown config_column_physics_type: "//trim(config_column_physics_type), MPAS_LOG_CRIT)
+    endif ! config_column_physics_type
 
     ! init testing system test arrays
     call seaice_set_testing_system_test_arrays(domain)
@@ -111,7 +125,11 @@ contains
 
     ! init the basic column physics package
     call mpas_log_write(" Initialize column parameters...")
-    call seaice_init_icepack_physics_package_parameters(domain)
+    if (trim(config_column_physics_type) == "icepack") then
+       call seaice_init_icepack_physics_package_parameters(domain)
+    else if (trim(config_column_physics_type) == "column_package") then
+       call seaice_init_column_physics_package_parameters(domain)
+    endif ! config_column_physics_type
 
     ! init coupler fluxes
     call mpas_log_write(" Initialize coupler fields...")
@@ -133,7 +151,11 @@ contains
 
     ! column physics initialization
     call mpas_log_write(" Initialize column variables...")
-    call seaice_init_icepack_physics_package_variables(domain, clock)
+    if (trim(config_column_physics_type) == "icepack") then
+       call seaice_init_icepack_physics_package_variables(domain, clock)
+    else if (trim(config_column_physics_type) == "column_package") then
+       call seaice_init_column_physics_package_variables(domain, clock)
+    endif ! config_column_physics_type
 
     ! init ice state
     call mpas_log_write(" Initialize ice state...")
@@ -170,6 +192,8 @@ contains
 
     use seaice_icepack, only: &
          seaice_init_icepack_shortwave
+    use seaice_column, only: &
+         seaice_init_column_shortwave
 
     type(domain_type), intent(inout) :: &
          domain !< Input/Output:
@@ -182,12 +206,21 @@ contains
          config_use_column_shortwave, &
          config_do_restart
 
+    character(len=strKIND), pointer :: &
+         config_column_physics_type
+
     call MPAS_pool_get_config(domain % configs, "config_use_column_package", config_use_column_package)
     call MPAS_pool_get_config(domain % configs, "config_use_column_shortwave", config_use_column_shortwave)
     call MPAS_pool_get_config(domain % configs, "config_do_restart", config_do_restart)
+    call MPAS_pool_get_config(domain % configs, "config_column_physics_type", config_column_physics_type)
 
-    if (config_use_column_package .and. config_use_column_shortwave .and. .not. config_do_restart) &
-         call seaice_init_icepack_shortwave(domain, clock)
+    if (config_use_column_package .and. config_use_column_shortwave .and. .not. config_do_restart) then
+       if (trim(config_column_physics_type) == "icepack") then
+          call seaice_init_icepack_shortwave(domain, clock)
+       else if (trim(config_column_physics_type) == "column_package") then
+          call seaice_init_column_shortwave(domain, clock)
+       endif ! config_column_physics_type
+    endif
 
   end subroutine seaice_init_post_clock_advance
 
@@ -265,6 +298,8 @@ contains
          seaice_init_square_point_test_case_hex
     use seaice_icepack, only: &
          seaice_icepack_aggregate
+    use seaice_column, only: &
+         seaice_column_aggregate
 
     type(domain_type), intent(inout) :: &
          domain !< Input/Output:
@@ -277,7 +312,8 @@ contains
 
     character(len=strKIND), pointer :: &
          config_initial_condition_type, &
-         config_initial_velocity_type
+         config_initial_velocity_type, &
+         config_column_physics_type
 
     integer, dimension(:), pointer :: &
          interiorVertex
@@ -453,9 +489,15 @@ contains
     endif
 
     ! aggregate tracers even if restart
-    call MPAS_pool_get_config(domain % blocklist % configs, "config_use_column_package", config_use_column_package)
-    if (config_use_column_package) &
-         call seaice_icepack_aggregate(domain)
+    call MPAS_pool_get_config(domain % configs, "config_use_column_package", config_use_column_package)
+    call MPAS_pool_get_config(domain % configs, "config_column_physics_type", config_column_physics_type)
+    if (config_use_column_package) then
+       if (trim(config_column_physics_type) == "icepack") then
+          call seaice_icepack_aggregate(domain)
+       else if (trim(config_column_physics_type) == "column_package") then
+          call seaice_column_aggregate(domain)
+       endif ! config_column_physics_type
+    endif
 
   end subroutine init_ice_state!}}}
 
@@ -592,6 +634,9 @@ contains
     use seaice_icepack, only: &
          seaice_icepack_init_trcr, &
          seaice_icepack_enthalpy_snow
+    use seaice_column, only: &
+         seaice_column_init_trcr, &
+         seaice_column_enthalpy_snow
 
     type(block_type), intent(inout) :: &
          block !< Input/Output:
@@ -651,6 +696,11 @@ contains
     real(kind=RKIND), parameter :: &
          initialCategorySnowThickness = 0.2_RKIND
 
+    character(len=strKIND), pointer :: &
+         config_column_physics_type
+
+    call MPAS_pool_get_config(configs, "config_column_physics_type", config_column_physics_type)
+
     call MPAS_pool_get_config(configs, "config_initial_latitude_north", config_initial_latitude_north)
     call MPAS_pool_get_config(configs, "config_initial_latitude_south", config_initial_latitude_south)
 
@@ -701,25 +751,47 @@ contains
           landIceMask(iCell) == 0) then
 
           ! has ice
-          do iCategory = 1, nCategories
+          if (trim(config_column_physics_type) == "icepack") then
+             do iCategory = 1, nCategories
 
-             iceAreaCategory(1,iCategory,iCell)    = initialCategoryIceArea(iCategory)
-             iceVolumeCategory(1,iCategory,iCell)  = initialCategoryIceArea(iCategory) * initialCategoryIceThickness(iCategory)
-             snowVolumeCategory(1,iCategory,iCell) = min(iceAreaCategory(1,iCategory,iCell) * initialCategorySnowThickness, &
-                                                         0.2_RKIND * iceVolumeCategory(1,iCategory,iCell))
+                iceAreaCategory(1,iCategory,iCell)    = initialCategoryIceArea(iCategory)
+                iceVolumeCategory(1,iCategory,iCell)  = initialCategoryIceArea(iCategory) * initialCategoryIceThickness(iCategory)
+                snowVolumeCategory(1,iCategory,iCell) = min(iceAreaCategory(1,iCategory,iCell) * initialCategorySnowThickness, &
+                     0.2_RKIND * iceVolumeCategory(1,iCategory,iCell))
 
-             call seaice_icepack_init_trcr(&
-                  airTemperature(iCell), &
-                  seaFreezingTemperature(iCell), &
-                  initialSalinityProfile(:,iCell), &
-                  initialMeltingTemperatureProfile(:,iCell), &
-                  surfaceTemperature(1,iCategory,iCell), &
-                  nIceLayers, &
-                  nSnowLayers, &
-                  iceEnthalpy(:,iCategory,iCell), &
-                  snowEnthalpy(:,iCategory,iCell))
+                call seaice_icepack_init_trcr(&
+                     airTemperature(iCell), &
+                     seaFreezingTemperature(iCell), &
+                     initialSalinityProfile(:,iCell), &
+                     initialMeltingTemperatureProfile(:,iCell), &
+                     surfaceTemperature(1,iCategory,iCell), &
+                     nIceLayers, &
+                     nSnowLayers, &
+                     iceEnthalpy(:,iCategory,iCell), &
+                     snowEnthalpy(:,iCategory,iCell))
 
-          enddo ! iCategory
+             enddo ! iCategory
+          else if (trim(config_column_physics_type) == "column_package") then
+             do iCategory = 1, nCategories
+
+                iceAreaCategory(1,iCategory,iCell)    = initialCategoryIceArea(iCategory)
+                iceVolumeCategory(1,iCategory,iCell)  = initialCategoryIceArea(iCategory) * initialCategoryIceThickness(iCategory)
+                snowVolumeCategory(1,iCategory,iCell) = min(iceAreaCategory(1,iCategory,iCell) * initialCategorySnowThickness, &
+                     0.2_RKIND * iceVolumeCategory(1,iCategory,iCell))
+
+                call seaice_column_init_trcr(&
+                     airTemperature(iCell), &
+                     seaFreezingTemperature(iCell), &
+                     initialSalinityProfile(:,iCell), &
+                     initialMeltingTemperatureProfile(:,iCell), &
+                     surfaceTemperature(1,iCategory,iCell), &
+                     nIceLayers, &
+                     nSnowLayers, &
+                     iceEnthalpy(:,iCategory,iCell), &
+                     snowEnthalpy(:,iCategory,iCell))
+
+             enddo ! iCategory
+          endif ! config_column_physics_type
 
        else
 
@@ -729,9 +801,15 @@ contains
           snowVolumeCategory(1,:,iCell) = 0.0_RKIND
 
           surfaceTemperature(1,:,iCell) = seaFreezingTemperature(iCell)
-          do iSnowLayer = 1, nSnowLayers
-             snowEnthalpy(iSnowLayer,:,iCell) = seaice_icepack_enthalpy_snow(0.0_RKIND)
-          end do
+          if (trim(config_column_physics_type) == "icepack") then
+             do iSnowLayer = 1, nSnowLayers
+                snowEnthalpy(iSnowLayer,:,iCell) = seaice_icepack_enthalpy_snow(0.0_RKIND)
+             end do
+          else if (trim(config_column_physics_type) == "column_package") then
+             do iSnowLayer = 1, nSnowLayers
+                snowEnthalpy(iSnowLayer,:,iCell) = seaice_column_enthalpy_snow(0.0_RKIND)
+             end do
+          endif ! config_column_physics_type
 
        endif
 
@@ -777,6 +855,8 @@ contains
 
     use seaice_icepack, only: &
          seaice_icepack_init_itd
+    use seaice_column, only: &
+         seaice_column_init_itd
 
     ! Note: the resulting average ice thickness
     ! tends to be less than hbar due to the
@@ -816,6 +896,11 @@ contains
     character(len=strKIND) :: &
          abortMessage
 
+    character(len=strKIND), pointer :: &
+         config_column_physics_type
+
+    call MPAS_pool_get_config(block % configs, "config_column_physics_type", config_column_physics_type)
+
     call MPAS_pool_get_subpool(block % structs, "initial", initial)
     call MPAS_pool_get_subpool(block % structs, "mesh", mesh)
 
@@ -830,11 +915,19 @@ contains
 
     if (.not. config_use_column_package) then
 
-       call seaice_icepack_init_itd(&
-            nCategories, &
-            categoryThicknessLimits, &
-            abortFlag, &
-            abortMessage)
+       if (trim(config_column_physics_type) == "icepack") then
+          call seaice_icepack_init_itd(&
+               nCategories, &
+               categoryThicknessLimits, &
+               abortFlag, &
+               abortMessage)
+       else if (trim(config_column_physics_type) == "column_package") then
+          call seaice_column_init_itd(&
+               nCategories, &
+               categoryThicknessLimits, &
+               abortFlag, &
+               abortMessage)
+       endif ! config_column_physics_type
 
        ! code abort
        if (abortFlag) then
@@ -1051,6 +1144,9 @@ contains
     use seaice_icepack, only: &
          seaice_icepack_init_trcr, &
          seaice_icepack_enthalpy_snow
+    use seaice_column, only: &
+         seaice_column_init_trcr, &
+         seaice_column_enthalpy_snow
 
     type(block_type), intent(inout) :: &
          block !< Input/Output:
@@ -1111,6 +1207,10 @@ contains
     real(kind=RKIND), parameter :: &
          initialCategorySnowThickness = 0.0_RKIND
 
+    character(len=strKIND), pointer :: &
+         config_column_physics_type
+
+    call MPAS_pool_get_config(configs, "config_column_physics_type", config_column_physics_type)
     call MPAS_pool_get_config(configs, "config_initial_latitude_north", config_initial_latitude_north)
     call MPAS_pool_get_config(configs, "config_initial_latitude_south", config_initial_latitude_south)
 
@@ -1168,49 +1268,95 @@ contains
     initialCategoryIceThickness(4) = (categoryThicknessLimits(4) + categoryThicknessLimits(4)) * 0.5_RKIND
     initialCategoryIceThickness(5) = categoryThicknessLimits(5) + 1.0_RKIND
 
-    do iCell = 1, nCellsSolve
+    if (trim(config_column_physics_type) == "icepack") then
+       do iCell = 1, nCellsSolve
 
-       if (seaSurfaceTemperature(iCell) <= seaFreezingTemperature(iCell) + 0.2_RKIND .and. &
-          (latCell(iCell) > config_initial_latitude_north * seaiceDegreesToRadians .or. &
-           latCell(iCell) < config_initial_latitude_south * seaiceDegreesToRadians) .and. &
-          landIceMask(iCell) == 0) then
+          if (seaSurfaceTemperature(iCell) <= seaFreezingTemperature(iCell) + 0.2_RKIND .and. &
+               (latCell(iCell) > config_initial_latitude_north * seaiceDegreesToRadians .or. &
+               latCell(iCell) < config_initial_latitude_south * seaiceDegreesToRadians) .and. &
+               landIceMask(iCell) == 0) then
 
-          ! has ice
-          do iCategory = 1, nCategories
+             ! has ice
+             do iCategory = 1, nCategories
 
-             iceAreaCategory(1,iCategory,iCell)    = initialCategoryIceArea(iCategory)
-             iceVolumeCategory(1,iCategory,iCell)  = initialCategoryIceArea(iCategory) * initialCategoryIceThickness(iCategory)
-             snowVolumeCategory(1,iCategory,iCell) = min(iceAreaCategory(1,iCategory,iCell) * initialCategorySnowThickness, &
-                                                         0.2_RKIND * iceVolumeCategory(1,iCategory,iCell))
+                iceAreaCategory(1,iCategory,iCell)    = initialCategoryIceArea(iCategory)
+                iceVolumeCategory(1,iCategory,iCell)  = initialCategoryIceArea(iCategory) * initialCategoryIceThickness(iCategory)
+                snowVolumeCategory(1,iCategory,iCell) = min(iceAreaCategory(1,iCategory,iCell) * initialCategorySnowThickness, &
+                     0.2_RKIND * iceVolumeCategory(1,iCategory,iCell))
 
-             call seaice_icepack_init_trcr(&
-                  airTemperature(iCell), &
-                  seaFreezingTemperature(iCell), &
-                  initialSalinityProfile(:,iCell), &
-                  initialMeltingTemperatureProfile(:,iCell), &
-                  surfaceTemperature(1,iCategory,iCell), &
-                  nIceLayers, &
-                  nSnowLayers, &
-                  iceEnthalpy(:,iCategory,iCell), &
-                  snowEnthalpy(:,iCategory,iCell))
+                call seaice_icepack_init_trcr(&
+                     airTemperature(iCell), &
+                     seaFreezingTemperature(iCell), &
+                     initialSalinityProfile(:,iCell), &
+                     initialMeltingTemperatureProfile(:,iCell), &
+                     surfaceTemperature(1,iCategory,iCell), &
+                     nIceLayers, &
+                     nSnowLayers, &
+                     iceEnthalpy(:,iCategory,iCell), &
+                     snowEnthalpy(:,iCategory,iCell))
 
-          enddo ! iCategory
+             enddo ! iCategory
 
-       else
+          else
 
-          ! no ice
-          iceAreaCategory(1,:,iCell)    = 0.0_RKIND
-          iceVolumeCategory(1,:,iCell)  = 0.0_RKIND
-          snowVolumeCategory(1,:,iCell) = 0.0_RKIND
+             ! no ice
+             iceAreaCategory(1,:,iCell)    = 0.0_RKIND
+             iceVolumeCategory(1,:,iCell)  = 0.0_RKIND
+             snowVolumeCategory(1,:,iCell) = 0.0_RKIND
 
-          surfaceTemperature(1,:,iCell) = seaFreezingTemperature(iCell)
-          do iSnowLayer = 1, nSnowLayers
-             snowEnthalpy(iSnowLayer,:,iCell) = seaice_icepack_enthalpy_snow(0.0_RKIND)
-          end do
+             surfaceTemperature(1,:,iCell) = seaFreezingTemperature(iCell)
+             do iSnowLayer = 1, nSnowLayers
+                snowEnthalpy(iSnowLayer,:,iCell) = seaice_icepack_enthalpy_snow(0.0_RKIND)
+             end do
 
-       endif
+          endif
 
-    enddo ! iCell
+       enddo ! iCell
+    else if (trim(config_column_physics_type) == "column_package") then
+       do iCell = 1, nCellsSolve
+
+          if (seaSurfaceTemperature(iCell) <= seaFreezingTemperature(iCell) + 0.2_RKIND .and. &
+               (latCell(iCell) > config_initial_latitude_north * seaiceDegreesToRadians .or. &
+               latCell(iCell) < config_initial_latitude_south * seaiceDegreesToRadians) .and. &
+               landIceMask(iCell) == 0) then
+
+             ! has ice
+             do iCategory = 1, nCategories
+
+                iceAreaCategory(1,iCategory,iCell)    = initialCategoryIceArea(iCategory)
+                iceVolumeCategory(1,iCategory,iCell)  = initialCategoryIceArea(iCategory) * initialCategoryIceThickness(iCategory)
+                snowVolumeCategory(1,iCategory,iCell) = min(iceAreaCategory(1,iCategory,iCell) * initialCategorySnowThickness, &
+                     0.2_RKIND * iceVolumeCategory(1,iCategory,iCell))
+
+                call seaice_column_init_trcr(&
+                     airTemperature(iCell), &
+                     seaFreezingTemperature(iCell), &
+                     initialSalinityProfile(:,iCell), &
+                     initialMeltingTemperatureProfile(:,iCell), &
+                     surfaceTemperature(1,iCategory,iCell), &
+                     nIceLayers, &
+                     nSnowLayers, &
+                     iceEnthalpy(:,iCategory,iCell), &
+                     snowEnthalpy(:,iCategory,iCell))
+
+             enddo ! iCategory
+
+          else
+
+             ! no ice
+             iceAreaCategory(1,:,iCell)    = 0.0_RKIND
+             iceVolumeCategory(1,:,iCell)  = 0.0_RKIND
+             snowVolumeCategory(1,:,iCell) = 0.0_RKIND
+
+             surfaceTemperature(1,:,iCell) = seaFreezingTemperature(iCell)
+             do iSnowLayer = 1, nSnowLayers
+                snowEnthalpy(iSnowLayer,:,iCell) = seaice_column_enthalpy_snow(0.0_RKIND)
+             end do
+
+          endif
+
+       enddo ! iCell
+    endif ! config_column_physics_type
 
     ! clean up
     deallocate(initialCategoryIceArea)
@@ -2093,6 +2239,10 @@ contains
          seaice_icepack_liquidus_temperature, &
          seaice_icepack_init_ocean_conc, &
          seaice_icepack_initial_air_drag_coefficient
+    use seaice_column, only: &
+         seaice_column_liquidus_temperature, &
+         seaice_column_init_ocean_conc, &
+         seaice_column_initial_air_drag_coefficient
 
     use seaice_constants, only: &
          seaiceStefanBoltzmann, &
@@ -2170,8 +2320,13 @@ contains
          iBio, &
          indexj
 
+    character(len=strKIND), pointer :: &
+         config_column_physics_type
+
     block => domain % blocklist
     do while (associated(block))
+
+       call MPAS_pool_get_config(block % configs, "config_column_physics_type", config_column_physics_type)
 
        !-------------------------------------------------------------
        ! Physics fluxes received from atmosphere
@@ -2202,9 +2357,15 @@ contains
 
        call MPAS_pool_get_config(block % configs, "config_do_restart", config_do_restart)
 
-       do iCell = 1, nCells
-          seaFreezingTemperature(iCell) = seaice_icepack_liquidus_temperature(seaSurfaceSalinity(iCell))
-       enddo ! iCell
+       if (trim(config_column_physics_type) == "icepack") then
+          do iCell = 1, nCells
+             seaFreezingTemperature(iCell) = seaice_icepack_liquidus_temperature(seaSurfaceSalinity(iCell))
+          enddo ! iCell
+       else if (trim(config_column_physics_type) == "column_package") then
+          do iCell = 1, nCells
+             seaFreezingTemperature(iCell) = seaice_column_liquidus_temperature(seaSurfaceSalinity(iCell))
+          enddo ! iCell
+       endif ! config_column_physics_type
 
        ! sea surface temperature is not initialized if we're restarting
        if (.not. config_do_restart) then
@@ -2225,8 +2386,11 @@ contains
 
           call MPAS_pool_get_subpool(block % structs, "drag", drag)
           call MPAS_pool_get_array(drag, "airDragCoefficient", airDragCoefficient)
-          airDragCoefficient = seaice_icepack_initial_air_drag_coefficient()
-
+          if (trim(config_column_physics_type) == "icepack") then
+             airDragCoefficient = seaice_icepack_initial_air_drag_coefficient()
+          else if (trim(config_column_physics_type) == "column_package") then
+             airDragCoefficient = seaice_column_initial_air_drag_coefficient()
+          endif ! config_column_physics_type
        endif
 
        !-------------------------------------------------------------
@@ -2292,30 +2456,58 @@ contains
           call MPAS_pool_get_array(biogeochemistry, "carbonToNitrogenRatioAlgae", carbonToNitrogenRatioAlgae)
           call MPAS_pool_get_array(biogeochemistry, "carbonToNitrogenRatioDON", carbonToNitrogenRatioDON)
 
-          do iCell = 1, nCells
+          if (trim(config_column_physics_type) == "icepack") then
+             do iCell = 1, nCells
 
-             call seaice_icepack_init_ocean_conc(&
-                  oceanAmmoniumConc(iCell), &
-                  oceanDMSPConc(iCell), &
-                  oceanDMSConc(iCell), &
-                  oceanAlgaeConc(:,iCell), &
-                  oceanDOCConc(:,iCell), &
-                  oceanDICConc(:,iCell), &
-                  oceanDONConc(:,iCell), &
-                  oceanDissolvedIronConc(:,iCell), &
-                  oceanParticulateIronConc(:,iCell), &
-                  oceanHumicsConc(iCell), &
-                  oceanNitrateConc(iCell), &
-                  oceanSilicateConc(iCell),&
-                  oceanZAerosolConc(:,iCell), &
-                  maxDICType, &
-                  maxDONType, &
-                  maxIronType, &
-                  maxAerosolType, &
-                  carbonToNitrogenRatioAlgae, &
-                  carbonToNitrogenRatioDON)
+                call seaice_icepack_init_ocean_conc(&
+                     oceanAmmoniumConc(iCell), &
+                     oceanDMSPConc(iCell), &
+                     oceanDMSConc(iCell), &
+                     oceanAlgaeConc(:,iCell), &
+                     oceanDOCConc(:,iCell), &
+                     oceanDICConc(:,iCell), &
+                     oceanDONConc(:,iCell), &
+                     oceanDissolvedIronConc(:,iCell), &
+                     oceanParticulateIronConc(:,iCell), &
+                     oceanHumicsConc(iCell), &
+                     oceanNitrateConc(iCell), &
+                     oceanSilicateConc(iCell),&
+                     oceanZAerosolConc(:,iCell), &
+                     maxDICType, &
+                     maxDONType, &
+                     maxIronType, &
+                     maxAerosolType, &
+                     carbonToNitrogenRatioAlgae, &
+                     carbonToNitrogenRatioDON)
 
-          enddo ! iCell
+             enddo ! iCell
+          else if (trim(config_column_physics_type) == "column_package") then
+             do iCell = 1, nCells
+
+                call seaice_column_init_ocean_conc(&
+                     oceanAmmoniumConc(iCell), &
+                     oceanDMSPConc(iCell), &
+                     oceanDMSConc(iCell), &
+                     oceanAlgaeConc(:,iCell), &
+                     oceanDOCConc(:,iCell), &
+                     oceanDICConc(:,iCell), &
+                     oceanDONConc(:,iCell), &
+                     oceanDissolvedIronConc(:,iCell), &
+                     oceanParticulateIronConc(:,iCell), &
+                     oceanHumicsConc(iCell), &
+                     oceanNitrateConc(iCell), &
+                     oceanSilicateConc(iCell),&
+                     oceanZAerosolConc(:,iCell), &
+                     maxDICType, &
+                     maxDONType, &
+                     maxIronType, &
+                     maxAerosolType, &
+                     carbonToNitrogenRatioAlgae, &
+                     carbonToNitrogenRatioDON)
+
+             enddo ! iCell
+
+          endif ! config_column_physics_type
 
        endif ! config_use_column_biogeochemistry
 

--- a/components/mpas-seaice/src/shared/mpas_seaice_initialize.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_initialize.F
@@ -214,11 +214,15 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_column_physics_type", config_column_physics_type)
 
     if (config_use_column_package .and. config_use_column_shortwave .and. .not. config_do_restart) then
+#ifdef icepackON
        if (trim(config_column_physics_type) == "icepack") then
           call seaice_init_icepack_shortwave(domain, clock)
        else if (trim(config_column_physics_type) == "column_package") then
+#endif
           call seaice_init_column_shortwave(domain, clock)
+#ifdef icepackON
        endif ! config_column_physics_type
+#endif
     endif
 
   end subroutine seaice_init_post_clock_advance

--- a/components/mpas-seaice/src/shared/mpas_seaice_initialize.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_initialize.F
@@ -53,9 +53,12 @@ contains
     use seaice_mesh, only: seaice_init_mesh
     use seaice_advection, only: seaice_init_advection
     use seaice_velocity_solver, only: seaice_init_velocity_solver
-    use seaice_column, only: &
-         seaice_init_column_physics_package_parameters, &
-         seaice_init_column_physics_package_variables
+    use seaice_icepack, only: &
+         seaice_init_icepack_constants, &
+         seaice_init_icepack_physics_package_parameters, &
+         seaice_init_icepack_physics_package_variables
+    use seaice_icepack, only: &
+         seaice_init_icepack_physics_package_variables
     use seaice_forcing, only: seaice_forcing_init, seaice_reset_coupler_fluxes
     use seaice_diagnostics, only: &
          seaice_set_testing_system_test_arrays
@@ -81,6 +84,9 @@ contains
 
     call mpas_log_write("seaice_init: Initialize sea-ice model")
 
+    ! set column constants
+    call seaice_init_icepack_constants()
+
     ! init testing system test arrays
     call seaice_set_testing_system_test_arrays(domain)
 
@@ -105,7 +111,7 @@ contains
 
     ! init the basic column physics package
     call mpas_log_write(" Initialize column parameters...")
-    call seaice_init_column_physics_package_parameters(domain)
+    call seaice_init_icepack_physics_package_parameters(domain)
 
     ! init coupler fluxes
     call mpas_log_write(" Initialize coupler fields...")
@@ -127,7 +133,7 @@ contains
 
     ! column physics initialization
     call mpas_log_write(" Initialize column variables...")
-    call seaice_init_column_physics_package_variables(domain, clock)
+    call seaice_init_icepack_physics_package_variables(domain, clock)
 
     ! init ice state
     call mpas_log_write(" Initialize ice state...")
@@ -162,8 +168,8 @@ contains
        domain, &
        clock)!{{{
 
-    use seaice_column, only: &
-         seaice_init_column_shortwave
+    use seaice_icepack, only: &
+         seaice_init_icepack_shortwave
 
     type(domain_type), intent(inout) :: &
          domain !< Input/Output:
@@ -181,7 +187,7 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_do_restart", config_do_restart)
 
     if (config_use_column_package .and. config_use_column_shortwave .and. .not. config_do_restart) &
-         call seaice_init_column_shortwave(domain, clock)
+         call seaice_init_icepack_shortwave(domain, clock)
 
   end subroutine seaice_init_post_clock_advance
 
@@ -257,8 +263,8 @@ contains
     use seaice_testing, only: &
          seaice_init_square_test_case_hex, &
          seaice_init_square_point_test_case_hex
-    use seaice_column, only: &
-         seaice_column_aggregate
+    use seaice_icepack, only: &
+         seaice_icepack_aggregate
 
     type(domain_type), intent(inout) :: &
          domain !< Input/Output:
@@ -449,7 +455,7 @@ contains
     ! aggregate tracers even if restart
     call MPAS_pool_get_config(domain % blocklist % configs, "config_use_column_package", config_use_column_package)
     if (config_use_column_package) &
-         call seaice_column_aggregate(domain)
+         call seaice_icepack_aggregate(domain)
 
   end subroutine init_ice_state!}}}
 
@@ -583,9 +589,9 @@ contains
     use seaice_constants, only: &
          seaiceDegreesToRadians
 
-    use ice_colpkg, only: &
-         colpkg_init_trcr, &
-         colpkg_enthalpy_snow
+    use seaice_icepack, only: &
+         seaice_icepack_init_trcr, &
+         seaice_icepack_enthalpy_snow
 
     type(block_type), intent(inout) :: &
          block !< Input/Output:
@@ -612,8 +618,8 @@ contains
          seaSurfaceTemperature, &
          seaFreezingTemperature
 
-      integer, dimension(:), pointer :: &
-           landIceMask
+    integer, dimension(:), pointer :: &
+         landIceMask
 
     real(kind=RKIND), dimension(:,:), pointer :: &
          initialSalinityProfile, &
@@ -702,7 +708,7 @@ contains
              snowVolumeCategory(1,iCategory,iCell) = min(iceAreaCategory(1,iCategory,iCell) * initialCategorySnowThickness, &
                                                          0.2_RKIND * iceVolumeCategory(1,iCategory,iCell))
 
-             call colpkg_init_trcr(&
+             call seaice_icepack_init_trcr(&
                   airTemperature(iCell), &
                   seaFreezingTemperature(iCell), &
                   initialSalinityProfile(:,iCell), &
@@ -724,7 +730,7 @@ contains
 
           surfaceTemperature(1,:,iCell) = seaFreezingTemperature(iCell)
           do iSnowLayer = 1, nSnowLayers
-             snowEnthalpy(iSnowLayer,:,iCell) = colpkg_enthalpy_snow(0.0_RKIND)
+             snowEnthalpy(iSnowLayer,:,iCell) = seaice_icepack_enthalpy_snow(0.0_RKIND)
           end do
 
        endif
@@ -769,8 +775,8 @@ contains
     use seaice_constants, only: &
          seaicePuny
 
-    use ice_colpkg, only: &
-         colpkg_init_itd
+    use seaice_icepack, only: &
+         seaice_icepack_init_itd
 
     ! Note: the resulting average ice thickness
     ! tends to be less than hbar due to the
@@ -824,7 +830,7 @@ contains
 
     if (.not. config_use_column_package) then
 
-       call colpkg_init_itd(&
+       call seaice_icepack_init_itd(&
             nCategories, &
             categoryThicknessLimits, &
             abortFlag, &
@@ -1042,9 +1048,9 @@ contains
     use seaice_constants, only: &
          seaiceDegreesToRadians
 
-    use ice_colpkg, only: &
-         colpkg_init_trcr, &
-         colpkg_enthalpy_snow
+    use seaice_icepack, only: &
+         seaice_icepack_init_trcr, &
+         seaice_icepack_enthalpy_snow
 
     type(block_type), intent(inout) :: &
          block !< Input/Output:
@@ -1072,8 +1078,8 @@ contains
          seaFreezingTemperature, &
          categoryThicknessLimits
 
-      integer, dimension(:), pointer :: &
-           landIceMask
+    integer, dimension(:), pointer :: &
+         landIceMask
 
     real(kind=RKIND), dimension(:,:), pointer :: &
          initialSalinityProfile, &
@@ -1177,7 +1183,7 @@ contains
              snowVolumeCategory(1,iCategory,iCell) = min(iceAreaCategory(1,iCategory,iCell) * initialCategorySnowThickness, &
                                                          0.2_RKIND * iceVolumeCategory(1,iCategory,iCell))
 
-             call colpkg_init_trcr(&
+             call seaice_icepack_init_trcr(&
                   airTemperature(iCell), &
                   seaFreezingTemperature(iCell), &
                   initialSalinityProfile(:,iCell), &
@@ -1199,7 +1205,7 @@ contains
 
           surfaceTemperature(1,:,iCell) = seaFreezingTemperature(iCell)
           do iSnowLayer = 1, nSnowLayers
-             snowEnthalpy(iSnowLayer,:,iCell) = colpkg_enthalpy_snow(0.0_RKIND)
+             snowEnthalpy(iSnowLayer,:,iCell) = seaice_icepack_enthalpy_snow(0.0_RKIND)
           end do
 
        endif
@@ -2083,16 +2089,14 @@ contains
 
   subroutine initialize_coupler_fields(domain)
 
-    use ice_colpkg, only: &
-         colpkg_liquidus_temperature, &
-         colpkg_init_ocean_conc
+    use seaice_icepack, only: &
+         seaice_icepack_liquidus_temperature, &
+         seaice_icepack_init_ocean_conc, &
+         seaice_icepack_initial_air_drag_coefficient
 
     use seaice_constants, only: &
          seaiceStefanBoltzmann, &
          seaiceFreshWaterFreezingPoint
-
-    use seaice_column, only: &
-         seaice_column_initial_air_drag_coefficient
 
     type(domain_type) :: domain
 
@@ -2199,7 +2203,7 @@ contains
        call MPAS_pool_get_config(block % configs, "config_do_restart", config_do_restart)
 
        do iCell = 1, nCells
-          seaFreezingTemperature(iCell) = colpkg_liquidus_temperature(seaSurfaceSalinity(iCell))
+          seaFreezingTemperature(iCell) = seaice_icepack_liquidus_temperature(seaSurfaceSalinity(iCell))
        enddo ! iCell
 
        ! sea surface temperature is not initialized if we're restarting
@@ -2221,7 +2225,7 @@ contains
 
           call MPAS_pool_get_subpool(block % structs, "drag", drag)
           call MPAS_pool_get_array(drag, "airDragCoefficient", airDragCoefficient)
-          airDragCoefficient = seaice_column_initial_air_drag_coefficient()
+          airDragCoefficient = seaice_icepack_initial_air_drag_coefficient()
 
        endif
 
@@ -2290,7 +2294,7 @@ contains
 
           do iCell = 1, nCells
 
-             call colpkg_init_ocean_conc(&
+             call seaice_icepack_init_ocean_conc(&
                   oceanAmmoniumConc(iCell), &
                   oceanDMSPConc(iCell), &
                   oceanDMSConc(iCell), &

--- a/components/mpas-seaice/src/shared/mpas_seaice_initialize.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_initialize.F
@@ -85,6 +85,9 @@ contains
     real(kind=RKIND), intent(in) :: &
          dt !< Input:
 
+    type(block_type), pointer :: &
+         block
+
     character(len=strKIND), pointer :: &
          config_column_physics_type
 
@@ -489,8 +492,8 @@ contains
     endif
 
     ! aggregate tracers even if restart
-    call MPAS_pool_get_config(domain % configs, "config_use_column_package", config_use_column_package)
-    call MPAS_pool_get_config(domain % configs, "config_column_physics_type", config_column_physics_type)
+    call MPAS_pool_get_config(domain % blocklist % configs, "config_use_column_package", config_use_column_package)
+    call MPAS_pool_get_config(domain % blocklist % configs, "config_column_physics_type", config_column_physics_type)
     if (config_use_column_package) then
        if (trim(config_column_physics_type) == "icepack") then
           call seaice_icepack_aggregate(domain)

--- a/components/mpas-seaice/src/shared/mpas_seaice_time_integration.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_time_integration.F
@@ -57,14 +57,14 @@ contains
     use seaice_advection, only: &
          seaice_run_advection
 
-    use seaice_column, only: &
-         seaice_column_predynamics_time_integration, &
-         seaice_column_dynamics_time_integration, &
-         seaice_column_postdynamics_time_integration, &
-         seaice_column_reinitialize_fluxes, &
-         seaice_column_reinitialize_diagnostics_thermodynamics, &
-         seaice_column_reinitialize_diagnostics_bgc, &
-         seaice_column_reinitialize_diagnostics_dynamics
+    use seaice_icepack, only: &
+         seaice_icepack_predynamics_time_integration, &
+         seaice_icepack_dynamics_time_integration, &
+         seaice_icepack_postdynamics_time_integration, &
+         seaice_icepack_reinitialize_fluxes, &
+         seaice_icepack_reinitialize_diagnostics_thermodynamics, &
+         seaice_icepack_reinitialize_diagnostics_bgc, &
+         seaice_icepack_reinitialize_diagnostics_dynamics
 
     use seaice_prescribed, only: &
          seaice_run_prescribed_ice
@@ -113,8 +113,8 @@ contains
 
     ! reinitialize diagnostics
     call mpas_timer_start("Reinitialize diagnostics thermodynamics/bgc")
-    call seaice_column_reinitialize_diagnostics_thermodynamics(domain)
-    call seaice_column_reinitialize_diagnostics_bgc(domain)
+    call seaice_icepack_reinitialize_diagnostics_thermodynamics(domain)
+    call seaice_icepack_reinitialize_diagnostics_bgc(domain)
     call mpas_timer_stop("Reinitialize diagnostics thermodynamics/bgc")
 
     configs => domain % configs
@@ -126,7 +126,7 @@ contains
 
     ! pre dynamics column physics
     call mpas_timer_start("Column pre-dynamics")
-    call seaice_column_predynamics_time_integration(domain, clock)
+    call seaice_icepack_predynamics_time_integration(domain, clock)
     call mpas_timer_stop("Column pre-dynamics")
 
     ! dynamics
@@ -139,7 +139,7 @@ contains
 
           ! reinitialize dynamics diagnostics
           call mpas_timer_start("Reinitialize diagnostics dynamics")
-          call seaice_column_reinitialize_diagnostics_dynamics(domain)
+          call seaice_icepack_reinitialize_diagnostics_dynamics(domain)
           call mpas_timer_stop("Reinitialize diagnostics dynamics")
 
           ! velocity solve
@@ -155,7 +155,7 @@ contains
 
           ! ridging
           call mpas_timer_start("Column")
-          call seaice_column_dynamics_time_integration(domain, clock)
+          call seaice_icepack_dynamics_time_integration(domain, clock)
           call mpas_timer_stop("Column")
 
        enddo ! iDynamicsSubcycle
@@ -163,7 +163,7 @@ contains
 
     ! shortwave
     call mpas_timer_start("Column post-dynamics")
-    call seaice_column_postdynamics_time_integration(domain, clock)
+    call seaice_icepack_postdynamics_time_integration(domain, clock)
     call mpas_timer_stop("Column post-dynamics")
 
     ! check the physical state of the model
@@ -245,13 +245,13 @@ contains
   subroutine seaice_timestep_finalize(&
        domain)!{{{
 
-    use seaice_column, only: &
-         seaice_column_reinitialize_fluxes
+    use seaice_icepack, only: &
+         seaice_icepack_reinitialize_fluxes
 
     type(domain_type), intent(in) :: &
          domain
 
-    call seaice_column_reinitialize_fluxes(domain)
+    call seaice_icepack_reinitialize_fluxes(domain)
 
   end subroutine seaice_timestep_finalize
 

--- a/components/mpas-seaice/src/shared/mpas_seaice_time_integration.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_time_integration.F
@@ -65,6 +65,14 @@ contains
          seaice_icepack_reinitialize_diagnostics_thermodynamics, &
          seaice_icepack_reinitialize_diagnostics_bgc, &
          seaice_icepack_reinitialize_diagnostics_dynamics
+    use seaice_column, only: &
+         seaice_column_predynamics_time_integration, &
+         seaice_column_dynamics_time_integration, &
+         seaice_column_postdynamics_time_integration, &
+         seaice_column_reinitialize_fluxes, &
+         seaice_column_reinitialize_diagnostics_thermodynamics, &
+         seaice_column_reinitialize_diagnostics_bgc, &
+         seaice_column_reinitialize_diagnostics_dynamics
 
     use seaice_prescribed, only: &
          seaice_run_prescribed_ice
@@ -81,9 +89,6 @@ contains
     integer, intent(in) :: &
          itimestep !< Input:
 
-    type(block_type), pointer :: &
-         block
-
     type (MPAS_pool_type), pointer :: &
          configs
 
@@ -96,6 +101,13 @@ contains
 
     integer :: &
          iDynamicsSubcycle
+
+    character(len=strKIND), pointer :: &
+         config_column_physics_type
+
+    configs => domain % configs
+
+    call MPAS_pool_get_config(configs, "config_column_physics_type", config_column_physics_type)
 
 #ifndef MPAS_PERF_MOD_TIMERS
     ! set halo timer
@@ -113,11 +125,14 @@ contains
 
     ! reinitialize diagnostics
     call mpas_timer_start("Reinitialize diagnostics thermodynamics/bgc")
-    call seaice_icepack_reinitialize_diagnostics_thermodynamics(domain)
-    call seaice_icepack_reinitialize_diagnostics_bgc(domain)
+    if (trim(config_column_physics_type) == "icepack") then
+       call seaice_icepack_reinitialize_diagnostics_thermodynamics(domain)
+       call seaice_icepack_reinitialize_diagnostics_bgc(domain)
+    else if (trim(config_column_physics_type) == "column_package") then
+       call seaice_column_reinitialize_diagnostics_thermodynamics(domain)
+       call seaice_column_reinitialize_diagnostics_bgc(domain)
+    endif ! config_column_physics_type
     call mpas_timer_stop("Reinitialize diagnostics thermodynamics/bgc")
-
-    configs => domain % configs
 
     call MPAS_pool_get_config(configs, "config_use_advection", config_use_advection)
 
@@ -126,7 +141,11 @@ contains
 
     ! pre dynamics column physics
     call mpas_timer_start("Column pre-dynamics")
-    call seaice_icepack_predynamics_time_integration(domain, clock)
+    if (trim(config_column_physics_type) == "icepack") then
+       call seaice_icepack_predynamics_time_integration(domain, clock)
+    else if (trim(config_column_physics_type) == "column_package") then
+       call seaice_column_predynamics_time_integration(domain, clock)
+    endif ! config_column_physics_type
     call mpas_timer_stop("Column pre-dynamics")
 
     ! dynamics
@@ -139,7 +158,11 @@ contains
 
           ! reinitialize dynamics diagnostics
           call mpas_timer_start("Reinitialize diagnostics dynamics")
-          call seaice_icepack_reinitialize_diagnostics_dynamics(domain)
+          if (trim(config_column_physics_type) == "icepack") then
+             call seaice_icepack_reinitialize_diagnostics_dynamics(domain)
+          else if (trim(config_column_physics_type) == "column_package") then
+             call seaice_column_reinitialize_diagnostics_dynamics(domain)
+          endif ! config_column_physics_type
           call mpas_timer_stop("Reinitialize diagnostics dynamics")
 
           ! velocity solve
@@ -155,7 +178,11 @@ contains
 
           ! ridging
           call mpas_timer_start("Column")
-          call seaice_icepack_dynamics_time_integration(domain, clock)
+          if (trim(config_column_physics_type) == "icepack") then
+             call seaice_icepack_dynamics_time_integration(domain, clock)
+          else if (trim(config_column_physics_type) == "column_package") then
+             call seaice_column_dynamics_time_integration(domain, clock)
+          endif ! config_column_physics_type
           call mpas_timer_stop("Column")
 
        enddo ! iDynamicsSubcycle
@@ -163,7 +190,11 @@ contains
 
     ! shortwave
     call mpas_timer_start("Column post-dynamics")
-    call seaice_icepack_postdynamics_time_integration(domain, clock)
+    if (trim(config_column_physics_type) == "icepack") then
+       call seaice_icepack_postdynamics_time_integration(domain, clock)
+    else if (trim(config_column_physics_type) == "column_package") then
+       call seaice_column_postdynamics_time_integration(domain, clock)
+    endif ! config_column_physics_type
     call mpas_timer_stop("Column post-dynamics")
 
     ! check the physical state of the model
@@ -247,11 +278,22 @@ contains
 
     use seaice_icepack, only: &
          seaice_icepack_reinitialize_fluxes
+    use seaice_column, only: &
+         seaice_column_reinitialize_fluxes
 
     type(domain_type), intent(in) :: &
          domain
 
-    call seaice_icepack_reinitialize_fluxes(domain)
+    character(len=strKIND), pointer :: &
+         config_column_physics_type
+
+    call MPAS_pool_get_config(domain % configs, "config_column_physics_type", config_column_physics_type)
+
+    if (trim(config_column_physics_type) == "icepack") then
+       call seaice_icepack_reinitialize_fluxes(domain)
+    else if (trim(config_column_physics_type) == "column_package") then
+       call seaice_column_reinitialize_fluxes(domain)
+    endif ! config_column_physics_type
 
   end subroutine seaice_timestep_finalize
 

--- a/components/mpas-seaice/src/shared/mpas_seaice_time_integration.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_time_integration.F
@@ -190,11 +190,15 @@ contains
 
     ! shortwave
     call mpas_timer_start("Column post-dynamics")
+#ifdef icepackON
     if (trim(config_column_physics_type) == "icepack") then
        call seaice_icepack_postdynamics_time_integration(domain, clock)
     else if (trim(config_column_physics_type) == "column_package") then
+#endif
        call seaice_column_postdynamics_time_integration(domain, clock)
+#ifdef icepackON
     endif ! config_column_physics_type
+#endif
     call mpas_timer_stop("Column post-dynamics")
 
     ! check the physical state of the model

--- a/components/mpas-seaice/src/shared/mpas_seaice_time_integration.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_time_integration.F
@@ -190,15 +190,11 @@ contains
 
     ! shortwave
     call mpas_timer_start("Column post-dynamics")
-#ifdef icepackON
     if (trim(config_column_physics_type) == "icepack") then
        call seaice_icepack_postdynamics_time_integration(domain, clock)
     else if (trim(config_column_physics_type) == "column_package") then
-#endif
        call seaice_column_postdynamics_time_integration(domain, clock)
-#ifdef icepackON
     endif ! config_column_physics_type
-#endif
     call mpas_timer_stop("Column post-dynamics")
 
     ! check the physical state of the model

--- a/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver.F
@@ -1345,6 +1345,8 @@ contains
 
     use seaice_icepack, only: &
          seaice_icepack_ice_strength
+    use seaice_column, only: &
+         seaice_column_ice_strength
 
     use seaice_constants, only: &
          seaiceIceStrengthConstantHiblerP, &
@@ -1393,8 +1395,13 @@ contains
          iCell, &
          ierr
 
+    character(len=strKIND), pointer :: &
+         config_column_physics_type
+
     block => domain % blocklist
     do while (associated(block))
+
+       call MPAS_pool_get_config(block % configs, "config_column_physics_type", config_column_physics_type)
 
        call MPAS_pool_get_config(block % configs, "config_use_column_package", config_use_column_package)
        call MPAS_pool_get_config(block % configs, "config_use_column_vertical_thermodynamics", &
@@ -1439,25 +1446,47 @@ contains
 
        else
 
-          do iCell = 1, nCellsSolve
+          if (trim(config_column_physics_type) == "icepack") then
+             do iCell = 1, nCellsSolve
 
-             icePressure(iCell) = 0.0_RKIND
+                icePressure(iCell) = 0.0_RKIND
 
-             if (solveStress(iCell) == 1) then
+                if (solveStress(iCell) == 1) then
 
-                ! this routine doesnt reset icePressure
-                call seaice_icepack_ice_strength(&
-                     nCategories, &
-                     iceAreaCell(iCell), &
-                     iceVolumeCell(iCell), &
-                     openWaterArea(iCell), &
-                     iceAreaCategory(1,:,iCell), &
-                     iceVolumeCategory(1,:,iCell), &
-                     icePressure(iCell))
+                   ! this routine doesnt reset icePressure
+                   call seaice_icepack_ice_strength(&
+                        nCategories, &
+                        iceAreaCell(iCell), &
+                        iceVolumeCell(iCell), &
+                        openWaterArea(iCell), &
+                        iceAreaCategory(1,:,iCell), &
+                        iceVolumeCategory(1,:,iCell), &
+                        icePressure(iCell))
 
-             endif ! solveStress
+                endif ! solveStress
 
-          enddo ! iCell
+             enddo ! iCell
+          else if (trim(config_column_physics_type) == "column_package") then
+             do iCell = 1, nCellsSolve
+
+                icePressure(iCell) = 0.0_RKIND
+
+                if (solveStress(iCell) == 1) then
+
+                   ! this routine doesnt reset icePressure
+                   call seaice_column_ice_strength(&
+                        nCategories, &
+                        iceAreaCell(iCell), &
+                        iceVolumeCell(iCell), &
+                        openWaterArea(iCell), &
+                        iceAreaCategory(1,:,iCell), &
+                        iceVolumeCategory(1,:,iCell), &
+                        icePressure(iCell))
+
+                endif ! solveStress
+
+             enddo ! iCell
+          endif ! config_column_physics_type
 
        endif
 

--- a/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver.F
@@ -1343,8 +1343,8 @@ contains
 
   subroutine ice_strength(domain)
 
-    use ice_colpkg, only: &
-         colpkg_ice_strength
+    use seaice_icepack, only: &
+         seaice_icepack_ice_strength
 
     use seaice_constants, only: &
          seaiceIceStrengthConstantHiblerP, &
@@ -1446,7 +1446,7 @@ contains
              if (solveStress(iCell) == 1) then
 
                 ! this routine doesnt reset icePressure
-                call colpkg_ice_strength(&
+                call seaice_icepack_ice_strength(&
                      nCategories, &
                      iceAreaCell(iCell), &
                      iceVolumeCell(iCell), &


### PR DESCRIPTION
Begins installation of Icepack as an alternative column physics package in MPAS-seaice. The new namelist flag `config_column_physics_type` chooses between them. Calls using `icepack_intfc.F90` routines activate Icepack physics.

This PR cherry-picks in changes introduced in @akturner 's branch https://github.com/akturner/E3SM/tree/akturner/mpas-seaice/icepack-integration.

[BFB] with the current branch (eclare108213/seaice/icepack-integration) with the default `config_column_physics_type = 'column_package'`.