### PR TITLE
Add Icepack's vertical thermo

### DIFF
--- a/components/mpas-seaice/bld/build-namelist
+++ b/components/mpas-seaice/bld/build-namelist
@@ -911,12 +911,8 @@ if ($surface_mode eq 'non-free') {
 } else {
         add_default($nl, 'config_ocean_surface_type', 'val'=>"free");
 }
+add_default($nl, 'config_salt_flux_coupling_type');
 add_default($nl, 'config_couple_biogeochemistry_fields');
-if ($iceberg_mode eq 'data') {
-        add_default($nl, 'config_use_data_icebergs', 'val'=>"true");
-} else {
-        add_default($nl, 'config_use_data_icebergs', 'val'=>"false");
-}
 
 ###############################
 # Namelist group: diagnostics #

--- a/components/mpas-seaice/bld/build-namelist
+++ b/components/mpas-seaice/bld/build-namelist
@@ -1230,6 +1230,7 @@ my @groups = qw(seaice_model
                 meltponds
                 thermodynamics
                 itd
+		floesize
                 ridging
                 atmosphere
                 ocean

--- a/components/mpas-seaice/bld/build-namelist
+++ b/components/mpas-seaice/bld/build-namelist
@@ -876,6 +876,12 @@ add_default($nl, 'config_congelation_ice_porosity');
 add_default($nl, 'config_itd_conversion_type');
 add_default($nl, 'config_category_bounds_type');
 
+#############################
+# Namelist group:  floesize #
+#############################
+add_default($nl, 'config_floeshape');
+add_default($nl, 'config_floediam');
+
 ###########################
 # Namelist group: ridging #
 ###########################

--- a/components/mpas-seaice/bld/build-namelist
+++ b/components/mpas-seaice/bld/build-namelist
@@ -911,6 +911,11 @@ if ($surface_mode eq 'non-free') {
 } else {
         add_default($nl, 'config_ocean_surface_type', 'val'=>"free");
 }
+if ($iceberg_mode eq 'data') {
+    add_default($nl, 'config_use_data_icebergs', 'val'=>"true");
+} else {
+    add_default($nl, 'config_use_data_icebergs', 'val'=>"false");
+}
 add_default($nl, 'config_salt_flux_coupling_type');
 add_default($nl, 'config_couple_biogeochemistry_fields');
 

--- a/components/mpas-seaice/bld/build-namelist-group-list
+++ b/components/mpas-seaice/bld/build-namelist-group-list
@@ -17,6 +17,7 @@ my @groups = qw(seaice_model
                 meltponds
                 thermodynamics
                 itd
+	        floesize	
                 ridging
                 atmosphere
                 ocean

--- a/components/mpas-seaice/bld/build-namelist-section
+++ b/components/mpas-seaice/bld/build-namelist-section
@@ -432,6 +432,7 @@ add_default($nl, 'config_sea_freezing_temperature_type');
 add_default($nl, 'config_ocean_surface_type');
 add_default($nl, 'config_couple_biogeochemistry_fields');
 add_default($nl, 'config_use_data_icebergs');
+add_default($nl, 'config_salt_fux_coupling_type');
 
 ###############################
 # Namelist group: diagnostics #

--- a/components/mpas-seaice/bld/build-namelist-section
+++ b/components/mpas-seaice/bld/build-namelist-section
@@ -399,6 +399,13 @@ add_default($nl, 'config_congelation_ice_porosity');
 add_default($nl, 'config_itd_conversion_type');
 add_default($nl, 'config_category_bounds_type');
 
+############################
+# Namelist group: floesize #
+############################
+
+add_default($nl, 'config_floeshape');
+add_default($nl, 'config_floediam');
+
 ###########################
 # Namelist group: ridging #
 ###########################

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -383,6 +383,10 @@
 <config_itd_conversion_type>'linear remap'</config_itd_conversion_type>
 <config_category_bounds_type>'original'</config_category_bounds_type>
 
+<!-- floesize -->
+<config_floeshape>0.66</config_floeshape>
+<config_floediam>300.0</config_floediam>
+
 <!-- ridging -->
 <config_ice_strength_formulation>'Rothrock75'</config_ice_strength_formulation>
 <config_ridging_participation_function>'exponential'</config_ridging_participation_function>

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -411,6 +411,7 @@
 <config_ocean_surface_type>'free'</config_ocean_surface_type>
 <config_couple_biogeochemistry_fields>false</config_couple_biogeochemistry_fields>
 <config_use_data_icebergs>false</config_use_data_icebergs>
+<config_salt_flux_coupling_type>'constant'</config_salt_flux_coupling_type>
 
 <!-- diagnostics -->
 <config_check_state>false</config_check_state>

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -391,7 +391,7 @@
 <config_ratio_ridging_work_to_PE>17.0</config_ratio_ridging_work_to_PE>
 
 <!-- atmosphere -->
-<config_atmos_boundary_method>'ccsm3'</config_atmos_boundary_method>
+<config_atmos_boundary_method>'similarity'</config_atmos_boundary_method>
 <config_calc_surface_stresses>true</config_calc_surface_stresses>
 <config_calc_surface_temperature>true</config_calc_surface_temperature>
 <config_use_form_drag>false</config_use_form_drag>

--- a/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
@@ -2571,6 +2571,14 @@ Valid values: true or false
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_salt_flux_coupling_type" type="character"
+	category="ocean" group="ocean">
+Type of salt flux to ocean method
+
+Valid values: 'constant' or 'prognostic'
+Default: Defined in namelist_defaults.xml
+</entry>
+
 
 <!-- diagnostics -->
 

--- a/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
@@ -2460,7 +2460,7 @@ Default: Defined in namelist_defaults.xml
 	category="atmosphere" group="atmosphere">
 Atmosphere boundary method.
 
-Valid values: 'ccsm3' or 'constant'
+Valid values: 'similarity' or 'constant' or 'mixed'
 Default: Defined in namelist_defaults.xml
 </entry>
 

--- a/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
@@ -2410,6 +2410,23 @@ Valid values: 'single category', 'original', 'new', 'WMO', or 'asymptotic'
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<!-- floesize -->
+
+<entry id="config_floeshape" type="real"
+	category="floesize" group="floesize">
+Floe shape constant for lateral melt.
+
+Valid values: any real value.
+Default: 0.66: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_floediam" type="real"
+	category="floesize" group="floesize">
+Effective floe diameter for lateral melt in m.
+
+Valid values: any real value
+Default: 300.0: Defined in namelist_defaults.xml
+</entry>
 
 <!-- ridging -->
 

--- a/components/mpas-seaice/src/Registry.xml
+++ b/components/mpas-seaice/src/Registry.xml
@@ -1705,6 +1705,19 @@
 			icepack_name="kcatbound"
 		/>
 	</nml_record>
+	
+	<nml_record name="floesize" in_defaults="true">
+		<nml_option name="config_floeshape" type="real" default_value="0.66" units="unitless"
+			description="Floe shape constant for lateral melt."
+			possible_values="any real number between 0 and 1"
+			icepack_name="floeshape"
+		/>
+		<nml_option name="config_floediam" type="real" default_value="300.0" units="m"
+			description="Effective floe diameter for lateral melt in m."
+			possible_values="any real number."
+			icepack_name="floediam"
+		/>
+	</nml_record>
 
 	<nml_record name="ridging" in_defaults="true">
 		<nml_option name="config_ice_strength_formulation" type="character" default_value="Rothrock75" units="unitless"

--- a/components/mpas-seaice/src/Registry.xml
+++ b/components/mpas-seaice/src/Registry.xml
@@ -1804,6 +1804,10 @@
 			description="Use data iceberg meltwater forcing"
 			possible_values="true or false"
 		/>
+		<nml_option name="config_salt_flux_coupling_type" type="character" default_value="constant" units="unitless"
+			description="Type of salt flux to ocean method"
+			possible_values="'constant', or 'prognostic'"
+		/>
 	</nml_record>
 
 	<nml_record name="diagnostics" in_defaults="true">
@@ -3801,6 +3805,11 @@
 		     dimensions="nCells Time"
 		     units="C"
 		/>
+		<var name="bottomTemperature"
+		     type="real"
+		     dimensions="nCells Time"
+		     units="C"
+		/>
 		<var name="freezingMeltingPotential"
 		     type="real"
 		     dimensions="nCells Time"
@@ -4323,6 +4332,11 @@
 		     dimensions="nCells Time"
 		     units="1"
 		/>
+		<var name="lateralHeatFlux"
+		     type="real"
+		     dimensions="nCells Time"
+		     units="W m-2"
+		/>
 		<var name="surfaceIceMelt"
 		     type="real"
 		     dimensions="nCells Time"
@@ -4386,6 +4400,11 @@
 		<var name="snowThicknessChangeCategory"
 		     type="real"
 		     dimensions="nCategories nCells Time"
+		     units="m s-1"
+		/>
+		<var name="snowThicknessChangeCell"
+		     type="real"
+		     dimensions="nCells Time"
 		     units="m s-1"
 		/>
 		<var name="frazilFormation"
@@ -4452,6 +4471,16 @@
 		     dimensions="nCells Time"
 		     units="kg m-2 s-1"
 		/>
+		<var name="evaporativeWaterFluxSnow"
+		     type="real"
+		     dimensions="nCells Time"
+		     units="kg m-2 s-1"
+		/>
+		<var name="evaporativeWaterFluxIce"
+		     type="real"
+		     dimensions="nCells Time"
+		     units="kg m-2 s-1"
+		/>
 	</var_struct>
 
 	<!-- fluxes with the ocean -->
@@ -4499,6 +4528,16 @@
 		<var name="oceanHeatFluxIceBottom"
 		     type="real"
 		     dimensions="nCells Time"
+		     units="W m-2"
+		/>
+		<var name="bottomConductiveFlux"
+		     type="real"
+		     dimensions="nCells Time"
+		     units="W m-2"
+		/>
+		<var name="bottomConductiveFluxCategory"
+		     type="real"
+		     dimensions="nCategories nCells Time"
 		     units="W m-2"
 		/>
 	</var_struct>
@@ -5431,6 +5470,11 @@
 		     type="real"
 		     dimensions="nCells Time"
 		     units="day"
+		/>
+		<var name="snowIceInterfaceTemperature"
+		     type="real"
+		     dimensions="nCells Time"
+		     units="C"
 		/>
 		<var name="iceAreaTendencyTransport"
 		     type="real"

--- a/components/mpas-seaice/src/Registry.xml
+++ b/components/mpas-seaice/src/Registry.xml
@@ -1735,9 +1735,9 @@
 	</nml_record>
 
 	<nml_record name="atmosphere" in_defaults="true">
-		<nml_option name="config_atmos_boundary_method" type="character" default_value="ccsm3" units="unitless"
+		<nml_option name="config_atmos_boundary_method" type="character" default_value="similarity" units="unitless"
 			description="Atmosphere boundary method."
-			possible_values="'ccsm3' or 'constant'"
+			possible_values="'similarity' or 'constant' or 'mixed'"
 			icepack_name="atmbndy"
 		/>
 		<nml_option name="config_calc_surface_stresses" type="logical" default_value="true" units="unitless"

--- a/components/mpas-seaice/src/shared/mpas_seaice_column.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_column.F
@@ -10014,8 +10014,9 @@ contains
 
     ! check config_atmos_boundary_method value
     if (.not. (trim(config_atmos_boundary_method) == "ccsm3" .or. &
-               trim(config_atmos_boundary_method) == "constant")) then
-       call config_error("config_atmos_boundary_method", config_atmos_boundary_method, "'ccsm3' or 'constant'")
+               trim(config_atmos_boundary_method) == "constant" .or. &
+               trim(config_atmos_boundary_method) == "similarity")) then  ! similarity = ccsm3 = default
+       call config_error("config_atmos_boundary_method", config_atmos_boundary_method, "'similarity' or 'constant' or 'cccsm3'")
     endif
 
     ! check config_itd_conversion_type value

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -215,6 +215,9 @@ contains
 
   subroutine seaice_init_icepack_physics_package_parameters(domain)
 
+    use icepack_intfc, only: &
+         icepack_configure
+
     type(domain_type), intent(inout) :: domain
 
     logical, pointer :: &
@@ -222,6 +225,9 @@ contains
 
     call MPAS_pool_get_config(domain % configs, "config_use_column_package", config_use_column_package)
     if (config_use_column_package) then
+
+       ! configure icepack before any other part of it is called
+       call icepack_configure ()
 
        ! set non activated variable pointers to other memory
        call init_column_non_activated_pointers(domain)
@@ -381,9 +387,9 @@ contains
 
   subroutine init_column_thermodynamic_profiles(domain)
 
-    use ice_colpkg, only: &
-         colpkg_init_thermo, &
-         colpkg_liquidus_temperature
+    use ice_colpkg, only: &             !echmod - remove
+         colpkg_init_thermo, &          !echmod - remove
+         colpkg_liquidus_temperature    !echmod - remove
     use icepack_intfc, only: &
          icepack_init_thermo, &
          icepack_liquidus_temperature
@@ -419,9 +425,9 @@ contains
 
        allocate(initialSalinityProfileVertical(1:nIceLayers+1))
 
-       call colpkg_init_thermo(&
-            nIceLayers, &
-            initialSalinityProfileVertical)
+       call colpkg_init_thermo(&              !echmod - remove
+            nIceLayers, &                     !echmod - remove
+            initialSalinityProfileVertical)   !echmod - remove
        call icepack_init_thermo(&
             nIceLayers, &
             initialSalinityProfileVertical)
@@ -12492,30 +12498,6 @@ contains
          seaicePi, &                         ! pi
          seaiceGravity, &                    ! gravitational acceleration (m/s^2)
          seaiceSnowPatchiness, &             ! snow patchiness parameter
-         seaiceIceStrengthConstantHiblerP, & ! P* constant in Hibler strength formulation
-         seaiceIceStrengthConstantHiblerC, & ! C* constant in Hibler strength formulation
-         skeletalLayerThickness              ! skeletal layer thickness
-
-    use seaice_constants, only: &
-         pii, &                              ! pi
-         seaicePuny, &                       ! a small number
-         seaiceSecondsPerDay, &              ! number of seconds in 1 day
-         seaiceDensityIce, &                 ! density of ice (kg/m^3)
-         seaiceDensitySnow, &                ! density of snow (kg/m^3)
-         seaiceDensitySeaWater, &            ! density of seawater (kg/m^3)
-         seaiceDensityFreshwater, &          ! density of freshwater (kg/m^3)
-         seaiceAirSpecificHeat, &            ! specific heat of air (J/kg/K)
-         seaiceSeaWaterSpecificHeat, &       ! specific heat of ocn (J/kg/K)
-         seaiceLatentHeatSublimation, &      ! latent heat, sublimation freshwater (J/kg)
-         seaiceStefanBoltzmann, &            ! J m-2 K-4 s-1
-         seaiceIceSnowEmissivity, &          ! emissivity of snow and ice
-         seaiceStabilityReferenceHeight, &   ! stability reference height (m)
-         seaiceFreshWaterFreezingPoint, &    ! freezing temp of fresh ice (K)
-         seaiceIceOceanDragCoefficient, &    ! ice ocean drag coefficient
-         seaiceIceSurfaceRoughness, &        ! ice surface roughness (m)
-         seaiceVonKarmanConstant, &          ! Von Karman constant
-         seaiceOceanAlbedo, &                ! Ocean albedo
-         seaiceGravity, &                    ! gravitational acceleration (m/s^2)
          seaiceIceStrengthConstantHiblerP, & ! P* constant in Hibler strength formulation
          seaiceIceStrengthConstantHiblerC, & ! C* constant in Hibler strength formulation
          skeletalLayerThickness              ! skeletal layer thickness

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -384,6 +384,9 @@ contains
     use ice_colpkg, only: &
          colpkg_init_thermo, &
          colpkg_liquidus_temperature
+    use icepack_intfc, only: &
+         icepack_init_thermo, &
+         icepack_liquidus_temperature
 
     type(domain_type), intent(inout) :: domain
 
@@ -419,6 +422,9 @@ contains
        call colpkg_init_thermo(&
             nIceLayers, &
             initialSalinityProfileVertical)
+       call icepack_init_thermo(&
+            nIceLayers, &
+            initialSalinityProfileVertical)
 
        call MPAS_pool_get_subpool(block % structs, "initial", initial)
 
@@ -431,7 +437,7 @@ contains
              ! these profiles are not used by mushy
              initialSalinityProfile(iIceLayer,iCell)           = initialSalinityProfileVertical(iIceLayer)
              initialMeltingTemperatureProfile(iIceLayer,iCell) = &
-                  colpkg_liquidus_temperature(initialSalinityProfileVertical(iIceLayer))
+                  icepack_liquidus_temperature(initialSalinityProfileVertical(iIceLayer))
 
           enddo ! iIceLayer
        enddo ! iCell
@@ -879,7 +885,8 @@ contains
 
   subroutine init_column_thermodynamic_tracers(domain)
 
-    use ice_colpkg, only: colpkg_init_trcr
+    use icepack_intfc, only: &
+         icepack_init_trcr
 
     type(domain_type), intent(inout) :: domain
 
@@ -943,7 +950,7 @@ contains
        do iCell = 1, nCellsSolve
           do iCategory = 1, nCategories
 
-             call colpkg_init_trcr(&
+             call icepack_init_trcr(&
                   airTemperature(iCell), &
                   seaFreezingTemperature(iCell), &
                   initialSalinityProfile(:,iCell), &
@@ -1294,9 +1301,10 @@ contains
 
   subroutine column_vertical_thermodynamics(domain, clock)
 
-    use ice_colpkg, only: &
-         colpkg_step_therm1, &
-         colpkg_clear_warnings
+    use icepack_intfc, only: &
+         icepack_step_therm1, &
+         icepack_warnings_clear, &
+         icepack_warnings_aborted
 
     use seaice_constants, only: &
          seaicePuny
@@ -1396,10 +1404,12 @@ contains
          seaSurfaceTemperature, &
          seaSurfaceSalinity, &
          seaFreezingTemperature, &
+         bottomTemperature, &
          oceanStressCellU, &
          oceanStressCellV, &
          freezingMeltingPotential, &
          lateralIceMeltFraction, &
+         lateralHeatFlux, &
          snowfallRate, &
          rainfallRate, &
          pondFreshWaterFlux, &
@@ -1412,19 +1422,24 @@ contains
          sensibleHeatFlux, &
          latentHeatFlux, &
          evaporativeWaterFlux, &
+         evaporativeWaterFluxSnow, &
+         evaporativeWaterFluxIce, &
          oceanFreshWaterFlux, &
          oceanSaltFlux, &
          oceanHeatFlux, &
          oceanShortwaveFlux, &
+         bottomConductiveFlux, &
          surfaceIceMelt, &
          basalIceMelt, &
          lateralIceMelt, &
          snowMelt, &
          congelation, &
          snowiceFormation, &
+         snowThicknessChangeCell, &
          frazilFormation, &
          meltOnset, &
          freezeOnset, &
+         snowIceInterfaceTemperature, &
          oceanHeatFluxIceBottom, &
          openWaterArea, &
          snowLossToLeads, &
@@ -1450,6 +1465,7 @@ contains
          pondLidMeltFluxFraction, &
          surfaceHeatFluxCategory, &
          surfaceConductiveFluxCategory, &
+         bottomConductiveFluxCategory, &
          latentHeatFluxCouple, &
          sensibleHeatFluxCouple, &
          surfaceHeatFluxCouple, &
@@ -1614,6 +1630,7 @@ contains
 
        call MPAS_pool_get_array(ocean_coupling, "seaSurfaceTemperature", seaSurfaceTemperature)
        call MPAS_pool_get_array(ocean_coupling, "seaSurfaceSalinity", seaSurfaceSalinity)
+       call MPAS_pool_get_array(ocean_coupling, "bottomTemperature", bottomTemperature)
        call MPAS_pool_get_array(ocean_coupling, "freezingMeltingPotential", freezingMeltingPotential)
        call MPAS_pool_get_array(ocean_coupling, "seaFreezingTemperature", seaFreezingTemperature)
 
@@ -1637,6 +1654,7 @@ contains
        call MPAS_pool_get_array(drag, "dragFloeSeparation", dragFloeSeparation)
 
        call MPAS_pool_get_array(melt_growth_rates, "lateralIceMeltFraction", lateralIceMeltFraction)
+       call MPAS_pool_get_array(melt_growth_rates, "lateralHeatFlux", lateralHeatFlux)
        call MPAS_pool_get_array(melt_growth_rates, "surfaceIceMelt", surfaceIceMelt)
        call MPAS_pool_get_array(melt_growth_rates, "surfaceIceMeltCategory", surfaceIceMeltCategory)
        call MPAS_pool_get_array(melt_growth_rates, "basalIceMelt", basalIceMelt )
@@ -1648,6 +1666,7 @@ contains
        call MPAS_pool_get_array(melt_growth_rates, "congelationCategory", congelationCategory)
        call MPAS_pool_get_array(melt_growth_rates, "snowiceFormation", snowiceFormation)
        call MPAS_pool_get_array(melt_growth_rates, "snowiceFormationCategory", snowiceFormationCategory)
+       call MPAS_pool_get_array(melt_growth_rates, "snowThicknessChangeCell", snowThicknessChangeCell)
        call MPAS_pool_get_array(melt_growth_rates, "snowThicknessChangeCategory", snowThicknessChangeCategory)
        call MPAS_pool_get_array(melt_growth_rates, "frazilFormation", frazilFormation)
 
@@ -1661,12 +1680,16 @@ contains
        call MPAS_pool_get_array(atmos_fluxes, "latentHeatFlux", latentHeatFlux)
        call MPAS_pool_get_array(atmos_fluxes, "latentHeatFluxCategory", latentHeatFluxCategory)
        call MPAS_pool_get_array(atmos_fluxes, "evaporativeWaterFlux", evaporativeWaterFlux)
+       call MPAS_pool_get_array(atmos_fluxes, "evaporativeWaterFluxSnow", evaporativeWaterFluxSnow)
+       call MPAS_pool_get_array(atmos_fluxes, "evaporativeWaterFluxIce", evaporativeWaterFluxIce)
 
        call MPAS_pool_get_array(ocean_fluxes, "oceanFreshWaterFlux", oceanFreshWaterFlux)
        call MPAS_pool_get_array(ocean_fluxes, "oceanSaltFlux", oceanSaltFlux)
        call MPAS_pool_get_array(ocean_fluxes, "oceanHeatFlux", oceanHeatFlux)
        call MPAS_pool_get_array(ocean_fluxes, "oceanShortwaveFlux", oceanShortwaveFlux)
        call MPAS_pool_get_array(ocean_fluxes, "oceanHeatFluxIceBottom", oceanHeatFluxIceBottom)
+       call MPAS_pool_get_array(ocean_fluxes, "bottomConductiveFlux", bottomConductiveFlux)
+       call MPAS_pool_get_array(ocean_fluxes, "bottomConductiveFluxCategory", bottomConductiveFluxCategory)
 
        call MPAS_pool_get_array(shortwave, "surfaceShortwaveFlux", surfaceShortwaveFlux)
        call MPAS_pool_get_array(shortwave, "interiorShortwaveFlux", interiorShortwaveFlux)
@@ -1685,6 +1708,7 @@ contains
 
        call MPAS_pool_get_array(diagnostics, "meltOnset", meltOnset)
        call MPAS_pool_get_array(diagnostics, "freezeOnset", freezeOnset)
+       call MPAS_pool_get_array(diagnostics, "snowIceInterfaceTemperature", snowIceInterfaceTemperature)
 
        call MPAS_pool_get_array(snow, "snowLossToLeads", snowLossToLeads)
        call MPAS_pool_get_array(snow, "snowMeltMassCell", snowMeltMassCell)
@@ -1759,141 +1783,142 @@ contains
              northernHemisphereMask = .false.
           endif
 
-          call colpkg_clear_warnings()
-          call colpkg_step_therm1(&
-               config_dt, &
-               nCategories, &
-               nIceLayers, &
-               nSnowLayers, &
-               nAerosols, &
-               openWaterArea(iCell), &
-               iceAreaCategoryInitial(:,iCell), &
-               iceVolumeCategoryInitial(:,iCell), &
-               snowVolumeCategoryInitial(:,iCell), &
-               iceAreaCell(iCell), &
-               iceAreaCategory(1,:,iCell), &
-               iceVolumeCell(iCell), &
-               iceVolumeCategory(1,:,iCell), &
-               snowVolumeCell(iCell), &
-               snowVolumeCategory(1,:,iCell), &
-               uVelocityCell(iCell), &
-               vVelocityCell(iCell), &
-               surfaceTemperature(1,:,iCell), &
-               snowEnthalpy(:,:,iCell), &
-               iceEnthalpy(:,:,iCell), &
-               iceSalinity(:,:,iCell), &
-               snowIceMass(:,:,iCell), &
-               snowLiquidMass(:,:,iCell), &
-               levelIceArea(1,:,iCell), &
-               levelIceVolume(1,:,iCell), &
-               pondArea(1,:,iCell), &
-               pondDepth(1,:,iCell), &
-               pondLidThickness(1,:,iCell), &
-               iceAge(1,:,iCell), &
-               firstYearIceArea(1,:,iCell), &
-               snowGrainRadius(:,:,iCell), &
-               config_use_snow_liquid_ponds, &
-               specificSnowAerosol(:,:,:), &
-               specificIceAerosol(:,:,:), &
-               uAirVelocity(iCell), &
-               vAirVelocity(iCell), &
-               windSpeed(iCell), &
-               airLevelHeight(iCell), &
-               airSpecificHumidity(iCell), &
-               airDensity(iCell), &
-               airTemperature(iCell), &
-               atmosReferenceTemperature2m(iCell), &
-               atmosReferenceHumidity2m(iCell), &
-               atmosReferenceSpeed10m(iCell), &
-               airOceanDragCoefficientRatio(iCell), &
-               oceanDragCoefficient(iCell), &
-               oceanDragCoefficientSkin(iCell), &
-               oceanDragCoefficientFloe(iCell), &
-               oceanDragCoefficientKeel(iCell), &
-               airDragCoefficient(iCell), &
-               airDragCoefficientSkin(iCell), &
-               airDragCoefficientFloe(iCell), &
-               airDragCoefficientPond(iCell), &
-               airDragCoefficientRidge(iCell), &
-               dragFreeboard(iCell), &
-               dragIceSnowDraft(iCell), &
-               dragRidgeHeight(iCell), &
-               dragRidgeSeparation(iCell), &
-               dragKeelDepth(iCell), &
-               dragKeelSeparation(iCell), &
-               dragFloeLength(iCell), &
-               dragFloeSeparation(iCell), &
-               airStressForcingU(iCell), &
-               airStressForcingV(iCell), &
-               airStressCellU(iCell), &
-               airStressCellV(iCell), &
-               airPotentialTemperature(iCell), &
-               seaSurfaceTemperature(iCell), &
-               seaSurfaceSalinity(iCell), &
-               seaFreezingTemperature(iCell), &
-               oceanStressCellU(iCell), &
-               oceanStressCellV(iCell), &
-               oceanHeatFluxIceBottom(iCell), &
-               freezingMeltingPotential(iCell), &
-               lateralIceMeltFraction(iCell), &
-               snowfallRate(iCell), &
-               rainfallRate(iCell), &
-               pondFreshWaterFlux(iCell), &
-               snowLossToLeads(iCell), &
-               surfaceHeatFlux(iCell), &
-               surfaceHeatFluxCategory(:,iCell), &
-               surfaceConductiveFlux(iCell), &
-               surfaceConductiveFluxCategory(:,iCell), &
-               surfaceShortwaveFlux(:,iCell), &
-               interiorShortwaveFlux(:,iCell), &
-               penetratingShortwaveFlux(:,iCell), &
-               absorbedShortwaveFlux(iCell), &
-               longwaveUp(iCell), &
-               absorbedShortwaveSnowLayer(:,:,iCell), &
-               absorbedShortwaveIceLayer(:,:,iCell), &
-               longwaveDown(iCell), &
-               solarZenithAngleCosine(iCell), &
-               sensibleHeatFlux(iCell), &
-               sensibleHeatFluxCategory(:,iCell), &
-               latentHeatFlux(iCell), &
-               latentHeatFluxCategory(:,iCell), &
-               evaporativeWaterFlux(iCell), &
-               oceanFreshWaterFlux(iCell), &
-               oceanSaltFlux(iCell), &
-               oceanHeatFlux(iCell), &
-               oceanShortwaveFlux(iCell), &
-               latentHeatFluxCouple(:,iCell), &
-               sensibleHeatFluxCouple(:,iCell), &
-               surfaceHeatFluxCouple(:,iCell), &
-               surfaceConductiveFluxCouple(:,iCell), &
-               atmosAerosolFlux(:,iCell), &
-               oceanAerosolFlux(:,iCell), &
-               pondSnowDepthDifference(:,iCell), &
-               pondLidMeltFluxFraction(:,iCell), &
-               surfaceIceMelt(iCell), &
-               surfaceIceMeltCategory(:,iCell), &
-               basalIceMelt(iCell), &
-               basalIceMeltCategory(:,iCell), &
-               lateralIceMelt(iCell), &
-               snowMelt(iCell), &
-               snowMeltCategory(:,iCell), &
-               snowMeltMassCell(iCell), &
-               snowMeltMassCategory(:,iCell), &
-               congelation(iCell), &
-               congelationCategory(:,iCell), &
-               snowiceFormation(iCell), &
-               snowiceFormationCategory(:,iCell), &
-               snowThicknessChangeCategory(:,iCell), &
-               frazilFormation(iCell), &
-               northernHemisphereMask, &
-               .not. northernHemisphereMask, &
-               meltOnset(iCell), &
-               freezeOnset(iCell), &
-               dayOfYear, &
-               abortFlag, &
-               abortMessage, &
-               config_use_prescribed_ice)
-          call column_write_warnings(abortFlag)
+          call icepack_warnings_clear()
+          call icepack_step_therm1(&
+               dt=config_dt, &
+               ncat=nCategories, &
+               nilyr=nIceLayers, &
+               nslyr=nSnowLayers, &
+               aicen_init=iceAreaCategoryInitial(:,iCell), &
+               vicen_init=iceVolumeCategoryInitial(:,iCell), &
+               vsnon_init=snowVolumeCategoryInitial(:,iCell), &
+               aice=iceAreaCell(iCell), &
+               aicen=iceAreaCategory(1,:,iCell), &
+               vice=iceVolumeCell(iCell), &
+               vicen=iceVolumeCategory(1,:,iCell), &
+               vsno=snowVolumeCell(iCell), &
+               vsnon=snowVolumeCategory(1,:,iCell), &
+               uvel=uVelocityCell(iCell), &
+               vvel=vVelocityCell(iCell), &
+               Tsfc=surfaceTemperature(1,:,iCell), &
+               zqsn=snowEnthalpy(:,:,iCell), &
+               zqin=iceEnthalpy(:,:,iCell), &
+               zSin=iceSalinity(:,:,iCell), &
+               alvl=levelIceArea(1,:,iCell), &
+               vlvl=levelIceVolume(1,:,iCell), &
+               apnd=pondArea(1,:,iCell), &
+               hpnd=pondDepth(1,:,iCell), &
+               ipnd=pondLidThickness(1,:,iCell), &
+               iage=iceAge(1,:,iCell), &
+               FY=firstYearIceArea(1,:,iCell), &
+               aerosno=specificSnowAerosol(:,:,:), &
+               aeroice=specificIceAerosol(:,:,:), &
+               uatm=uAirVelocity(iCell), &
+               vatm=vAirVelocity(iCell), &
+               wind=windSpeed(iCell), &
+               zlvl=airLevelHeight(iCell), &
+               Qa=airSpecificHumidity(iCell), &
+               rhoa=airDensity(iCell), &
+               Tair=airTemperature(iCell), &
+               Tref=atmosReferenceTemperature2m(iCell), &
+               Qref=atmosReferenceHumidity2m(iCell), &
+               Uref=atmosReferenceSpeed10m(iCell), &
+               Cdn_atm_ratio=airOceanDragCoefficientRatio(iCell), &
+               Cdn_ocn=oceanDragCoefficient(iCell), &
+               Cdn_ocn_skin=oceanDragCoefficientSkin(iCell), &
+               Cdn_ocn_floe=oceanDragCoefficientFloe(iCell), &
+               Cdn_ocn_keel=oceanDragCoefficientKeel(iCell), &
+               Cdn_atm=airDragCoefficient(iCell), &
+               Cdn_atm_skin=airDragCoefficientSkin(iCell), &
+               Cdn_atm_floe=airDragCoefficientFloe(iCell), &
+               Cdn_atm_pond=airDragCoefficientPond(iCell), &
+               Cdn_atm_rdg=airDragCoefficientRidge(iCell), &
+               hfreebd=dragFreeboard(iCell), &
+               hdraft=dragIceSnowDraft(iCell), &
+               hridge=dragRidgeHeight(iCell), &
+               distrdg=dragRidgeSeparation(iCell), &
+               hkeel=dragKeelDepth(iCell), &
+               dkeel=dragKeelSeparation(iCell), &
+               lfloe=dragFloeLength(iCell), &
+               dfloe=dragFloeSeparation(iCell), &
+               strax=airStressForcingU(iCell), &
+               stray=airStressForcingV(iCell), &
+               strairxT=airStressCellU(iCell), &
+               strairyT=airStressCellV(iCell), &
+               potT=airPotentialTemperature(iCell), &
+               sst=seaSurfaceTemperature(iCell), &
+               sss=seaSurfaceSalinity(iCell), &
+               Tf=seaFreezingTemperature(iCell), &
+               strocnxT=oceanStressCellU(iCell), &
+               strocnyT=oceanStressCellV(iCell), &
+               fbot=oceanHeatFluxIceBottom(iCell), &
+               Tbot=bottomTemperature(iCell), &
+               Tsnice=snowIceInterfaceTemperature(iCell), &
+               frzmlt=freezingMeltingPotential(iCell), &
+               rside=lateralIceMeltFraction(iCell), &
+               fside=lateralHeatFlux(iCell), &
+               fsnow=snowfallRate(iCell), &
+               frain=rainfallRate(iCell), &
+               fpond=pondFreshWaterFlux(iCell), &
+               fsloss=snowLossToLeads(iCell), &
+               fsurf=surfaceHeatFlux(iCell), &
+               fsurfn=surfaceHeatFluxCategory(:,iCell), &
+               fcondtop=surfaceConductiveFlux(iCell), &
+               fcondtopn=surfaceConductiveFluxCategory(:,iCell), &
+               fcondbot=bottomConductiveFlux(iCell), &
+               fcondbotn=bottomConductiveFluxCategory(:,iCell), &
+               fswsfcn=surfaceShortwaveFlux(:,iCell), &
+               fswintn=interiorShortwaveFlux(:,iCell), &
+               fswthrun=penetratingShortwaveFlux(:,iCell), & ! Wrong dimensions?
+               fswabs=absorbedShortwaveFlux(iCell), &
+               flwout=longwaveUp(iCell), &
+               Sswabsn=absorbedShortwaveSnowLayer(:,:,iCell), &
+               Iswabsn=absorbedShortwaveIceLayer(:,:,iCell), &
+               flw=longwaveDown(iCell), &
+               fsens=sensibleHeatFlux(iCell), &
+               fsensn=sensibleHeatFluxCategory(:,iCell), &
+               flat=latentHeatFlux(iCell), &
+               flatn=latentHeatFluxCategory(:,iCell), &
+               evap=evaporativeWaterFlux(iCell), &
+               evaps=evaporativeWaterFluxSnow(iCell), &
+               evapi=evaporativeWaterFluxIce(iCell), &
+               fresh=oceanFreshWaterFlux(iCell), &
+               fsalt=oceanSaltFlux(iCell), &
+               fhocn=oceanHeatFlux(iCell), &
+               fswthru=oceanShortwaveFlux(iCell), & !??
+               flatn_f=latentHeatFluxCouple(:,iCell), &
+               fsensn_f=sensibleHeatFluxCouple(:,iCell), &
+               fsurfn_f=surfaceHeatFluxCouple(:,iCell), &
+               fcondtopn_f=surfaceConductiveFluxCouple(:,iCell) , &
+               faero_atm=atmosAerosolFlux(:,iCell), &
+               faero_ocn=oceanAerosolFlux(:,iCell), &
+               dhsn=pondSnowDepthDifference(:,iCell), &
+               ffracn=pondLidMeltFluxFraction(:,iCell), &
+               meltt=surfaceIceMelt(iCell), &
+               melttn=surfaceIceMeltCategory(:,iCell), &
+               meltb=basalIceMelt(iCell), &
+               meltbn=basalIceMeltCategory(:,iCell), &
+               melts=snowMelt(iCell), &
+               meltsn=snowMeltCategory(:,iCell), &
+               congel=congelation(iCell), &
+               congeln=congelationCategory(:,iCell), &
+               snoice=snowiceFormation(iCell), &
+               snoicen=snowiceFormationCategory(:,iCell), &
+               dsnow=snowThicknessChangeCell(iCell), &
+               dsnown=snowThicknessChangeCategory(:,iCell), &
+               meltsliq=snowMeltMassCell(iCell), &
+               meltsliqn=snowMeltMassCategory(:,iCell), &
+               rsnwn=snowGrainRadius(:,:,iCell), &
+               smicen=snowIceMass(:,:,iCell), &
+               smliqn=snowLiquidMass(:,:,iCell), &
+               lmask_n=northernHemisphereMask, &
+               lmask_s=(.not. northernHemisphereMask), &
+               mlt_onset=meltOnset(iCell), &
+               frz_onset=freezeOnset(iCell), &
+               yday=dayOfYear, &
+               prescribed_ice=config_use_prescribed_ice)
+          abortFlag = icepack_warnings_aborted()
+          call seaice_icepack_write_warnings(abortFlag)
 
           ! cell-specific abort message
           if (abortFlag) then
@@ -4721,7 +4746,7 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_ratio_C_to_N_proteins", config_ratio_C_to_N_proteins)
 
     if (config_use_ocean_mixed_layer) &
-         call seaice_column_ocean_mixed_layer(domain)
+         call seaice_icepack_ocean_mixed_layer(domain)
 
     block => domain % blocklist
     do while (associated(block))
@@ -5537,6 +5562,243 @@ contains
 
   end subroutine seaice_column_ocean_mixed_layer
 
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  seaice_icepack_ocean_mixed_layer
+!
+!> \brief
+!> \author Adrian K. Turner, LANL
+!> \date 6th April
+!> \details
+!>
+!
+!-----------------------------------------------------------------------
+
+  subroutine seaice_icepack_ocean_mixed_layer(domain)
+
+    use icepack_intfc, only: &
+         icepack_atm_boundary, &
+         icepack_ocn_mixed_layer
+
+    use seaice_constants, only: &
+         seaiceOceanAlbedo
+
+    type(domain_type) :: domain
+
+    type(block_type), pointer :: block
+
+    type(MPAS_pool_type), pointer :: &
+         oceanCoupling, &
+         atmosCoupling, &
+         atmosForcing, &
+         tracersAggregate, &
+         drag, &
+         oceanFluxes, &
+         oceanAtmosphere
+
+    real(kind=RKIND), dimension(:), pointer :: &
+         seaSurfaceTemperature, &
+         seaFreezingTemperature, &
+         oceanMixedLayerDepth, &
+         oceanHeatFluxConvergence, &
+         airPotentialTemperature, &
+         airSpecificHumidity, &
+         uAirVelocity, &
+         vAirVelocity, &
+         windSpeed, &
+         airLevelHeight, &
+         airDensity, &
+         longwaveDown, &
+         iceAreaCell, &
+         freezingMeltingPotential, &
+         shortwaveVisibleDirectDown, &
+         shortwaveVisibleDiffuseDown, &
+         shortwaveIRDirectDown, &
+         shortwaveIRDiffuseDown, &
+         airDragCoefficient, &
+         airOceanDragCoefficientRatio, &
+         oceanHeatFlux, &
+         oceanShortwaveFlux, &
+         airStressOceanU, &
+         airStressOceanV, &
+         atmosReferenceTemperature2mOcean, &
+         atmosReferenceHumidity2mOcean, &
+         longwaveUpOcean, &
+         sensibleHeatFluxOcean, &
+         latentHeatFluxOcean, &
+         evaporativeWaterFluxOcean, &
+         albedoVisibleDirectOcean, &
+         albedoIRDirectOcean, &
+         albedoVisibleDiffuseOcean, &
+         albedoIRDiffuseOcean
+
+    real(kind=RKIND) :: &
+         sensibleTransferCoefficient, &
+         latentTransferCoefficient, &
+         potentialTemperatureDifference, &
+         specificHumidityDifference
+
+    real(kind=RKIND), pointer :: &
+         config_dt
+
+    integer :: &
+         iCell
+
+    integer, pointer :: &
+         nCellsSolve
+
+    integer, dimension(:), pointer :: &
+           landIceMask
+
+    logical, pointer :: &
+         config_use_test_ice_shelf
+
+    call MPAS_pool_get_config(domain % configs, "config_dt", config_dt)
+
+    block => domain % blocklist
+    do while (associated(block))
+
+       call MPAS_pool_get_subpool(block % structs, "ocean_coupling", oceanCoupling)
+       call MPAS_pool_get_subpool(block % structs, "atmos_coupling", atmosCoupling)
+       call MPAS_pool_get_subpool(block % structs, "atmos_forcing", atmosForcing)
+       call MPAS_pool_get_subpool(block % structs, "tracers_aggregate", tracersAggregate)
+       call MPAS_pool_get_subpool(block % structs, "drag", drag)
+       call MPAS_pool_get_subpool(block % structs, "ocean_fluxes", oceanFluxes)
+       call MPAS_pool_get_subpool(block % structs, "ocean_atmosphere", oceanAtmosphere)
+
+       call MPAS_pool_get_dimension(oceanCoupling, "nCellsSolve", nCellsSolve)
+
+       call MPAS_pool_get_array(oceanCoupling, "seaSurfaceTemperature", seaSurfaceTemperature)
+       call MPAS_pool_get_array(oceanCoupling, "seaFreezingTemperature", seaFreezingTemperature)
+       call MPAS_pool_get_array(oceanCoupling, "freezingMeltingPotential", freezingMeltingPotential)
+       call MPAS_pool_get_array(oceanCoupling, "oceanMixedLayerDepth", oceanMixedLayerDepth)
+       call MPAS_pool_get_array(oceanCoupling, "oceanHeatFluxConvergence", oceanHeatFluxConvergence)
+
+       call MPAS_pool_get_array(atmosCoupling, "airPotentialTemperature", airPotentialTemperature)
+       call MPAS_pool_get_array(atmosCoupling, "uAirVelocity", uAirVelocity)
+       call MPAS_pool_get_array(atmosCoupling, "vAirVelocity", vAirVelocity)
+       call MPAS_pool_get_array(atmosCoupling, "airLevelHeight", airLevelHeight)
+       call MPAS_pool_get_array(atmosCoupling, "airSpecificHumidity", airSpecificHumidity)
+       call MPAS_pool_get_array(atmosCoupling, "airDensity", airDensity)
+       call MPAS_pool_get_array(atmosCoupling, "longwaveDown", longwaveDown)
+       call MPAS_pool_get_array(atmosCoupling, "shortwaveVisibleDirectDown", shortwaveVisibleDirectDown)
+       call MPAS_pool_get_array(atmosCoupling, "shortwaveVisibleDiffuseDown", shortwaveVisibleDiffuseDown)
+       call MPAS_pool_get_array(atmosCoupling, "shortwaveIRDirectDown", shortwaveIRDirectDown)
+       call MPAS_pool_get_array(atmosCoupling, "shortwaveIRDiffuseDown", shortwaveIRDiffuseDown)
+
+       call MPAS_pool_get_array(atmosForcing, "windSpeed", windSpeed)
+
+       call MPAS_pool_get_array(tracersAggregate, "iceAreaCell", iceAreaCell)
+
+       call MPAS_pool_get_array(drag, "airDragCoefficient", airDragCoefficient)
+       call MPAS_pool_get_array(drag, "airOceanDragCoefficientRatio", airOceanDragCoefficientRatio)
+
+       call MPAS_pool_get_array(oceanFluxes, "oceanHeatFlux", oceanHeatFlux)
+       call MPAS_pool_get_array(oceanFluxes, "oceanShortwaveFlux", oceanShortwaveFlux)
+
+       call MPAS_pool_get_array(oceanAtmosphere, "airStressOceanU", airStressOceanU)
+       call MPAS_pool_get_array(oceanAtmosphere, "airStressOceanV", airStressOceanV)
+       call MPAS_pool_get_array(oceanAtmosphere, "atmosReferenceTemperature2mOcean", atmosReferenceTemperature2mOcean)
+       call MPAS_pool_get_array(oceanAtmosphere, "atmosReferenceHumidity2mOcean", atmosReferenceHumidity2mOcean)
+       call MPAS_pool_get_array(oceanAtmosphere, "albedoVisibleDirectOcean", albedoVisibleDirectOcean)
+       call MPAS_pool_get_array(oceanAtmosphere, "albedoVisibleDiffuseOcean", albedoVisibleDiffuseOcean)
+       call MPAS_pool_get_array(oceanAtmosphere, "albedoIRDirectOcean", albedoIRDirectOcean)
+       call MPAS_pool_get_array(oceanAtmosphere, "albedoIRDiffuseOcean", albedoIRDiffuseOcean)
+       call MPAS_pool_get_array(oceanAtmosphere, "longwaveUpOcean", longwaveUpOcean)
+       call MPAS_pool_get_array(oceanAtmosphere, "sensibleHeatFluxOcean", sensibleHeatFluxOcean)
+       call MPAS_pool_get_array(oceanAtmosphere, "latentHeatFluxOcean", latentHeatFluxOcean)
+       call MPAS_pool_get_array(oceanAtmosphere, "evaporativeWaterFluxOcean", evaporativeWaterFluxOcean)
+
+       do iCell = 1, nCellsSolve
+          call icepack_atm_boundary(&
+               sfctype='ocn', &
+               Tsf=seaSurfaceTemperature(iCell), &
+               potT=airPotentialTemperature(iCell), &
+               uatm=uAirVelocity(iCell), &
+               vatm=vAirVelocity(iCell), &
+               wind=windSpeed(iCell), &
+               zlvl=airLevelHeight(iCell), &
+               Qa=airSpecificHumidity(iCell), &
+               rhoa=airDensity(iCell), &
+               strx=airStressOceanU(iCell), &
+               stry=airStressOceanV(iCell), &
+               Tref=atmosReferenceTemperature2mOcean(iCell), &
+               Qref=atmosReferenceHumidity2mOcean(iCell), &
+               delt=potentialTemperatureDifference, &
+               delq=specificHumidityDifference, &
+               lhcoef=latentTransferCoefficient, &
+               shcoef=sensibleTransferCoefficient, &
+               Cdn_atm=airDragCoefficient(iCell), &
+               Cdn_atm_ratio_n=airOceanDragCoefficientRatio(iCell))
+
+          albedoVisibleDirectOcean(iCell)  = seaiceOceanAlbedo
+          albedoIRDirectOcean(iCell)       = seaiceOceanAlbedo
+          albedoVisibleDiffuseOcean(iCell) = seaiceOceanAlbedo
+          albedoIRDiffuseOcean(iCell)      = seaiceOceanAlbedo
+
+          call icepack_ocn_mixed_layer(&
+               alvdr_ocn=albedoVisibleDirectOcean(iCell), &
+               swvdr=shortwaveVisibleDirectDown(iCell), &
+               alidr_ocn=albedoIRDirectOcean(iCell), &
+               swidr=shortwaveIRDirectDown(iCell), &
+               alvdf_ocn=albedoVisibleDiffuseOcean(iCell), &
+               swvdf=shortwaveVisibleDiffuseDown(iCell), &
+               alidf_ocn=albedoIRDiffuseOcean(iCell), &
+               swidf=shortwaveIRDiffuseDown(iCell), &
+               sst=seaSurfaceTemperature(iCell), &
+               flwout_ocn=longwaveUpOcean(iCell), &
+               fsens_ocn=sensibleHeatFluxOcean(iCell), &
+               shcoef=sensibleTransferCoefficient, &
+               flat_ocn=latentHeatFluxOcean(iCell), &
+               lhcoef=latentTransferCoefficient, &
+               evap_ocn=evaporativeWaterFluxOcean(iCell), &
+               flw=longwaveDown(iCell), &
+               delt=potentialTemperatureDifference, &
+               delq=specificHumidityDifference, &
+               aice=iceAreaCell(iCell), &
+               fhocn=oceanHeatFlux(iCell), &
+               fswthru=oceanShortwaveFlux(iCell), &
+               hmix=oceanMixedLayerDepth(iCell), &
+               Tf=seaFreezingTemperature(iCell), &
+               qdp=oceanHeatFluxConvergence(iCell), &
+               frzmlt=freezingMeltingPotential(iCell), &
+               dt=config_dt)
+
+       enddo ! iCell
+
+       block => block % next
+    enddo
+
+    ! remove frazil from below ice shelves if were testing that
+    call MPAS_pool_get_config(domain % configs, "config_use_test_ice_shelf", config_use_test_ice_shelf)
+
+    if (config_use_test_ice_shelf) then
+
+       block => domain % blocklist
+       do while (associated(block))
+
+          call MPAS_pool_get_subpool(block % structs, "ocean_coupling", oceanCoupling)
+
+          call MPAS_pool_get_array(oceanCoupling, "freezingMeltingPotential", freezingMeltingPotential)
+          call MPAS_pool_get_array(oceanCoupling, "landIceMask", landIceMask)
+
+          call MPAS_pool_get_dimension(oceanCoupling, "nCellsSolve", nCellsSolve)
+
+          do iCell = 1, nCellsSolve
+
+             if (landIceMask(iCell) == 1) then
+                freezingMeltingPotential(iCell) = 0.0_RKIND
+             endif
+
+          enddo ! iCell
+
+          block => block % next
+       enddo
+
+    endif !
+
+  end subroutine seaice_icepack_ocean_mixed_layer
+
 !-----------------------------------------------------------------------
 ! Other passthrough functions to column package
 !-----------------------------------------------------------------------
@@ -5552,8 +5814,8 @@ contains
        iceEnthalpy, &
        snowEnthalpy)
 
-    use ice_colpkg, only: &
-         colpkg_init_trcr
+    use icepack_intfc, only: &
+         icepack_init_trcr
 
     integer, intent(in) :: &
          nIceLayers, & ! number of ice layers
@@ -5574,7 +5836,7 @@ contains
          iceEnthalpy, & ! ice enthalpy profile (J/m3)
          snowEnthalpy   ! snow enthalpy profile (J/m3)
 
-    call colpkg_init_trcr(airTemperature, &
+    call icepack_init_trcr(airTemperature, &
          seaFreezingTemperature, &
          initialSalinityProfile, &
          initialMeltingTemperatureProfile, &
@@ -5811,7 +6073,7 @@ contains
 ! initialize constants
 !-----------------------------------------------------------------------
 
-  subroutine seaice_init_icepack_constants()
+  subroutine seaice_init_column_constants()
 
     use seaice_constants, only: &
          seaiceGravity, &
@@ -5883,6 +6145,87 @@ contains
     seaiceIceOceanDragCoefficient    = dragio
     skeletalLayerThickness           = sk_l
     gramsCarbonPerMolCarbon          = R_gC2molC
+
+    iceAreaMinimum       = seaicePuny
+    iceThicknessMinimum  = seaicePuny
+    snowThicknessMinimum = seaicePuny
+
+  end subroutine seaice_init_column_constants
+
+!-----------------------------------------------------------------------
+
+  subroutine seaice_init_icepack_constants()
+
+    use seaice_constants, only: &
+         seaiceGravity, &
+         seaicePuny, &
+         seaiceDensityIce, &
+         seaiceDensitySnow, &
+         seaiceDensitySeaWater, &
+         seaiceDensityFreshwater, &
+         seaiceStefanBoltzmann, &
+         seaiceIceSnowEmissivity, &
+         seaiceFreshWaterFreezingPoint, &
+         seaiceAirSpecificHeat, &
+         seaiceLatentHeatSublimation, &
+         seaiceLatentHeatMelting, &
+         seaiceOceanAlbedo, &
+         seaiceVonKarmanConstant, &
+         seaiceIceSurfaceRoughness, &
+         seaiceStabilityReferenceHeight, &
+         seaiceIceStrengthConstantHiblerP, &
+         seaiceIceStrengthConstantHiblerC, &
+         seaiceIceOceanDragCoefficient, &
+         skeletalLayerThickness, &
+         gramsCarbonPerMolCarbon, &
+         iceAreaMinimum, &
+         iceThicknessMinimum, &
+         snowThicknessMinimum
+
+    use icepack_parameters, only: &
+         gravit, &
+         rhoi, &
+         rhos, &
+         rhow, &
+         puny, &
+         stefan_boltzmann, &
+         emissivity, &
+         Tffresh, &
+         cp_air, &
+         Lsub, &
+         Lfresh, &
+         Pstar, &
+         Cstar, &
+         dragio, &
+         albocn, &
+         rhofresh, &
+         vonkar, &
+         iceruf, &
+         zref, &
+         sk_l!, &
+         !R_gC2molC
+
+    seaiceGravity                    = gravit
+    seaicePuny                       = puny
+    seaiceDensityIce                 = rhoi
+    seaiceDensitySnow                = rhos
+    seaiceDensitySeaWater            = rhow
+    seaiceDensityFreshwater          = rhofresh
+    seaiceStefanBoltzmann            = stefan_boltzmann
+    seaiceIceSnowEmissivity          = emissivity
+    seaiceFreshWaterFreezingPoint    = Tffresh
+    seaiceAirSpecificHeat            = cp_air
+    seaiceLatentHeatSublimation      = Lsub
+    seaiceLatentHeatMelting          = Lfresh
+    seaiceOceanAlbedo                = albocn
+    seaiceVonKarmanConstant          = vonkar
+    seaiceIceSurfaceRoughness        = iceruf
+    seaiceStabilityReferenceHeight   = zref
+    seaiceIceStrengthConstantHiblerP = Pstar
+    seaiceIceStrengthConstantHiblerC = Cstar
+    seaiceIceOceanDragCoefficient    = dragio
+    skeletalLayerThickness           = sk_l
+    !gramsCarbonPerMolCarbon          = R_gC2molC
 
     iceAreaMinimum       = seaicePuny
     iceThicknessMinimum  = seaicePuny
@@ -9477,6 +9820,7 @@ contains
          config_itd_conversion_type, &
          config_category_bounds_type, &
          config_pond_refreezing_type, &
+         config_salt_flux_coupling_type, &
          config_ocean_heat_transfer_type, &
          config_sea_freezing_temperature_type
 
@@ -9536,6 +9880,7 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_itd_conversion_type", config_itd_conversion_type)
     call MPAS_pool_get_config(domain % configs, "config_category_bounds_type", config_category_bounds_type)
     call MPAS_pool_get_config(domain % configs, "config_pond_refreezing_type", config_pond_refreezing_type)
+    call MPAS_pool_get_config(domain % configs, "config_salt_flux_coupling_type", config_salt_flux_coupling_type)
     call MPAS_pool_get_config(domain % configs, "config_calc_surface_stresses", config_calc_surface_stresses)
     call MPAS_pool_get_config(domain % configs, "config_calc_surface_temperature", config_calc_surface_temperature)
     call MPAS_pool_get_config(domain % configs, "config_max_meltwater_retained_fraction", config_max_meltwater_retained_fraction)
@@ -9645,6 +9990,11 @@ contains
     if (.not. (trim(config_pond_refreezing_type) == "cesm" .or. &
                trim(config_pond_refreezing_type) == "hlid")) then
        call config_error("config_pond_refreezing_type", config_pond_refreezing_type, "'cesm' or 'hlid'")
+    endif
+
+    ! check config_salt_flux_coupling_type
+    if (.not. trim(config_salt_flux_coupling_type) == "constant") then
+       call config_error("config_salt_flux_coupling_type", config_salt_flux_coupling_type, "'constant'")
     endif
 
     ! check for consistency in snow vertical dimension
@@ -12170,6 +12520,7 @@ contains
          config_itd_conversion_type, &
          config_category_bounds_type, &
          config_pond_refreezing_type, &
+         config_salt_flux_coupling_type, &
          config_ocean_heat_transfer_type, &
          config_sea_freezing_temperature_type, &
          config_skeletal_bgc_flux_type, &
@@ -12408,6 +12759,7 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_category_bounds_type", config_category_bounds_type)
     call MPAS_pool_get_config(domain % configs, "config_snow_to_ice_transition_depth", config_snow_to_ice_transition_depth)
     call MPAS_pool_get_config(domain % configs, "config_pond_refreezing_type", config_pond_refreezing_type)
+    call MPAS_pool_get_config(domain % configs, "config_salt_flux_coupling_type", config_salt_flux_coupling_type)
     call MPAS_pool_get_config(domain % configs, "config_pond_flushing_timescale", config_pond_flushing_timescale)
     call MPAS_pool_get_config(domain % configs, "config_min_meltwater_retained_fraction", config_min_meltwater_retained_fraction)
     call MPAS_pool_get_config(domain % configs, "config_max_meltwater_retained_fraction", config_max_meltwater_retained_fraction)
@@ -12687,6 +13039,7 @@ contains
          kcatbound_in            = config_category_bounds_type_int, &
          hs0_in                  = config_snow_to_ice_transition_depth, &
          frzpnd_in               = config_pond_refreezing_type, &
+         saltflux_option_in      = config_salt_flux_coupling_type, &
          !floeshape_in            = , &
          !wave_spec_in            = , &
          !wave_spec_type_in       = , &

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -6182,7 +6182,12 @@ contains
          iceThicknessMinimum, &
          snowThicknessMinimum
 
-    use icepack_parameters, only: &
+!echmod: These constants will need to be defined in the MPAS-SI driver (or a shared E3SM constants file) 
+!echmod: eventually, rather than in the old column package. For now, use the column package's values.
+!echmod: If E3SM/MPAS-SI wants to use icepack's default values (not recommended), then they should be 
+!echmod: obtained using icepack_query_parameters instead of 'using' them.  In that case, initializing 
+!echmod: them with the icepack_init_parameters call is unnecessary.
+    use ice_constants_colpkg, only: &  ! for E3SM runs this is currently in src/column/constants/cesm/
          gravit, &
          rhoi, &
          rhos, &
@@ -9965,9 +9970,10 @@ contains
     endif
 
     ! check config_atmos_boundary_method value
-    if (.not. (trim(config_atmos_boundary_method) == "ccsm3" .or. &
-               trim(config_atmos_boundary_method) == "constant")) then
-       call config_error("config_atmos_boundary_method", config_atmos_boundary_method, "'ccsm3' or 'constant'")
+    if (.not. (trim(config_atmos_boundary_method) == "similarity" .or. &
+               trim(config_atmos_boundary_method) == "constant" .or. &
+               trim(config_atmos_boundary_method) == "mixed")) then
+       call config_error("config_atmos_boundary_method", config_atmos_boundary_method, "'similarity' or 'constant' or 'mixed'")
     endif
 
     ! check config_itd_conversion_type value
@@ -12505,6 +12511,30 @@ contains
     use icepack_intfc, only: &
          icepack_init_parameters
 
+    use seaice_constants, only: &
+         pii, &                              ! pi
+         seaicePuny, &                       ! a small number
+         seaiceSecondsPerDay, &              ! number of seconds in 1 day
+         seaiceDensityIce, &                 ! density of ice (kg/m^3)
+         seaiceDensitySnow, &                ! density of snow (kg/m^3)
+         seaiceDensitySeaWater, &            ! density of seawater (kg/m^3)
+         seaiceDensityFreshwater, &          ! density of freshwater (kg/m^3)
+         seaiceAirSpecificHeat, &            ! specific heat of air (J/kg/K)
+         seaiceSeaWaterSpecificHeat, &       ! specific heat of ocn (J/kg/K)
+         seaiceLatentHeatSublimation, &      ! latent heat, sublimation freshwater (J/kg)
+         seaiceStefanBoltzmann, &            ! J m-2 K-4 s-1
+         seaiceIceSnowEmissivity, &          ! emissivity of snow and ice
+         seaiceStabilityReferenceHeight, &   ! stability reference height (m)
+         seaiceFreshWaterFreezingPoint, &    ! freezing temp of fresh ice (K)
+         seaiceIceOceanDragCoefficient, &    ! ice ocean drag coefficient
+         seaiceIceSurfaceRoughness, &        ! ice surface roughness (m)
+         seaiceVonKarmanConstant, &          ! Von Karman constant
+         seaiceOceanAlbedo, &                ! Ocean albedo
+         seaiceGravity, &                    ! gravitational acceleration (m/s^2)
+         seaiceIceStrengthConstantHiblerP, & ! P* constant in Hibler strength formulation
+         seaiceIceStrengthConstantHiblerC, & ! C* constant in Hibler strength formulation
+         skeletalLayerThickness              ! skeletal layer thickness
+
     type(domain_type), intent(inout) :: &
          domain
 
@@ -12936,50 +12966,50 @@ contains
 
     call icepack_init_parameters(&
          !argcheck_in             = , &
-         !puny_in                 = , &
+!         puny_in                 = seaicePuny, &
          !bignum_in               = , &
-         !pi_in                   = , &
-         !secday_in               = , &
-         !rhos_in                 = , &
-         !rhoi_in                 = , &
-         !rhow_in                 = , &
-         !cp_air_in               = , &
-         !emissivity_in           = , &
+!         pi_in                   = pii, &
+!         secday_in               = seaiceSecondsPerDay, &
+!         rhos_in                 = seaiceDensitySnow, &
+!         rhoi_in                 = seaiceDensityIce, &
+!         rhow_in                 = seaiceDensitySeaWater, &
+!         cp_air_in               = seaiceAirSpecificHeat, &
+!         emissivity_in           = seaiceIceSnowEmissivity, &
          !cp_ice_in               = , &
-         !cp_ocn_in               = , &
+!         cp_ocn_in               = seaiceSeaWaterSpecificHeat, &
          !hfrazilmin_in           = , &
          !floediam_in             = , &
          !depressT_in             = , &
-         !dragio_in               = , &
+!         dragio_in               = seaiceIceOceanDragCoefficient, &
          !thickness_ocn_layer1_in = , &
-         !iceruf_ocn_in           = , &
-         !albocn_in               = , &
-         !gravit_in               = , &
+!         iceruf_ocn_in           = seaiceIceSurfaceRoughness, &
+!         albocn_in               = seaiceOceanAlbedo, &
+!         gravit_in               = seaiceGravity, &
          !viscosity_dyn_in        = , &
          !Tocnfrz_in              = , &
-         !rhofresh_in             = , &
+!         rhofresh_in             = seaiceDensityFreshwater, &
          !zvir_in                 = , &
-         !vonkar_in               = , &
+!         vonkar_in               = seaiceVonKarmanConstant, &
          !cp_wv_in                = , &
-         !stefan_boltzmann_in     = , &
+!         stefan_boltzmann_in     = seaiceStefanBoltzmann, &
          !ice_ref_salinity_in     = , &
-         !Tffresh_in              = , &
-         !Lsub_in                 = , &
+!         Tffresh_in              = seaiceFreshWaterFreezingPoint, &
+!         Lsub_in                 = seaiceLatentHeatSublimation, &
          !Lvap_in                 = , &
          !Timelt_in               = , &
          !Tsmelt_in               = , &
          !iceruf_in               = , &
          Cf_in                   = config_ratio_ridging_work_to_PE, &
-         !Pstar_in                = , &
-         !Cstar_in                = , &
+!         Pstar_in                = seaiceIceStrengthConstantHiblerP, &
+!         Cstar_in                = seaiceIceStrengthConstantHiblerC, &
          !kappav_in               = , &
          !kice_in                 = , &
          !ksno_in                 = , &
-         !zref_in                 = , &
+!         zref_in                 = seaiceStabilityReferenceHeight, &
          !hs_min_in               = , &
          !snowpatch_in            = , &
          !rhosi_in                = , &
-         !sk_l_in                 = , &
+!         sk_l_in                 = skeletalLayerThickness, &
          !saltmax_in              = , &
          !phi_init_in             = , &
          !min_salin_in            = , &
@@ -13089,15 +13119,14 @@ contains
          !sw_frac_in              = , &
          !sw_dtemp_in             = , &
          snwgrain_in             = config_use_snow_grain_radius &
-         !snwredist_in            = , &
-         !use_smliq_pnd_in        = , &
-         !rsnw_fall_in            = , &
-         !rsnw_tmax_in            = , &
-         !rhosnew_in              = , &
-         !rhosmin_in              = , &
-         !rhosmax_in              = , &
-         !windmin_in              = , &
-         !drhosdwind_in           = , &
+         !snwredist_in            = config_snow_redistribution_scheme, &
+         !use_smliq_pnd_in        = config_use_snow_liquid_ponds, &
+         !rsnw_fall_in            = config_fallen_snow_radius, &
+         !rsnw_tmax_in            = config_max_dry_snow_radius, &
+         !rhosnew_in              = config_new_snow_density, &
+         !rhosmax_in              = config_max_snow_density, &
+         !windmin_in              = config_minimum_wind_compaction, &
+         !drhosdwind_in           = config_wind_compaction_factor), &
          !snwlvlfac_in            = , &
          !isnw_T_in               = , &
          !isnw_Tgrd_in            = , &
@@ -13109,87 +13138,14 @@ contains
          !snowage_kappa_in        = , &
          !snowage_drdt0_in        = , &
          !snw_aging_table_in      = , &
-         !snw_ssp_table_in        = , &
-         !ssp_snwextdr_in         = , &
-         !ssp_snwextdf_in         = , &
-         !ssp_snwalbdr_in         = , &
-         !ssp_snwalbdf_in         = , &
-         !ssp_sasymmdr_in         = , &
-         !ssp_sasymmdf_in         = , &
-         !ssp_aasymmmd_in         = , &
-         !ssp_aerextmd_in         = , &
-         !ssp_aeralbmd_in         = , &
-         !ssp_abcenhmd_in         = , &
-         !ssp_aasymm_in           = , &
-         !ssp_aerext_in           = , &
-         !ssp_aeralb_in           =
          )
 
-
-
-    !call icepack_init_parameters(&
-    !     ktherm                = config_thermodynamics_type_int, &
-    !     conduct               = config_heat_conductivity_type, &
-    !     fbot_xfer_type        = config_ocean_heat_transfer_type, &
-    !     calc_Tsfc             = config_calc_surface_temperature, &
-    !     ustar_min             = config_min_friction_velocity, &
-    !     a_rapid_mode          = config_rapid_mode_channel_radius, &
-    !     Rac_rapid_mode        = config_rapid_model_critical_Ra, &
-    !     aspect_rapid_mode     = config_rapid_mode_aspect_ratio, &
-    !     dSdt_slow_mode        = config_slow_mode_drainage_strength, &
-    !     phi_c_slow_mode       = config_slow_mode_critical_porosity, &
-    !     phi_i_mushy           = config_congelation_ice_porosity, &
-    !     shortwave             = config_shortwave_type, &
-    !     albedo_type           = config_albedo_type, &
-    !     albicev               = config_visible_ice_albedo, &
-    !     albicei               = config_infrared_ice_albedo, &
-    !     albsnowv              = config_visible_snow_albedo, &
-    !     albsnowi              = config_infrared_snow_albedo, &
-    !     ahmax                 = config_variable_albedo_thickness_limit, &
-    !     R_ice                 = config_ice_shortwave_tuning_parameter, &
-    !     R_pnd                 = config_pond_shortwave_tuning_parameter, &
-    !     R_snw                 = config_snow_shortwave_tuning_parameter, &
-    !     dT_mlt                = config_temp_change_snow_grain_radius_change, &
-    !     rsnw_mlt              = config_max_melting_snow_grain_radius, &
-    !     kalg                  = config_algae_absorption_coefficient, &
-    !     kstrength             = config_ice_strength_formulation_int, &
-    !     krdg_partic           = config_ridging_participation_function_int, &
-    !     krdg_redist           = config_ridging_redistribution_function_int, &
-    !     mu_rdg                = config_ridiging_efolding_scale, &
-    !     Cf                    = config_ratio_ridging_work_to_PE, &
-    !     atmbndy               = config_atmos_boundary_method, &
-    !     calc_strair           = config_calc_surface_stresses, &
-    !     formdrag              = config_use_form_drag, &
-    !     highfreq              = config_use_high_frequency_coupling, &
-    !     natmiter              = config_boundary_layer_iteration_number, &
-    !     oceanmixed_ice        = config_use_ocean_mixed_layer, &
-    !     tfrz_option           = config_sea_freezing_temperature_type, &!
-    !     kitd                  = config_itd_conversion_type_int, &
-    !     kcatbound             = config_category_bounds_type_int, &
-    !     hs0                   = config_snow_to_ice_transition_depth, &
-    !     frzpnd                = config_pond_refreezing_type, &
-    !     dpscale               = config_pond_flushing_timescale, &
-    !     rfracmin              = config_min_meltwater_retained_fraction, &
-    !     rfracmax              = config_max_meltwater_retained_fraction, &
-    !     pndaspect             = config_pond_depth_to_fraction_ratio, &
-    !     hs1                   = config_snow_on_pond_ice_tapering_parameter, &
-    !     hp1                   = config_critical_pond_ice_thickness, &
-    !     bgc_flux_type         = config_skeletal_bgc_flux_type, &
-    !     z_tracers             = config_use_vertical_tracers, &
-    !     scale_bgc             = config_scale_initial_vertical_bgc, &
-    !     solve_zbgc            = config_use_vertical_biochemistry, &
-    !     dEdd_algae            = config_use_shortwave_bioabsorption, &
-    !     modal_aero            = config_use_modal_aerosols, &!
-    !     skl_bgc               = config_use_skeletal_biochemistry, &
-    !     solve_zsal            = config_use_vertical_zsalinity, &
-    !     grid_o                = config_biogrid_bottom_molecular_sublayer, &
-    !     l_sk                  = config_bio_gravity_drainage_length_scale, &
-    !     grid_o_t              = config_biogrid_top_molecular_sublayer, &
-    !     initbio_frac          = config_new_ice_fraction_biotracer, &
-    !     frazil_scav           = config_fraction_biotracer_in_frazil, &
-    !     grid_oS               = config_zsalinity_molecular_sublayer, &!
-    !     l_skS                 = config_zsalinity_gravity_drainage_scale, &!
-    !     phi_snow              = config_snow_porosity_at_ice_surface, &!
+! parameters that have not yet been fully implemented in the list above
+    !call icepack_init_parameters(& 
+    !     shortwave             = config_shortwave_type, &         ! not working correctly above
+    !     oceanmixed_ice        = config_use_ocean_mixed_layer, &  ! not used in Icepack/columnphysics (driver only)
+    !     grid_o_t              = config_biogrid_top_molecular_sublayer, &  ! not used in Icepack
+    !     frazil_scav           = config_fraction_biotracer_in_frazil, &    ! BGC 
     !     ratio_Si2N_diatoms    = config_ratio_Si_to_N_diatoms, &
     !     ratio_Si2N_sp         = config_ratio_Si_to_N_small_plankton, &
     !     ratio_Si2N_phaeo      = config_ratio_Si_to_N_phaeocystis, &
@@ -13305,14 +13261,6 @@ contains
     !     F_abs_chl_sp          = config_scales_absorption_small_plankton, &
     !     F_abs_chl_phaeo       = config_scales_absorption_phaeocystis, &
     !     ratio_C2N_proteins    = config_ratio_C_to_N_proteins, &
-    !     snwredist             = config_snow_redistribution_scheme, &
-    !     use_smliq_pnd         = config_use_snow_liquid_ponds, &
-    !     rsnw_fall             = config_fallen_snow_radius, &
-    !     rsnw_tmax             = config_max_dry_snow_radius, &
-    !     rhosnew               = config_new_snow_density, &
-    !     rhosmax               = config_max_snow_density, &
-    !     windmin               = config_minimum_wind_compaction, &
-    !     drhosdwind            = config_wind_compaction_factor)
 
     !-----------------------------------------------------------------------
     ! Parameters for thermodynamics
@@ -13463,7 +13411,7 @@ contains
     !-----------------------------------------------------------------------
 
     ! atmbndy:
-    ! atmo boundary method, 'default' ('ccsm3') or 'constant'
+    ! atmo boundary method, 'similarity' or 'constant' or 'mixed'
     !atmbndy = config_atmos_boundary_method
 
     ! calc_strair:

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -13242,7 +13242,7 @@ contains
          !snw_aging_table_in      = , &
          )
 
-!note that icepack_recomput_constants, called from icepck_init_parameters above, recomputes Lfresh
+!note that icepack_recompute_constants, called from icepck_init_parameters above, recomputes Lfresh
 ! - make Lfresh optional for E3SM?
 
     call mpas_log_write(" ----- compare values after icepack init -----")


### PR DESCRIPTION
Adds needed arguments and calls step_therm1 from Icepack.
Adds `config_salt_flux_coupling_type`, `config_floesize` and `config_floeshape`.
Adjusts values for `config_atmos_boundary_method` to those used in Icepack.
Adds mixed layer routine for Icepack.

[non-BFB]
Tested in D-cases with `config_column_physics_type='icepack'` and `'column_package'`, and will be further tested using CICE-QC.

Thanks to @akturner and @erinethomas for code contributions, and to @darincomeau for CICE-QC testing.