### PR TITLE
Update Icepack warnings calls, cori-haswell pes

### DIFF
--- a/components/mpas-seaice/cime_config/config_pes.xml
+++ b/components/mpas-seaice/cime_config/config_pes.xml
@@ -101,7 +101,22 @@
         </nthrds>
       </pes>
     </mach>
-    <mach name="theta|pm-gpu|cori-knl|cori-haswell|jlse">
+    <mach name="cori-haswell">
+      <pes compset="any" pesize="any">
+        <comment>seaice: default, 256 pes, 32 pes/node</comment>
+        <ntasks>
+          <ntasks_atm>256</ntasks_atm>
+          <ntasks_lnd>256</ntasks_lnd>
+          <ntasks_rof>256</ntasks_rof>
+          <ntasks_ice>256</ntasks_ice>
+          <ntasks_ocn>256</ntasks_ocn>
+          <ntasks_glc>256</ntasks_glc>
+          <ntasks_wav>256</ntasks_wav>
+          <ntasks_cpl>256</ntasks_cpl>
+        </ntasks>
+      </pes>
+    </mach>
+    <mach name="theta|pm-gpu|cori-knl|jlse">
       <pes compset="any" pesize="any">
         <comment>seaice: default, 1 node x MAX_MPITASKS_PER_NODE mpi x 1 omp @ root 0</comment>
         <ntasks>

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -12953,7 +12953,7 @@ contains
          !sw_redist_in            = , &        ! not yet implemented in MPAS-SI (stealth feature)
          !sw_frac_in              = , &        ! not yet implemented in MPAS-SI (stealth feature)
          !sw_dtemp_in             = , &        ! not yet implemented in MPAS-SI (stealth feature)
-         snwgrain_in             = config_use_snow_grain_radius &
+         snwgrain_in             = config_use_snow_grain_radius, &
          !snwredist_in            = config_snow_redistribution_scheme, &
          !use_smliq_pnd_in        = config_use_snow_liquid_ponds, &
          !rsnw_fall_in            = config_fallen_snow_radius, &
@@ -12974,19 +12974,6 @@ contains
          !snowage_drdt0_in        = , &
          !snw_aging_table_in      = , &
          snw_ssp_table_in        = tmp_config_snw_ssp_table &
-         !ssp_snwextdr_in         = , &
-         !ssp_snwextdf_in         = , &
-         !ssp_snwalbdr_in         = , &
-         !ssp_snwalbdf_in         = , &
-         !ssp_sasymmdr_in         = , &
-         !ssp_sasymmdf_in         = , &
-         !ssp_aasymmmd_in         = , &
-         !ssp_aerextmd_in         = , &
-         !ssp_aeralbmd_in         = , &
-         !ssp_abcenhmd_in         = , &
-         !ssp_aasymm_in           = , &
-         !ssp_aerext_in           = , &
-         !ssp_aeralb_in           =
          )
     call seaice_icepack_write_warnings(seaice_icepack_aborted())
 

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -16,7 +16,7 @@ module seaice_icepack
   use mpas_pool_routines
   use mpas_timekeeping
   use mpas_timer
-  use mpas_log, only: mpas_log_write
+  use mpas_log, only: mpas_log_write, mpas_log_info
 
   use seaice_error
 
@@ -729,6 +729,7 @@ contains
          config_do_restart
 
     call icepack_init_radiation()
+    call seaice_icepack_write_warnings(seaice_icepack_aborted())
 
     call MPAS_pool_get_config(domain % configs, "config_shortwave_type", config_shortwave_type)
     call MPAS_pool_get_config(domain % configs, "config_do_restart", config_do_restart)
@@ -742,12 +743,14 @@ contains
        call colpkg_init_orbit(&
             abortFlag, &
             abortMessage)
-       call icepack_init_orbit()
        call column_write_warnings(abortFlag)
 
        if (abortFlag) then
           call mpas_log_write("colpkg_init_orbit: "//trim(abortMessage), messageType=MPAS_LOG_CRIT)
-      endif
+       endif
+
+       call icepack_init_orbit()
+       call seaice_icepack_write_warnings(seaice_icepack_aborted())
 
     endif
 
@@ -2620,6 +2623,8 @@ contains
        block => block % next
     end do
 
+    call seaice_icepack_write_warnings(seaice_icepack_aborted())
+
   end subroutine column_prep_radiation
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
@@ -2882,8 +2887,7 @@ contains
   subroutine column_radiation(domain, clock, lInitialization)
 
     use icepack_intfc, only: &
-         icepack_step_radiation, &
-         icepack_warnings_clear
+         icepack_step_radiation
     use seaice_constants, only: &
          pii
 
@@ -3179,7 +3183,6 @@ contains
           call set_cice_tracer_array_category(block, ciceTracerObject, &
                  tracerArrayCategory, iCell, setGetPhysicsTracers, setGetBGCTracers)
 
-          call icepack_warnings_clear()
           call icepack_step_radiation(&
                dt=config_dt, &
                swgrid=verticalShortwaveGrid(:), &
@@ -3252,6 +3255,8 @@ contains
 
        block => block % next
     end do
+
+    call seaice_icepack_write_warnings(seaice_icepack_aborted())
 
   end subroutine column_radiation
 
@@ -5813,6 +5818,9 @@ contains
 
   subroutine seaice_init_icepack_constants()
 
+    use icepack_intfc, only: &
+         icepack_configure
+
     use seaice_constants, only: &
          seaicePi, &
          seaiceGravity, &
@@ -5886,6 +5894,9 @@ contains
          snowpatch, &
          sk_l!, &
          !R_gC2molC
+
+    call icepack_configure()
+    call seaice_icepack_write_warnings(seaice_icepack_aborted())
 
     seaicePi                         = pi
     seaiceGravity                    = gravit
@@ -10131,6 +10142,7 @@ contains
          tr_bgc_Fe_in    = config_use_iron, &
          tr_bgc_hum_in   = config_use_humics, &
          tr_bgc_PON_in   = config_use_nonreactive)
+    call seaice_icepack_write_warnings(seaice_icepack_aborted())
 
   end subroutine init_icepack_package_tracer_flags
 
@@ -10221,6 +10233,7 @@ contains
          !ntrcr_o_in   = , &
          nbtrcr_in    = tracerObject % nBioTracers, &
          nbtrcr_sw_in = tracerObject % nBioTracersShortwave)
+    call seaice_icepack_write_warnings(seaice_icepack_aborted())
 
   end subroutine init_icepack_package_tracer_sizes
 
@@ -10583,10 +10596,7 @@ contains
          bio_index_o_in   = tracerObject % index_LayerIndexToDataArray, &
          bio_index_in     = tracerObject % index_LayerIndexToBioIndex)
 
-    if (seaice_icepack_aborted()) then
-       call seaice_icepack_write_warnings(.true.)
-       call mpas_log_write("init_icepack_package_tracer_indices: icepack aborted", MPAS_LOG_CRIT)
-    endif
+    call seaice_icepack_write_warnings(seaice_icepack_aborted())
 
   end subroutine init_icepack_package_tracer_indices
 
@@ -12189,6 +12199,7 @@ contains
 
     use icepack_intfc, only: &
          icepack_init_parameters, &
+         icepack_write_parameters, &
          icepack_configure, &
          icepack_query_parameters ! debugging
 
@@ -12433,8 +12444,8 @@ contains
          config_itd_conversion_type_int, &
          config_category_bounds_type_int
 
-    character(len=strKIND), pointer :: tmp
-    character(len=strKIND), pointer :: tmp_config_shortwave
+    character(len=strKIND) :: tmp_config_shortwave
+    character(len=strKIND) :: tmp_config_snw_ssp_table
 
     ! debugging
     integer :: itmp1, itmp2
@@ -12649,12 +12660,12 @@ contains
     config_itd_conversion_type_int = config_cice_int("config_itd_conversion_type", config_itd_conversion_type)
     config_category_bounds_type_int = config_cice_int("config_category_bounds_type", config_category_bounds_type)
 
-    tmp_config_shortwave => config_shortwave_type
     if (config_use_snicar_ad .and. (trim(config_shortwave_type(1:4)) == "dEdd")) then
-       allocate (tmp)                    !echmod: is tmp necessary?
-       tmp = 'dEdd_snicar_ad'
-       tmp_config_shortwave => tmp
-       deallocate (tmp)
+       tmp_config_shortwave     = 'dEdd_snicar_ad'
+       tmp_config_snw_ssp_table = 'snicar'
+    else
+       tmp_config_shortwave     = config_shortwave_type
+       tmp_config_snw_ssp_table = 'test'
     endif
 
 !echmod debugging
@@ -12962,9 +12973,28 @@ contains
          !snowage_kappa_in        = , &
          !snowage_drdt0_in        = , &
          !snw_aging_table_in      = , &
+         snw_ssp_table_in        = tmp_config_snw_ssp_table &
+         !ssp_snwextdr_in         = , &
+         !ssp_snwextdf_in         = , &
+         !ssp_snwalbdr_in         = , &
+         !ssp_snwalbdf_in         = , &
+         !ssp_sasymmdr_in         = , &
+         !ssp_sasymmdf_in         = , &
+         !ssp_aasymmmd_in         = , &
+         !ssp_aerextmd_in         = , &
+         !ssp_aeralbmd_in         = , &
+         !ssp_abcenhmd_in         = , &
+         !ssp_aasymm_in           = , &
+         !ssp_aerext_in           = , &
+         !ssp_aeralb_in           =
          )
+    call seaice_icepack_write_warnings(seaice_icepack_aborted())
 
-    call icepack_configure ()     ! this recomputes Lfresh - make it optional for E3SM?
+! tcraig, this will write out icepack parameters to fort.101, need to uncomment 3 lines
+!    if (mpas_log_info % taskID == 0) then
+!      call icepack_write_parameters(101)
+!    endif
+!    call seaice_icepack_write_warnings(seaice_icepack_aborted())
 
     call mpas_log_write(" ----- compare values after icepack init -----")
 
@@ -17870,6 +17900,7 @@ contains
   subroutine seaice_icepack_write_warnings(logAsErrors)
 
     use icepack_intfc, only: &
+         icepack_warnings_clear, &
          icepack_warnings_getall
 
     character(len=strKINDWarnings), dimension(:), allocatable :: &
@@ -17887,11 +17918,14 @@ contains
        do iWarning = 1, size(warnings)
           call mpas_log_write(trim(warnings(iWarning)), messageType=MPAS_LOG_ERR)
        enddo ! iWarning
+       call mpas_log_write("icepack aborted", MPAS_LOG_CRIT)
     else
        do iWarning = 1, size(warnings)
           call mpas_log_write(trim(warnings(iWarning)), messageType=MPAS_LOG_WARN)
        enddo ! iWarning
     endif
+
+    call icepack_warnings_clear()
 
   end subroutine seaice_icepack_write_warnings
 


### PR DESCRIPTION
Update Icepack integration, mpas_seaice_icepack.F
- Update dEdd_snicar-ad parameter settings passed to Icepack Works with 
```
  config_column_physics_type = 'icepack' 
  config_use_snicar_ad = true 
```

Also need -DUSE_SNICARHC, added following to universal.cmake manually 

```
    if (COMP_NAME STREQUAL mpassi) 
      string(APPEND CPPDEFS " -DUSE_SNICARHC") 
    endif()
```
- Update seaice_icepack_write_warnings, write icepack output and abort if necessary
- Add calls to seaice_icepack_write_warnings after every icepack call
- Add call to icepack_configure
- Add ability to write out Icepack parameters to unit 101 (fort.101), commented out

Update Core-haswell D-case pe layout default, now set to 256 pes