### PR TITLE
updating Icepack to hash 6ca316f, adding wlat for FSD, updating colpkg

### DIFF
--- a/components/mpas-seaice/src/Registry.xml
+++ b/components/mpas-seaice/src/Registry.xml
@@ -4345,6 +4345,11 @@
 		     dimensions="nCells Time"
 		     units="1"
 		/>
+		<var name="lateralIceMeltRate"
+		     type="real"
+		     dimensions="nCells Time"
+		     units="m s-1"
+		/>
 		<var name="lateralHeatFlux"
 		     type="real"
 		     dimensions="nCells Time"

--- a/components/mpas-seaice/src/column/ice_atmo.F90
+++ b/components/mpas-seaice/src/column/ice_atmo.F90
@@ -262,7 +262,7 @@
 
       ustar_prev = c2 * ustar
 
-      k = 0
+      k = 1
       do while (abs(ustar - ustar_prev)/ustar > 0 .and. k <= natmiter)
 
          ustar_prev = ustar

--- a/components/mpas-seaice/src/column/ice_colpkg.F90
+++ b/components/mpas-seaice/src/column/ice_colpkg.F90
@@ -3640,7 +3640,7 @@
                                      Uref)
 
       use ice_atmo, only: atmo_boundary_const, atmo_boundary_layer
-      use ice_constants_colpkg, only: c0
+      use ice_constants_colpkg, only: c0, c1
 
       character (len=3), intent(in) :: &
          sfctype      ! ice or ocean
@@ -3689,9 +3689,12 @@
          worku = uvel
       endif
       ! should this be for vvel,workv?
-      if (present(uvel)) then
-         worku = uvel
+      if (present(vvel)) then
+         workv = vvel
       endif
+
+      ! NJ keeps icepack/colpkg BFB when atmbndy = 'constant'
+      Cdn_atm_ratio_n = c1
 
                if (trim(atmbndy) == 'constant') then
                   call atmo_boundary_const (sfctype,  calc_strair, &

--- a/components/mpas-seaice/src/column/ice_shortwave.F90
+++ b/components/mpas-seaice/src/column/ice_shortwave.F90
@@ -60,6 +60,9 @@
          hpmin  = 0.005_dbl_kind, & ! minimum allowed melt pond depth (m)
          hp0    = 0.200_dbl_kind    ! pond depth below which transition to bare ice
 
+      real (kind=dbl_kind), parameter :: &
+         exp_argmax = c10    ! maximum argument of exponential
+
       real (kind=dbl_kind) :: &
          exp_min                    ! minimum exponential value
 
@@ -926,15 +929,10 @@
       logical (kind=log_kind) :: &
          linitonly       ! local initonly value
 
-      real (kind=dbl_kind), parameter :: & 
-         argmax = c10    ! maximum argument of exponential
-
       linitonly = .false.
       if (present(initonly)) then
          linitonly = initonly
       endif
-
-      exp_min = exp(-argmax)
 
       ! cosine of the zenith angle
          call compute_coszen (tlat,          tlon, &
@@ -2397,13 +2395,13 @@
                 
                  ! get grain size index:
                  ! works for 25 < snw_rds < 1625 um:
-                 if (tmp_gs < 125) then
-                   tmp1 = tmp_gs/50
+                 if (tmp_gs < 125.0_dbl_kind) then
+                   tmp1 = tmp_gs/50.0_dbl_kind
                    k_bcini(k) = nint(tmp1)
-                 elseif (tmp_gs < 175) then
+                 elseif (tmp_gs < 175.0_dbl_kind) then
                    k_bcini(k) = 2
                  else
-                   tmp1 = (tmp_gs/250)+2
+                   tmp1 = (tmp_gs/250.0_dbl_kind)+c2
                    k_bcini(k) = nint(tmp1)
                  endif
               else                  ! use the largest snow grain size for ice
@@ -3347,7 +3345,10 @@
          tdr      , & ! tdir for gaussian integration
          smr      , & ! accumulator for rdif gaussian integration
          smt          ! accumulator for tdif gaussian integration
- 
+
+      real (kind=dbl_kind) :: &
+         exp_min                    ! minimum exponential value
+
       ! Delta-Eddington solution expressions
       alpha(w,uu,gg,e) = p75*w*uu*((c1 + gg*(c1-w))/(c1 - e*e*uu*uu))
       agamm(w,uu,gg,e) = p5*w*((c1 + c3*gg*(c1-w)*uu*uu)/(c1-e*e*uu*uu))
@@ -3385,7 +3386,7 @@
       ! value below the fresnel level, i.e. the cosine solar zenith 
       ! angle below the fresnel level for the refracted solar beam:
       mu0nij = sqrt(c1-((c1-mu0**2)/(refindx*refindx)))
- 
+
       ! compute level of fresnel refraction
       ! if ponded sea ice, fresnel level is the top of the pond.
       kfrsnl = 0
@@ -3434,7 +3435,9 @@
             ! non-refracted beam instead
             if( srftyp < 2 .and. k < kfrsnl ) mu0n = mu0
 
-            extins = max(exp_min, exp(-lm*ts))
+            !extins = max(exp_min, exp(-lm*ts))
+            exp_min = min(exp_argmax,lm*ts)
+            extins = exp(-exp_min)
             ne = n(ue,extins)
 
             ! first calculation of rdif, tdif using Delta-Eddington formulas
@@ -3443,7 +3446,9 @@
             tdif_a(k) = c4*ue/ne
 
             ! evaluate rdir,tdir for direct beam
-            trnlay(k) = max(exp_min, exp(-ts/mu0n))
+            !trnlay(k) = max(exp_min, exp(-ts/mu0n))
+            exp_min = min(exp_argmax,ts/mu0n)
+            trnlay(k) = exp(-exp_min)
             alp = alpha(ws,mu0n,gs,lm)
             gam = agamm(ws,mu0n,gs,lm)
             apg = alp + gam
@@ -3464,7 +3469,9 @@
                mu  = gauspt(ng)
                gwt = gauswt(ng)
                swt = swt + mu*gwt
-               trn = max(exp_min, exp(-ts/mu))
+               !trn = max(exp_min, exp(-ts/mu))
+               exp_min = min(exp_argmax,ts/mu)
+               trn = exp(-exp_min)
                alp = alpha(ws,mu,gs,lm)
                gam = agamm(ws,mu,gs,lm)
                apg = alp + gam
@@ -4649,13 +4656,13 @@
 
                  ! get grain size index:
                  ! works for 25 < snw_rds < 1625 um:
-                 if (tmp_gs < 125) then
-                   tmp1 = tmp_gs/50
+                 if (tmp_gs < 125._dbl_kind) then
+                   tmp1 = tmp_gs/50._dbl_kind
                    k_bcini(k) = nint(tmp1)
-                 elseif (tmp_gs < 175) then
+                 elseif (tmp_gs < 175._dbl_kind) then
                    k_bcini(k) = 2
                  else
-                   tmp1 = (tmp_gs/250)+2
+                   tmp1 = (tmp_gs/250._dbl_kind) + c2
                    k_bcini(k) = nint(tmp1)
                  endif
               else                  ! use the largest snow grain size for ice

--- a/components/mpas-seaice/src/shared/mpas_seaice_column.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_column.F
@@ -6256,8 +6256,12 @@ contains
          seaiceIceSnowEmissivity, &
          seaiceFreshWaterFreezingPoint, &
          seaiceAirSpecificHeat, &
+         seaiceWaterVaporSpecificHeat, &
+         seaiceSeaWaterSpecificHeat, &
+         seaiceLatentHeatVaporization, &
          seaiceLatentHeatSublimation, &
          seaiceLatentHeatMelting, &
+         seaiceReferenceSalinity, &
          seaiceOceanAlbedo, &
          seaiceVonKarmanConstant, &
          seaiceIceSurfaceRoughness, &
@@ -6281,8 +6285,12 @@ contains
          emissivity, &
          Tffresh, &
          cp_air, &
+         cp_wv, &
+         cp_ocn, &
+         Lvap, &
          Lsub, &
          Lfresh, &
+         ice_ref_salinity, &
          Pstar, &
          Cstar, &
          dragio, &
@@ -6304,8 +6312,12 @@ contains
     seaiceIceSnowEmissivity          = emissivity
     seaiceFreshWaterFreezingPoint    = Tffresh
     seaiceAirSpecificHeat            = cp_air
+    seaiceWaterVaporSpecificHeat     = cp_wv
+    seaiceSeaWaterSpecificHeat       = cp_ocn
+    seaiceLatentHeatVaporization     = Lvap
     seaiceLatentHeatSublimation      = Lsub
     seaiceLatentHeatMelting          = Lfresh
+    seaiceReferenceSalinity          = ice_ref_salinity
     seaiceOceanAlbedo                = albocn
     seaiceVonKarmanConstant          = vonkar
     seaiceIceSurfaceRoughness        = iceruf

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -1415,6 +1415,7 @@ contains
          oceanStressCellV, &
          freezingMeltingPotential, &
          lateralIceMeltFraction, &
+         lateralIceMeltRate, &
          lateralHeatFlux, &
          snowfallRate, &
          rainfallRate, &
@@ -1660,6 +1661,7 @@ contains
        call MPAS_pool_get_array(drag, "dragFloeSeparation", dragFloeSeparation)
 
        call MPAS_pool_get_array(melt_growth_rates, "lateralIceMeltFraction", lateralIceMeltFraction)
+       call MPAS_pool_get_array(melt_growth_rates, "lateralIceMeltRate", lateralIceMeltRate)
        call MPAS_pool_get_array(melt_growth_rates, "lateralHeatFlux", lateralHeatFlux)
        call MPAS_pool_get_array(melt_growth_rates, "surfaceIceMelt", surfaceIceMelt)
        call MPAS_pool_get_array(melt_growth_rates, "surfaceIceMeltCategory", surfaceIceMeltCategory)
@@ -1861,6 +1863,7 @@ contains
                Tsnice=snowIceInterfaceTemperature(iCell), &
                frzmlt=freezingMeltingPotential(iCell), &
                rside=lateralIceMeltFraction(iCell), &
+               wlat=lateralIceMeltRate(iCell), &
                fside=lateralHeatFlux(iCell), &
                fsnow=snowfallRate(iCell), &
                frain=rainfallRate(iCell), &
@@ -2025,6 +2028,7 @@ contains
              call mpas_log_write("oceanHeatFluxIceBottom: $r", messageType=MPAS_LOG_ERR, realArgs=(/oceanHeatFluxIceBottom(iCell)/))
              call mpas_log_write("freezingMeltingPotential: $r", messageType=MPAS_LOG_ERR, realArgs=(/freezingMeltingPotential(iCell)/))
              call mpas_log_write("lateralIceMeltFraction: $r", messageType=MPAS_LOG_ERR, realArgs=(/lateralIceMeltFraction(iCell)/))
+             call mpas_log_write("lateralIceMeltRate: $r", messageType=MPAS_LOG_ERR, realArgs=(/lateralIceMeltRate(iCell)/))
              call mpas_log_write("snowfallRate: $r", messageType=MPAS_LOG_ERR, realArgs=(/snowfallRate(iCell)/))
              call mpas_log_write("rainfallRate: $r", messageType=MPAS_LOG_ERR, realArgs=(/rainfallRate(iCell)/))
              call mpas_log_write("pondFreshWaterFlux: $r", messageType=MPAS_LOG_ERR, realArgs=(/pondFreshWaterFlux(iCell)/))
@@ -2189,6 +2193,7 @@ contains
          seaFreezingTemperature, &
          seaSurfaceSalinity, &
          lateralIceMeltFraction, &
+         lateralIceMeltRate, &
          lateralIceMelt, &
          freezingMeltingPotential, &
          frazilFormation, &
@@ -2323,6 +2328,7 @@ contains
        call MPAS_pool_get_array(ocean_fluxes, "oceanHeatFlux", oceanHeatFlux)
 
        call MPAS_pool_get_array(melt_growth_rates, "lateralIceMeltFraction", lateralIceMeltFraction)
+       call MPAS_pool_get_array(melt_growth_rates, "lateralIceMeltRate", lateralIceMeltRate)
        call MPAS_pool_get_array(melt_growth_rates, "lateralIceMelt", lateralIceMelt)
        call MPAS_pool_get_array(melt_growth_rates, "frazilFormation", frazilFormation)
        call MPAS_pool_get_array(melt_growth_rates, "frazilGrowthDiagnostic", frazilGrowthDiagnostic)
@@ -2422,6 +2428,7 @@ contains
                seaSurfaceSalinity(iCell), &
                initialSalinityProfile(:,iCell), &
                lateralIceMeltFraction(iCell), &
+!in icepack, not colpkg               lateralIceMeltRate(iCell), &
                lateralIceMelt(iCell), &
                freezingMeltingPotential(iCell), &
                frazilFormation(iCell), &


### PR DESCRIPTION
Updates icepack to the cice-consortium/E3SM-icepack-initial-integration branch.  This is the first icepack submodule update in this branch since https://github.com/eclare108213/E3SM/pull/3.

Runs with icepack are not BFB. Updating icepack by itself failed with a segfault in the frzmlt_bottom_lateral subroutine. Adding wlat to MPAS-SI's step_therm1 call fixed the problem (so this implementation does not appear to be backwards compatible).

Colpkg ('column') tests are not BFB with the prior version. The colpkg updates here enable BFB tests in single-column mode.