### PR TITLE
Adds changes for consistency with icepack and bugfix for boundary layer

### DIFF
--- a/components/mpas-seaice/src/column/ice_atmo.F90
+++ b/components/mpas-seaice/src/column/ice_atmo.F90
@@ -262,7 +262,7 @@
 
       ustar_prev = c2 * ustar
 
-      k = 0
+      k = 1
       do while (abs(ustar - ustar_prev)/ustar > 0 .and. k <= natmiter)
 
          ustar_prev = ustar

--- a/components/mpas-seaice/src/column/ice_colpkg.F90
+++ b/components/mpas-seaice/src/column/ice_colpkg.F90
@@ -3640,7 +3640,7 @@
                                      Uref)
 
       use ice_atmo, only: atmo_boundary_const, atmo_boundary_layer
-      use ice_constants_colpkg, only: c0
+      use ice_constants_colpkg, only: c0, c1
 
       character (len=3), intent(in) :: &
          sfctype      ! ice or ocean
@@ -3689,9 +3689,12 @@
          worku = uvel
       endif
       ! should this be for vvel,workv?
-      if (present(uvel)) then
-         worku = uvel
+      if (present(vvel)) then
+         workv = vvel
       endif
+
+      ! NJ keeps icepack/colpkg BFB when atmbndy = 'constant'
+      Cdn_atm_ratio_n = c1
 
                if (trim(atmbndy) == 'constant') then
                   call atmo_boundary_const (sfctype,  calc_strair, &


### PR DESCRIPTION
Corrections from @njeffery:

-changes initialization of counter to 1 in atm-boundary nonBFB because it changes the number of interations

-Initializes airOceanDrag ratio to 1
BFB except when atmos_boundary_layer = 'constant' and only changes restart output for airOceanDrag ratio.

-Corrects uVel -> vVel in atmos_boundary (bugfix, nonBFB)