### PR TITLE
activate snicar in icepack, check values

### DIFF
--- a/components/mpas-seaice/src/build_options.mk
+++ b/components/mpas-seaice/src/build_options.mk
@@ -4,7 +4,7 @@ endif
 EXE_NAME=seaice_model
 NAMELIST_SUFFIX=seaice
 FCINCLUDES += -I$(ROOT_DIR)/column -I$(ROOT_DIR)/shared -I$(ROOT_DIR)/analysis_members -I$(ROOT_DIR)/model_forward
-override CPPFLAGS += -DCORE_SEAICE
+override CPPFLAGS += -DCORE_SEAICE -DUSE_SNICARHC
 ifneq "$(ESM)" ""
 override CPPFLAGS += -Dcoupled -DCCSMCOUPLED
 endif

--- a/components/mpas-seaice/src/seaice.cmake
+++ b/components/mpas-seaice/src/seaice.cmake
@@ -1,6 +1,6 @@
 
 # build_options.mk stuff handled here
-list(APPEND CPPDEFS "-DCORE_SEAICE" "-Dcoupled" "-DCCSMCOUPLED")
+list(APPEND CPPDEFS "-DCORE_SEAICE" "-Dcoupled" "-DCCSMCOUPLED" "-DUSE_SNICARHC")
 list(APPEND INCLUDES "${CMAKE_BINARY_DIR}/core_seaice/icepack/columnphysics" "${CMAKE_BINARY_DIR}/core_seaice/column" "${CMAKE_BINARY_DIR}/core_seaice/shared" "${CMAKE_BINARY_DIR}/core_seaice/analysis_members" "${CMAKE_BINARY_DIR}/core_seaice/model_forward")
 
 

--- a/components/mpas-seaice/src/shared/mpas_seaice_column.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_column.F
@@ -3028,6 +3028,8 @@ contains
          iCategory, &
          iAerosol, &
          iTracer
+!         nspint_5bd, &  ! for checking against icepack array values
+!         nmbrad_snicar  ! for checking against icepack array values
 
     integer, dimension(:), allocatable :: &
          index_shortwaveAerosol
@@ -3155,6 +3157,38 @@ contains
        call MPAS_pool_get_array(snicar, "modalSingleScatterAlbedo5band", modalSingleScatterAlbedo5band)
        call MPAS_pool_get_array(snicar, "modalAsymmetryParameter5band", modalAsymmetryParameter5band)
        call MPAS_pool_get_array(snicar, "modalBCabsorptionParameter5band", modalBCabsorptionParameter5band)
+
+! write out corner values of arrays to compare with values from icepack tables (subroutine icepack_init_radiation)
+!    call mpas_log_write(' ')
+!    call mpas_log_write(" ----- snicar parameters (column) -----")
+!    nspint_5bd = size(iceAsymmetryParameterDirect,1)
+!    nmbrad_snicar = size(iceAsymmetryParameterDirect,2)
+!    call mpas_log_write('nspint_5bd $i',intArgs=(/nspint_5bd/))
+!    call mpas_log_write('nmbrad_snicar $i',intArgs=(/nmbrad_snicar/))
+!    call mpas_log_write('ssp_sasymmdr(1,1) $r',realArgs=(/iceAsymmetryParameterDirect(1,1)/))
+!    call mpas_log_write('ssp_sasymmdr(nspint_5bd,1) $r',realArgs=(/iceAsymmetryParameterDirect(nspint_5bd,1)/))
+!    call mpas_log_write('ssp_sasymmdr(1,nmbrad_snicar) $r',realArgs=(/iceAsymmetryParameterDirect(1,nmbrad_snicar)/))
+!    call mpas_log_write('ssp_sasymmdr(nspint_5bd,nmbrad_snicar) $r',realArgs=(/iceAsymmetryParameterDirect(nspint_5bd,nmbrad_snicar)/))
+!    call mpas_log_write('ssp_sasymmdc(1,1) $r',realArgs=(/iceAsymmetryParameterDiffuse(1,1)/))
+!    call mpas_log_write('ssp_sasymmdc(nspint_5bd,1) $r',realArgs=(/iceAsymmetryParameterDiffuse(nspint_5bd,1)/))
+!    call mpas_log_write('ssp_sasymmdc(1,nmbrad_snicar) $r',realArgs=(/iceAsymmetryParameterDiffuse(1,nmbrad_snicar)/))
+!    call mpas_log_write('ssp_sasymmdc(nspint_5bd,nmbrad_snicar) $r',realArgs=(/iceAsymmetryParameterDiffuse(nspint_5bd,nmbrad_snicar)/))
+!    call mpas_log_write('ssp_snwalbdr(1,1) $r',realArgs=(/iceSingleScatterAlbedoDirect(1,1)/))
+!    call mpas_log_write('ssp_snwalbdr(nspint_5bd,1) $r',realArgs=(/iceSingleScatterAlbedoDirect(nspint_5bd,1)/))
+!    call mpas_log_write('ssp_snwalbdr(1,nmbrad_snicar) $r',realArgs=(/iceSingleScatterAlbedoDirect(1,nmbrad_snicar)/))
+!    call mpas_log_write('ssp_snwalbdr(nspint_5bd,nmbrad_snicar) $r',realArgs=(/iceSingleScatterAlbedoDirect(nspint_5bd,nmbrad_snicar)/))
+!    call mpas_log_write('ssp_snwalbdc(1,1) $r',realArgs=(/iceSingleScatterAlbedoDiffuse(1,1)/))
+!    call mpas_log_write('ssp_snwalbdc(nspint_5bd,1) $r',realArgs=(/iceSingleScatterAlbedoDiffuse(nspint_5bd,1)/))
+!    call mpas_log_write('ssp_snwalbdc(1,nmbrad_snicar) $r',realArgs=(/iceSingleScatterAlbedoDiffuse(1,nmbrad_snicar)/))
+!    call mpas_log_write('ssp_snwalbdc(nspint_5bd,nmbrad_snicar) $r',realArgs=(/iceSingleScatterAlbedoDiffuse(nspint_5bd,nmbrad_snicar)/))
+!    call mpas_log_write('ssp_snwextdr(1,1) $r',realArgs=(/iceMassExtinctionCrossSectionDirect(1,1)/))
+!    call mpas_log_write('ssp_snwextdr(nspint_5bd,1) $r',realArgs=(/iceMassExtinctionCrossSectionDirect(nspint_5bd,1)/))
+!    call mpas_log_write('ssp_snwextdr(1,nmbrad_snicar) $r',realArgs=(/iceMassExtinctionCrossSectionDirect(1,nmbrad_snicar)/))
+!    call mpas_log_write('ssp_snwextdr(nspint_5bd,nmbrad_snicar) $r',realArgs=(/iceMassExtinctionCrossSectionDirect(nspint_5bd,nmbrad_snicar)/))
+!    call mpas_log_write('ssp_snwextdc(1,1) $r',realArgs=(/iceMassExtinctionCrossSectionDiffuse(1,1)/))
+!    call mpas_log_write('ssp_snwextdc(nspint_5bd,1) $r',realArgs=(/iceMassExtinctionCrossSectionDiffuse(nspint_5bd,1)/))
+!    call mpas_log_write('ssp_snwextdc(1,nmbrad_snicar) $r',realArgs=(/iceMassExtinctionCrossSectionDiffuse(1,nmbrad_snicar)/))
+!    call mpas_log_write('ssp_snwextdc(nspint_5bd,nmbrad_snicar) $r',realArgs=(/iceMassExtinctionCrossSectionDiffuse(nspint_5bd,nmbrad_snicar)/))
 
        call MPAS_pool_get_array(snow, "snowRadiusInStandardRadiationSchemeCategory", snowRadiusInStandardRadiationSchemeCategory)
 


### PR DESCRIPTION
Adds the `USE_SNICARHC` cpp to MPAS-SI's cmake file, which allows icepack to use its internal (Hard-Coded) tables of snicar data for dEdd radiation.  I checked that the values in Icepack and colpkg are the same in the 4 corners of each array - the `mpas_log_write` statements are commented out since they are written on every time step (or coupling interval?).  Similar write statements were added to icepack but I am not updating icepack here to include them (easy to add, if needed).  I'll paste the results in comments below.

We may need to revisit this implementation to include a 'file' option in icepack, but since the current netcdf files are incomplete (some necessary parameters or indices are hard-coded in colpkg rather than being available in the file), we are not using it.  Some BGC parameters or arrays still need to be added to icepack.