### PR TITLE
Corrects use of snow flags and adds flag consistency checks

### DIFF
--- a/components/mpas-seaice/src/column/ice_colpkg.F90
+++ b/components/mpas-seaice/src/column/ice_colpkg.F90
@@ -2288,11 +2288,11 @@
       ! Transport liquid water in snow between layers and
       ! compute the meltpond contribution
       !-----------------------------------------------------------------
-
-      call drain_snow (dt,            nslyr,        &
-                       vsnon   (n) ,  aicen    (n), &
-                       smice  (:,n),  smliq  (:,n), &
-                       meltsliqn(n),  use_smliq_pnd)
+      if (tr_rsnw) &
+         call drain_snow (dt,            nslyr,        &
+                          vsnon   (n) ,  aicen    (n), &
+                          smice  (:,n),  smliq  (:,n), &
+                          meltsliqn(n),  use_smliq_pnd)
 
 
       !-----------------------------------------------------------------
@@ -3842,7 +3842,6 @@
                                    vicen,     vsnon,    &
                                    alvl,      vlvl,     &
                                    smice,     smliq,    &
-                                   rhos_effn, rhos_eff, &
                                    rhos_cmpn, rhos_cmp, &
                                    rsnw,      zqin1,    &
                                    zSin1,     Tsfc,     &
@@ -3905,11 +3904,9 @@
          smice    , & ! mass of ice in snow (kg/m^3)
          smliq    , & ! mass of liquid in snow (kg/m^3)
          rsnw     , & ! snow grain radius (10^-6 m)
-         rhos_effn, & ! effective snow density: content (kg/m^3)
          rhos_cmpn    ! effective snow density: compaction (kg/m^3)
 
       real (kind=dbl_kind), intent(inout) :: &
-         rhos_eff , & ! mean effective snow density: content (kg/m^3)
          rhos_cmp     ! mean effective snow density: compaction (kg/m^3)
 
       ! dry snow aging parameters
@@ -3956,9 +3953,7 @@
 
       call snow_effective_density(nslyr,     ncat,     &
                                   vsnon,     vsno,     &
-                                  smice,     smliq,    &
                                   rhosnew,             &
-                                  rhos_effn, rhos_eff, &
                                   rhos_cmpn, rhos_cmp)
 
       !-----------------------------------------------------------------
@@ -4950,8 +4945,8 @@
            tr_pond_cesm_in , & ! if .true., use cesm pond tracer
            tr_pond_lvl_in  , & ! if .true., use level-ice pond tracer
            tr_pond_topo_in , & ! if .true., use explicit topography-based ponds
-           tr_snow_in      , & ! if .true., use snow trcrs (smice, smliq, rhos_cmp)
-           tr_rsnw_in      , & ! if .true., use snow grain radius tracer
+           tr_snow_in      , & ! if .true., use snow density tracer (rhos_cmp)
+           tr_rsnw_in      , & ! if .true., use snow grain radius, liquid and mass tracers (smice, smliq, rsnw)
            tr_aero_in      , & ! if .true., use aerosol tracers
            tr_brine_in     , & ! if .true., brine height differs from ice thickness
            tr_bgc_S_in     , & ! if .true., use zsalinity
@@ -4977,8 +4972,8 @@
              tr_pond_cesm , & ! if .true., use cesm pond tracer
              tr_pond_lvl  , & ! if .true., use level-ice pond tracer
              tr_pond_topo , & ! if .true., use explicit topography-based ponds
-             tr_snow      , & ! if .true., use snow trcrs (smice, smliq, rhos_cmp)
-             tr_rsnw      , & ! if .true., use snow grain radius tracer
+             tr_snow      , & ! if .true., use snow density tracer (rhos_cmp)
+             tr_rsnw      , & ! if .true., use snow grain radius, liquid and mass tracers (smice, smliq, rsnw)
              tr_aero      , & ! if .true., use aerosol tracers
              tr_brine     , & ! if .true., brine height differs from ice thickness
              tr_bgc_S     , & ! if .true., use zsalinity
@@ -5004,8 +4999,8 @@
              tr_pond_cesm_in , & ! if .true., use cesm pond tracer
              tr_pond_lvl_in  , & ! if .true., use level-ice pond tracer
              tr_pond_topo_in , & ! if .true., use explicit topography-based ponds
-             tr_snow_in      , & ! if .true., use snow trcrs (smice, smliq, rhos_cmp)
-             tr_rsnw_in      , & ! if .true., use snow grain radius tracer
+             tr_snow_in      , & ! if .true., use snow density tracer (rhos_cmp)
+             tr_rsnw_in      , & ! if .true., use snow grain radius, liquid and mass tracers (smice, smliq, rsnw)
              tr_aero_in      , & ! if .true., use aerosol tracers
              tr_brine_in     , & ! if .true., brine height differs from ice thickness
              tr_bgc_S_in     , & ! if .true., use zsalinity

--- a/components/mpas-seaice/src/column/ice_colpkg_tracers.F90
+++ b/components/mpas-seaice/src/column/ice_colpkg_tracers.F90
@@ -58,8 +58,8 @@
          tr_pond_cesm, & ! if .true., use cesm pond tracer
          tr_pond_lvl , & ! if .true., use level-ice pond tracer
          tr_pond_topo, & ! if .true., use explicit topography-based ponds
-         tr_snow     , & ! if .true., use snow tracers (ice, liquid water mass)
-         tr_rsnw     , & ! if .true., use dynamic snow grain radius tracer
+         tr_snow     , & ! if .true., use snow density tracer (rhos_cmp)
+         tr_rsnw     , & ! if .true., use dynamic snow grain radius, mass, liquid tracers
          tr_aero     , & ! if .true., use aerosol tracers
          tr_brine        ! if .true., brine height differs from ice thickness
 

--- a/components/mpas-seaice/src/column/ice_snow.F90
+++ b/components/mpas-seaice/src/column/ice_snow.F90
@@ -33,9 +33,7 @@
 
       subroutine snow_effective_density(nslyr,     ncat,     &
                                         vsnon,     vsno,     &
-                                        smice,     smliq,    &
                                         rhosnew,             &
-                                        rhos_effn, rhos_eff, &
                                         rhos_cmpn, rhos_cmp)
 
       integer (kind=int_kind), intent(in) :: &
@@ -51,13 +49,9 @@
 
       real (kind=dbl_kind), dimension(:,:), &
          intent(inout) :: &
-         smice    , & ! mass of ice in snow (kg/m^3)
-         smliq    , & ! mass of liquid in snow (kg/m^3)
-         rhos_effn, & ! effective snow density: content (kg/m^3)
          rhos_cmpn    ! effective snow density: compaction (kg/m^3)
 
       real (kind=dbl_kind), intent(inout) :: &
-         rhos_eff , & ! mean effective snow density: content (kg/m^3)
          rhos_cmp     ! mean effective snow density: compaction (kg/m^3)
 
       integer (kind=int_kind) :: &
@@ -65,7 +59,6 @@
          n    , & ! ice thickness category index
          cnt      ! counter for snow presence
 
-      rhos_eff = c0
       rhos_cmp = c0
 
       !-----------------------------------------------------------------
@@ -87,13 +80,10 @@
          do n = 1, ncat
             if (vsnon(n) > c0) then
                do k = 1, nslyr
-                  rhos_effn(k,n) = rhos_effn(k,n) + smice(k,n) + smliq(k,n)
-                  rhos_eff       = rhos_eff + vsnon(n)*rhos_effn(k,n)
                   rhos_cmp       = rhos_cmp + vsnon(n)*rhos_cmpn(k,n)
                enddo
             endif
          enddo
-         rhos_eff = rhos_eff/(vsno*real(nslyr,kind=dbl_kind))
          rhos_cmp = rhos_cmp/(vsno*real(nslyr,kind=dbl_kind))
 
       endif ! vsno
@@ -422,6 +412,8 @@
                                         zs1(:),   zs2(:),     &
                                         hslyr,    hsn_new(n), &
                                         zqsn(:,n))
+               else
+                  hsn_new(1) = hsn_new(1) + dhsn
                endif   ! nslyr > 1
             endif      ! |dhsn| > puny
          endif         ! ain > puny

--- a/components/mpas-seaice/src/column/ice_therm_vertical.F90
+++ b/components/mpas-seaice/src/column/ice_therm_vertical.F90
@@ -185,8 +185,8 @@
          yday         ! day of year
 
       logical (kind=log_kind), intent(in) :: &
-         tr_snow ,    &  ! if .true., use snow tracers
-         tr_rsnw         ! if .true., use dynamic snow grain radius
+         tr_snow ,    &  ! if .true., use snow density tracer
+         tr_rsnw         ! if .true., use dynamic snow grain radius, liquid and snow mass
 
       logical (kind=log_kind), intent(out) :: &
          l_stop       ! if true, print diagnostics and abort on return
@@ -310,7 +310,7 @@
                                               fadvocn,   snoice,    &
                                               einit,                &
                                               smice,     smliq,     &
-                                              tr_snow,              &
+                                              tr_rsnw,              &
                                               l_stop,    stop_label)
                
             if (l_stop) return
@@ -1124,8 +1124,8 @@
          sss             ! ocean salinity (PSU) 
 
       logical (kind=log_kind), intent(in) :: &
-         tr_snow    , &  ! if .true., use snow tracers
-         tr_rsnw         ! if .true., use snow dynamic snow grain radius
+         tr_snow    , &  ! if .true., use snow density tracer
+         tr_rsnw         ! if .true., use snow dynamic snow grain radius, snow liquid and mass
 
       ! local variables
 
@@ -1198,7 +1198,7 @@
          dzs(k) = hslyr
          smicetot(k) = c0
          smliqtot(k) = c0
-         if (tr_snow) then
+         if (tr_rsnw) then
            smicetot(k) = dzs(k) * smice(k)
            smliqtot(k) = dzs(k) * smliq(k)
          endif
@@ -1506,7 +1506,7 @@
             ! avoid roundoff errors
             zqsn(1) = min(zqsn(1), -rhos*Lfresh)
 
-            if (tr_snow) then
+            if (tr_rsnw) then
 
               smtot = c0
               if (abs(dzs(1)) > c0) smtot = smicetot(1)/dzs(1) !smice(1) ! save for now
@@ -1585,7 +1585,7 @@
     !-------------------------------------------------------------------
     ! Update snow mass tracers, smice and smliq, for uneven layers
     !-------------------------------------------------------------------
-       if (tr_snow) then
+       if (tr_rsnw) then
          do k = 1, nslyr
             meltsliq = meltsliq + smliqtot(k)  ! total liquid (in case all snow melted)
             if (dzs(k) > c0) then
@@ -1687,13 +1687,11 @@
                                hslyr,    hsn,      &
                                zqsn)   
 
-         if (tr_rsnw) &
-               call adjust_enthalpy (nslyr,              &
-                                     zs1(:),   zs2(:),   &
-                                     hslyr,    hsn,      &
-                                     rsnw(:))
-
-        if (tr_snow) then
+         if (tr_rsnw) then
+              call adjust_enthalpy (nslyr,              &
+                                    zs1(:),   zs2(:),   &
+                                    hslyr,    hsn,      &
+                                    rsnw(:))
               call adjust_enthalpy (nslyr,              &
                                     zs1(:),   zs2(:),   &
                                     hslyr,    hsn,      &
@@ -1721,7 +1719,7 @@
                fhocnn = fhocnn &
                       + zqsn(k)*hsn/(real(nslyr,kind=dbl_kind)*dt)
                zqsn(k) = -rhos*Lfresh
-               if (tr_snow) then
+               if (tr_rsnw) then
                  meltsliq = meltsliq + smicetot(k)  ! add to meltponds
                  smice(k) = rhos
                  smliq(k) = c0

--- a/components/mpas-seaice/src/shared/mpas_seaice_column.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_column.F
@@ -506,7 +506,8 @@ contains
          snowVolumeCell
 
     real(kind=RKIND), pointer :: &
-         config_fallen_snow_radius
+         config_fallen_snow_radius, &
+         config_new_snow_density
 
     integer, pointer :: &
          nCellsSolve, &
@@ -521,6 +522,7 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_use_effective_snow_density", config_use_effective_snow_density)
     call MPAS_pool_get_config(domain % configs, "config_use_snow_grain_radius", config_use_snow_grain_radius)
     call MPAS_pool_get_config(domain % configs, "config_fallen_snow_radius", config_fallen_snow_radius)
+    call MPAS_pool_get_config(domain % configs, "config_new_snow_density", config_new_snow_density)
     call MPAS_pool_get_config(domain % configs, "config_do_restart_snow_density", config_do_restart_snow_density)
     call MPAS_pool_get_config(domain % configs, "config_do_restart_snow_grain_radius", config_do_restart_snow_grain_radius)
 
@@ -538,72 +540,37 @@ contains
 
        call MPAS_pool_get_array(tracers, "snowVolumeCategory", snowVolumeCategory, 1)
        call MPAS_pool_get_array(tracers_aggregate, "snowVolumeCell", snowVolumeCell)
+       call MPAS_pool_get_array(snow, "snowMeltMassCategory", snowMeltMassCategory)
+       call MPAS_pool_get_array(snow, "snowMeltMassCell", snowMeltMassCell)
+       call MPAS_pool_get_array(snow, "snowDensityViaContent", snowDensityViaContent)
+
+       snowMeltMassCategory(:,:)   = 0.0_RKIND
+       snowMeltMassCell(:)         = 0.0_RKIND
+       snowDensityViaContent(:)    = seaiceDensitySnow
 
        if (config_use_effective_snow_density) then
 
-          call MPAS_pool_get_array(snow, "snowDensityViaContent", snowDensityViaContent)
           call MPAS_pool_get_array(snow, "snowDensityViaCompaction", snowDensityViaCompaction)
-          call MPAS_pool_get_array(snow, "snowMeltMassCategory", snowMeltMassCategory)
-          call MPAS_pool_get_array(snow, "snowMeltMassCell", snowMeltMassCell)
-
-          call MPAS_pool_get_array(tracers, "snowIceMass", snowIceMass, 1)
-          call MPAS_pool_get_array(tracers, "snowLiquidMass", snowLiquidMass, 1)
           call MPAS_pool_get_array(tracers, "snowDensity", snowDensity, 1)
 
           if (.not. config_do_restart_snow_density) then
 
-             snowIceMass(:,:,:)          = seaiceDensitySnow
-             snowLiquidMass(:,:,:)       = 0.0_RKIND
-             snowDensity(:,:,:)          = 0.0_RKIND
-             snowDensityViaContent(:)    = 0.0_RKIND
-             snowDensityViaCompaction(:) = 0.0_RKIND
-             snowMeltMassCategory(:,:)   = 0.0_RKIND
-             snowMeltMassCell(:)         = 0.0_RKIND
-
+             snowDensity(:,:,:)          = config_new_snow_density  !0.0_RKIND
              do iCell = 1, nCellsSolve
-
-                do iCategory = 1, nCategories
-                   if (snowVolumeCategory(1,iCategory,iCell) .gt. 0.0_RKIND) then
-                      do iSnowLayer = 1, nSnowLayers
-                         snowIceMass(iSnowLayer,iCategory,iCell) = seaiceDensitySnow
-                         snowDensity(iSnowLayer,iCategory,iCell) = seaiceDensitySnow
-                         snowDensityViaContent(iCell) = snowDensityViaContent(iCell) &
-                            + snowVolumeCategory(1,iCategory,iCell) * &
-                            (snowIceMass(iSnowLayer,iCategory,iCell) + &
-                            snowLiquidMass(iSnowLayer,iCategory,iCell))
-                         snowDensityViaCompaction(iCell) = snowDensityViaCompaction(iCell) &
-                            + snowVolumeCategory(1,iCategory,iCell) * &
-                            snowDensity(iSnowLayer,iCategory,iCell)
-                      enddo !iSnowLayer
-                   endif !snowVolumeCategory
-                enddo !iCategory
-                if (snowVolumeCell(iCell) .gt.  seaicePuny) then
-                   snowDensityViaContent(iCell) = snowDensityViaContent(iCell)/ &
-                      (snowVolumeCell(iCell) * real(nSnowLayers,kind=RKIND))  !!!CHECK THIS!!!
-                   snowDensityViaCompaction(iCell) = snowDensityViaCompaction(iCell)/ &
-                      (snowVolumeCell(iCell) * real(nSnowLayers,kind=RKIND))
+                if (snowVolumeCell(iCell) .gt. seaicePuny) then
+                   snowDensityViaCompaction(iCell) = config_new_snow_density
                 else
-                   snowDensityViaContent(iCell)    = 0.0_RKIND
                    snowDensityViaCompaction(iCell) = 0.0_RKIND
-                endif !snowVolumeCell
-
-             enddo ! iCell
+                endif
+             enddo
           else
-
-             snowDensityViaContent(:)    = 0.0_RKIND
              snowDensityViaCompaction(:) = 0.0_RKIND
-             snowMeltMassCategory(:,:)   = 0.0_RKIND
-             snowMeltMassCell(:)         = 0.0_RKIND
 
              do iCell = 1, nCellsSolve
 
                 do iCategory = 1, nCategories
                    if (snowVolumeCategory(1,iCategory,iCell) .gt. 0.0_RKIND) then
                       do iSnowLayer = 1, nSnowLayers
-                         snowDensityViaContent(iCell) = snowDensityViaContent(iCell) &
-                            + snowVolumeCategory(1,iCategory,iCell) * &
-                            (snowIceMass(iSnowLayer,iCategory,iCell) + &
-                            snowLiquidMass(iSnowLayer,iCategory,iCell))
                          snowDensityViaCompaction(iCell) = snowDensityViaCompaction(iCell) &
                             + snowVolumeCategory(1,iCategory,iCell) * &
                             snowDensity(iSnowLayer,iCategory,iCell)
@@ -611,12 +578,9 @@ contains
                    endif !snowVolumeCategory
                 enddo !iCategory
                 if (snowVolumeCell(iCell) .gt.  seaicePuny) then
-                   snowDensityViaContent(iCell) = snowDensityViaContent(iCell)/ &
-                      (snowVolumeCell(iCell) * real(nSnowLayers,kind=RKIND))  !!!CHECK THIS!!!
                    snowDensityViaCompaction(iCell) = snowDensityViaCompaction(iCell)/ &
                       (snowVolumeCell(iCell) * real(nSnowLayers,kind=RKIND))
                 else
-                   snowDensityViaContent(iCell)    = 0.0_RKIND
                    snowDensityViaCompaction(iCell) = 0.0_RKIND
                 endif !snowVolumeCell
 
@@ -627,15 +591,39 @@ contains
        if (config_use_snow_grain_radius) then
           if (.not. config_do_restart_snow_grain_radius) then
 
+             call MPAS_pool_get_array(tracers, "snowIceMass", snowIceMass, 1)
+             call MPAS_pool_get_array(tracers, "snowLiquidMass", snowLiquidMass, 1)
              call MPAS_pool_get_array(tracers, "snowGrainRadius", snowGrainRadius, 1)
 
-             snowGrainRadius(:,:,:) = config_fallen_snow_radius
+             snowGrainRadius(:,:,:)      = config_fallen_snow_radius
+             snowIceMass(:,:,:)          = seaiceDensitySnow
+             snowLiquidMass(:,:,:)       = 0.0_RKIND
+             snowDensityViaContent(:)    = seaiceDensitySnow
 
+          else
+             do iCell = 1, nCellsSolve
+                snowDensityViaContent(iCell) = 0.0_RKIND
+                do iCategory = 1, nCategories
+                   if (snowVolumeCategory(1,iCategory,iCell) .gt. 0.0_RKIND) then
+                      do iSnowLayer = 1, nSnowLayers
+                         snowDensityViaContent(iCell) = snowDensityViaContent(iCell) &
+                             + snowVolumeCategory(1,iCategory,iCell) * &
+                             (snowIceMass(iSnowLayer,iCategory,iCell) + &
+                             snowLiquidMass(iSnowLayer,iCategory,iCell))
+                       enddo !iSnowLayer
+                   endif !snowVolumeCategory
+                enddo !iCategory
+                if (snowVolumeCell(iCell) .gt.  seaicePuny) then
+                   snowDensityViaContent(iCell) = snowDensityViaContent(iCell)/ &
+                       (snowVolumeCell(iCell) * real(nSnowLayers,kind=RKIND))  !!!CHECK THIS!!!
+                else
+                   snowDensityViaContent(iCell)    = seaiceDensitySnow
+                endif !snowVolumeCell
+             enddo ! iCell
           endif ! config_do_restart_snow_grain_radius
-       endif ! config_use_snow_grain_radius
-
-       block => block % next
-    end do
+        endif ! config_use_snow_grain_radius
+        block => block % next
+     end do
 
   end subroutine init_column_snow_tracers
 
@@ -2650,7 +2638,8 @@ contains
          colpkg_get_warnings
 
     use seaice_constants, only: &
-         seaicePuny
+         seaicePuny, &
+         seaiceDensitySnow
 
     type(domain_type), intent(inout) :: domain
 
@@ -2731,9 +2720,6 @@ contains
          setGetPhysicsTracers, &
          setGetBGCTracers
 
-    real(kind=RKIND), dimension(:,:), allocatable :: &
-         effectiveSnowDensityCategory
-
     character(len=strKIND) :: &
          abortMessage, &
          abortLocation
@@ -2805,15 +2791,11 @@ contains
        setGetPhysicsTracers = .true.
        setGetBGCTracers     = config_use_column_biogeochemistry
 
-       allocate(effectiveSnowDensityCategory(1:nSnowLayers,1:nCategories))
-
        ! code abort
        abortFlag = .false.
        abortMessage = ""
 
        do iCell = 1, nCellsSolve
-
-          effectiveSnowDensityCategory(:,:) = 0.0_RKIND
 
           call colpkg_clear_warnings()
           call colpkg_step_snow (&
@@ -2830,8 +2812,6 @@ contains
                levelIceVolume(1,:,iCell), &
                snowIceMass(:,:,iCell), &
                snowLiquidMass(:,:,iCell), &
-               effectiveSnowDensityCategory(:,:), &
-               snowDensityViaContent(iCell), &
                snowDensity(:,:,iCell), &
                snowDensityViaCompaction(iCell), &
                snowGrainRadius(:,:,iCell), &
@@ -2860,9 +2840,27 @@ contains
           ! code abort
           if (abortFlag) exit
 
-       enddo !iCell
+          if (config_use_snow_grain_radius) then
+             snowDensityViaContent(iCell) = 0.0_RKIND
+             do iCategory = 1, nCategories
+                if (snowVolumeCategory(1,iCategory,iCell) .gt. 0.0_RKIND) then
+                   do iSnowLayer = 1, nSnowLayers
+                      snowDensityViaContent(iCell) = snowDensityViaContent(iCell) &
+                         + snowVolumeCategory(1,iCategory,iCell) * &
+                         (snowIceMass(iSnowLayer,iCategory,iCell) + &
+                         snowLiquidMass(iSnowLayer,iCategory,iCell))
+                   enddo !iSnowLayer
+                endif !snowVolumeCategory
+             enddo !iCategory
+             if (snowVolumeCell(iCell) .gt.  seaicePuny) then
+                snowDensityViaContent(iCell) = snowDensityViaContent(iCell)/ &
+                   (snowVolumeCell(iCell) * real(nSnowLayers,kind=RKIND))  !!!CHECK THIS!!!
+             else
+                snowDensityViaContent(iCell)    = seaiceDensitySnow
+             endif !snowVolumeCell
+          endif
 
-       deallocate(effectiveSnowDensityCategory)
+       enddo !iCell
 
        ! code abort
        call seaice_critical_error_write_block(domain, block, abortFlag)
@@ -6616,14 +6614,14 @@ contains
         config_use_topo_meltponds) &
          tracerObject % nTracers = tracerObject % nTracers + 1
 
-    ! snow density (ice mass, liquid mass, density)
+    ! snow density (density from compaction)
     if (config_use_effective_snow_density) then
-       tracerObject % nTracers = tracerObject % nTracers + nSnowLayers*3
+       tracerObject % nTracers = tracerObject % nTracers + nSnowLayers
     endif
 
-    ! snow grain radius
+    ! snow grain radius (ice mass, liquid mass, and snow grain radius)
     if (config_use_snow_grain_radius) then
-       tracerObject % nTracers = tracerObject % nTracers + nSnowLayers
+       tracerObject % nTracers = tracerObject % nTracers + nSnowLayers*3
     endif
 
     ! aerosols
@@ -6876,21 +6874,21 @@ contains
     endif
 
     ! snow density
-    tracerObject % index_snowIceMass = indexMissingValue
-    tracerObject % index_snowLiquidMass = indexMissingValue
     tracerObject % index_snowDensity = indexMissingValue
     if (config_use_effective_snow_density) then
-       tracerObject % index_snowIceMass = nTracers + 1
-       nTracers = nTracers + nSnowLayers
-       tracerObject % index_snowLiquidMass = nTracers + 1
-       nTracers = nTracers + nSnowLayers
        tracerObject % index_snowDensity = nTracers + 1
        nTracers = nTracers + nSnowLayers
     endif
 
     ! snow grain radius
+    tracerObject % index_snowIceMass = indexMissingValue
+    tracerObject % index_snowLiquidMass = indexMissingValue
     tracerObject % index_snowGrainRadius = indexMissingValue
     if (config_use_snow_grain_radius) then
+       tracerObject % index_snowIceMass = nTracers + 1
+       nTracers = nTracers + nSnowLayers
+       tracerObject % index_snowLiquidMass = nTracers + 1
+       nTracers = nTracers + nSnowLayers
        tracerObject % index_snowGrainRadius = nTracers + 1
        nTracers = nTracers + nSnowLayers
     endif
@@ -7013,8 +7011,6 @@ contains
     ! snow density
     if (config_use_effective_snow_density) then
        do iSnowLayer = 1, nSnowLayers
-          tracerObject % parentIndex(tracerObject % index_snowIceMass + iSnowLayer - 1) = 2
-          tracerObject % parentIndex(tracerObject % index_snowLiquidMass + iSnowLayer - 1) = 2
           tracerObject % parentIndex(tracerObject % index_snowDensity + iSnowLayer - 1) = 2
        enddo ! iSnowLayer
     endif
@@ -7022,6 +7018,8 @@ contains
     ! snow grain radius
     if (config_use_snow_grain_radius) then
        do iSnowLayer = 1, nSnowLayers
+          tracerObject % parentIndex(tracerObject % index_snowIceMass + iSnowLayer - 1) = 2
+          tracerObject % parentIndex(tracerObject % index_snowLiquidMass + iSnowLayer - 1) = 2
           tracerObject % parentIndex(tracerObject % index_snowGrainRadius + iSnowLayer - 1) = 2
        enddo ! iSnowLayer
     endif
@@ -7500,18 +7498,18 @@ contains
        nTracers = nTracers + 1
     end if
 
-    ! snow density (ice mass, liquid mass, density)
+    ! snow density (density from compaction)
     if (config_use_effective_snow_density) then
-       tracerArrayCategory(nTracers:nTracers+nSnowLayers-1,:) = snowIceMass(:,:,iCell)
-       nTracers = nTracers + nSnowLayers
-       tracerArrayCategory(nTracers:nTracers+nSnowLayers-1,:) = snowLiquidMass(:,:,iCell)
-       nTracers = nTracers + nSnowLayers
        tracerArrayCategory(nTracers:nTracers+nSnowLayers-1,:) = snowDensity(:,:,iCell)
        nTracers = nTracers + nSnowLayers
     endif
 
     ! snow grain radius
     if (config_use_snow_grain_radius) then
+       tracerArrayCategory(nTracers:nTracers+nSnowLayers-1,:) = snowIceMass(:,:,iCell)
+       nTracers = nTracers + nSnowLayers
+       tracerArrayCategory(nTracers:nTracers+nSnowLayers-1,:) = snowLiquidMass(:,:,iCell)
+       nTracers = nTracers + nSnowLayers
        tracerArrayCategory(nTracers:nTracers+nSnowLayers-1,:) = snowGrainRadius(:,:,iCell)
        nTracers = nTracers + nSnowLayers
     endif
@@ -7689,18 +7687,18 @@ contains
        nTracers = nTracers + 1
     end if
 
-    ! snow density (ice mass, liquid mass, density)
+    ! snow density (density from compaction)
     if (config_use_effective_snow_density) then
-       snowIceMass(:,:,iCell) = tracerArrayCategory(nTracers:nTracers+nSnowLayers-1,:)
-       nTracers = nTracers + nSnowLayers
-       snowLiquidMass(:,:,iCell) = tracerArrayCategory(nTracers:nTracers+nSnowLayers-1,:)
-       nTracers = nTracers + nSnowLayers
        snowDensity(:,:,iCell) = tracerArrayCategory(nTracers:nTracers+nSnowLayers-1,:)
        nTracers = nTracers + nSnowLayers
     endif
 
     ! snow grain radius
     if (config_use_snow_grain_radius) then
+       snowIceMass(:,:,iCell) = tracerArrayCategory(nTracers:nTracers+nSnowLayers-1,:)
+       nTracers = nTracers + nSnowLayers
+       snowLiquidMass(:,:,iCell) = tracerArrayCategory(nTracers:nTracers+nSnowLayers-1,:)
+       nTracers = nTracers + nSnowLayers
        snowGrainRadius(:,:,iCell) = tracerArrayCategory(nTracers:nTracers+nSnowLayers-1,:)
        nTracers = nTracers + nSnowLayers
     endif
@@ -7879,18 +7877,18 @@ contains
        nTracers = nTracers + 1
     end if
 
-    ! snow density (ice mass, liquid mass, density)
+    ! snow density (density from compaction)
     if (config_use_effective_snow_density) then
-       tracerArrayCell(nTracers:nTracers+nSnowLayers-1) = snowIceMassCell(:,iCell)
-       nTracers = nTracers + nSnowLayers
-       tracerArrayCell(nTracers:nTracers+nSnowLayers-1) = snowLiquidMassCell(:,iCell)
-       nTracers = nTracers + nSnowLayers
        tracerArrayCell(nTracers:nTracers+nSnowLayers-1) = snowDensityCell(:,iCell)
        nTracers = nTracers + nSnowLayers
     endif
 
     ! snow grain radius
     if (config_use_snow_grain_radius) then
+       tracerArrayCell(nTracers:nTracers+nSnowLayers-1) = snowIceMassCell(:,iCell)
+       nTracers = nTracers + nSnowLayers
+       tracerArrayCell(nTracers:nTracers+nSnowLayers-1) = snowLiquidMassCell(:,iCell)
+       nTracers = nTracers + nSnowLayers
        tracerArrayCell(nTracers:nTracers+nSnowLayers-1) = snowGrainRadiusCell(:,iCell)
        nTracers = nTracers + nSnowLayers
     endif
@@ -8069,18 +8067,18 @@ contains
        nTracers = nTracers + 1
     end if
 
-    ! snow density (ice mass, liquid mass, density)
+    ! snow density (density from compaction)
     if (config_use_effective_snow_density) then
-       snowIceMassCell(:,iCell) = tracerArrayCell(nTracers:nTracers+nSnowLayers-1)
-       nTracers = nTracers + nSnowLayers
-       snowLiquidMassCell(:,iCell) = tracerArrayCell(nTracers:nTracers+nSnowLayers-1)
-       nTracers = nTracers + nSnowLayers
        snowDensityCell(:,iCell) = tracerArrayCell(nTracers:nTracers+nSnowLayers-1)
        nTracers = nTracers + nSnowLayers
     endif
 
     ! snow grain radius
     if (config_use_snow_grain_radius) then
+       snowIceMassCell(:,iCell) = tracerArrayCell(nTracers:nTracers+nSnowLayers-1)
+       nTracers = nTracers + nSnowLayers
+       snowLiquidMassCell(:,iCell) = tracerArrayCell(nTracers:nTracers+nSnowLayers-1)
+       nTracers = nTracers + nSnowLayers
        snowGrainRadiusCell(:,iCell) = tracerArrayCell(nTracers:nTracers+nSnowLayers-1)
        nTracers = nTracers + nSnowLayers
     endif
@@ -9919,7 +9917,8 @@ contains
          config_category_bounds_type, &
          config_pond_refreezing_type, &
          config_ocean_heat_transfer_type, &
-         config_sea_freezing_temperature_type
+         config_sea_freezing_temperature_type, &
+         config_snow_redistribution_scheme
 
     logical, pointer :: &
          config_calc_surface_stresses, &
@@ -9947,7 +9946,11 @@ contains
          config_use_DON, &
          config_use_iron, &
          config_use_modal_aerosols, &
-         config_use_column_biogeochemistry
+         config_use_column_biogeochemistry, &
+         config_use_column_snow_tracers, &
+         config_use_effective_snow_density, &
+         config_use_snow_liquid_ponds, &
+         config_use_snow_grain_radius
 
     logical :: &
          use_meltponds
@@ -10008,6 +10011,11 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_use_column_biogeochemistry", config_use_column_biogeochemistry)
     call MPAS_pool_get_config(domain % configs, "config_nSnowLayers", config_nSnowLayers)
     call MPAS_pool_get_config(domain % configs, "config_nIceLayers", config_nIceLayers)
+    call MPAS_pool_get_config(domain % configs, "config_use_column_snow_tracers", config_use_column_snow_tracers)
+    call MPAS_pool_get_config(domain % configs, "config_use_effective_snow_density", config_use_effective_snow_density)
+    call MPAS_pool_get_config(domain % configs, "config_snow_redistribution_scheme", config_snow_redistribution_scheme)
+    call MPAS_pool_get_config(domain % configs, "config_use_snow_liquid_ponds", config_use_snow_liquid_ponds)
+    call MPAS_pool_get_config(domain % configs, "config_use_snow_grain_radius", config_use_snow_grain_radius)
 
     !-----------------------------------------------------------------------
     ! Check values
@@ -10138,6 +10146,35 @@ contains
     if (config_use_level_meltponds .and. abs(config_snow_to_ice_transition_depth) > seaicePuny) then
        call mpas_log_write(&
             "check_column_package_configs: config_use_level_meltponds = .true. and config_snow_to_ice_transition_depth /= 0", &
+            messageType=MPAS_LOG_CRIT)
+    endif
+
+    ! check config_snow_redistribution_scheme
+      if ((trim(config_snow_redistribution_scheme) == "ITDrdg" .or. &
+         trim(config_snow_redistribution_scheme) == "ITDsd") .and. .not. config_use_effective_snow_density) then
+       call mpas_log_write(&
+         "check_column_package_configs: config_snow_redistribution = 'ITD' but config_use_effective_snow_density is false", &
+            messageType=MPAS_LOG_CRIT)
+    endif
+
+    ! check config_use_snow_liquid_ponds and config_use_snow_grain_radius
+    if (config_use_snow_liquid_ponds .and. .not. config_use_snow_grain_radius) then
+       call mpas_log_write(&
+         "check_column_package_configs: config_use_snow_liquid_ponds = true but config_use_snow_grain_radius = false", &
+            messageType=MPAS_LOG_CRIT)
+    endif
+
+    ! check config_use_snow_grain_radius and config_use_column_snow_tracers
+    if (config_use_snow_grain_radius .and. .not. config_use_column_snow_tracers) then
+       call mpas_log_write(&
+         "check_column_package_configs: config_use_snow_grain_radius = true but config_use_column_snow_tracers = false", &
+            messageType=MPAS_LOG_CRIT)
+    endif
+
+    ! check config_use_snow_grain_radius and config_use_column_snow_tracers
+    if (config_use_column_snow_tracers .and. .not. config_use_snow_grain_radius) then
+       call mpas_log_write(&
+         "check_column_package_configs: config_use_column_snow_tracers but config_use_snow_grain_radius = false", &
             messageType=MPAS_LOG_CRIT)
     endif
 
@@ -12694,13 +12731,13 @@ contains
        ! snow density tracers
        if (.not. pkgColumnTracerEffectiveSnowDensityActive) then
           call set_stand_in_tracer_array(block, "snowDensity")
-          call set_stand_in_tracer_array(block, "snowLiquidMass")
-          call set_stand_in_tracer_array(block, "snowIceMass")
        endif
 
        ! snow grain radius
        if (.not. pkgColumnTracerSnowGrainRadiusActive) then
           call set_stand_in_tracer_array(block, "snowGrainRadius")
+          call set_stand_in_tracer_array(block, "snowLiquidMass")
+          call set_stand_in_tracer_array(block, "snowIceMass")
        endif
        !-----------------------------------------------------------------------
        ! other column packages
@@ -13024,13 +13061,13 @@ contains
        ! snow density tracers
        if (.not. pkgColumnTracerEffectiveSnowDensityActive) then
           call finalize_stand_in_tracer_array(block, "snowDensity")
-          call finalize_stand_in_tracer_array(block, "snowLiquidMass")
-          call finalize_stand_in_tracer_array(block, "snowIceMass")
        endif
 
        ! snow grain radius
        if (.not. pkgColumnTracerSnowGrainRadiusActive) then
           call finalize_stand_in_tracer_array(block, "snowGrainRadius")
+          call finalize_stand_in_tracer_array(block, "snowLiquidMass")
+          call finalize_stand_in_tracer_array(block, "snowIceMass")
        endif
        !-----------------------------------------------------------------------
        ! other column packages

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -510,7 +510,8 @@ contains
          snowVolumeCell
 
     real(kind=RKIND), pointer :: &
-         config_fallen_snow_radius
+         config_fallen_snow_radius, &
+         config_new_snow_density
 
     integer, pointer :: &
          nCellsSolve, &
@@ -525,6 +526,7 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_use_effective_snow_density", config_use_effective_snow_density)
     call MPAS_pool_get_config(domain % configs, "config_use_snow_grain_radius", config_use_snow_grain_radius)
     call MPAS_pool_get_config(domain % configs, "config_fallen_snow_radius", config_fallen_snow_radius)
+    call MPAS_pool_get_config(domain % configs, "config_new_snow_density", config_new_snow_density)
     call MPAS_pool_get_config(domain % configs, "config_do_restart_snow_density", config_do_restart_snow_density)
     call MPAS_pool_get_config(domain % configs, "config_do_restart_snow_grain_radius", config_do_restart_snow_grain_radius)
 
@@ -542,72 +544,36 @@ contains
 
        call MPAS_pool_get_array(tracers, "snowVolumeCategory", snowVolumeCategory, 1)
        call MPAS_pool_get_array(tracers_aggregate, "snowVolumeCell", snowVolumeCell)
+       call MPAS_pool_get_array(snow, "snowMeltMassCategory", snowMeltMassCategory)
+       call MPAS_pool_get_array(snow, "snowMeltMassCell", snowMeltMassCell)
+       call MPAS_pool_get_array(snow, "snowDensityViaContent", snowDensityViaContent)
+
+       snowMeltMassCategory(:,:)   = 0.0_RKIND
+       snowMeltMassCell(:)         = 0.0_RKIND
+       snowDensityViaContent(:)    = seaiceDensitySnow
 
        if (config_use_effective_snow_density) then
 
-          call MPAS_pool_get_array(snow, "snowDensityViaContent", snowDensityViaContent)
           call MPAS_pool_get_array(snow, "snowDensityViaCompaction", snowDensityViaCompaction)
-          call MPAS_pool_get_array(snow, "snowMeltMassCategory", snowMeltMassCategory)
-          call MPAS_pool_get_array(snow, "snowMeltMassCell", snowMeltMassCell)
-
-          call MPAS_pool_get_array(tracers, "snowIceMass", snowIceMass, 1)
-          call MPAS_pool_get_array(tracers, "snowLiquidMass", snowLiquidMass, 1)
           call MPAS_pool_get_array(tracers, "snowDensity", snowDensity, 1)
 
           if (.not. config_do_restart_snow_density) then
-
-             snowIceMass(:,:,:)          = 0.0_RKIND
-             snowLiquidMass(:,:,:)       = 0.0_RKIND
-             snowDensity(:,:,:)          = 0.0_RKIND
-             snowDensityViaContent(:)    = 0.0_RKIND
-             snowDensityViaCompaction(:) = 0.0_RKIND
-             snowMeltMassCategory(:,:)   = 0.0_RKIND
-             snowMeltMassCell(:)         = 0.0_RKIND
-
+             snowDensity(:,:,:)          = config_new_snow_density
              do iCell = 1, nCellsSolve
-
-                do iCategory = 1, nCategories
-                   if (snowVolumeCategory(1,iCategory,iCell) .gt. 0.0_RKIND) then
-                      do iSnowLayer = 1, nSnowLayers
-                         snowIceMass(iSnowLayer,iCategory,iCell) = seaiceDensitySnow
-                         snowDensity(iSnowLayer,iCategory,iCell) = seaiceDensitySnow
-                         snowDensityViaContent(iCell) = snowDensityViaContent(iCell) &
-                            + snowVolumeCategory(1,iCategory,iCell) * &
-                            (snowIceMass(iSnowLayer,iCategory,iCell) + &
-                            snowLiquidMass(iSnowLayer,iCategory,iCell))
-                         snowDensityViaCompaction(iCell) = snowDensityViaCompaction(iCell) &
-                            + snowVolumeCategory(1,iCategory,iCell) * &
-                            snowDensity(iSnowLayer,iCategory,iCell)
-                      enddo !iSnowLayer
-                   endif !snowVolumeCategory
-                enddo !iCategory
-                if (snowVolumeCell(iCell) .gt.  seaicePuny) then
-                   snowDensityViaContent(iCell) = snowDensityViaContent(iCell)/ &
-                      (snowVolumeCell(iCell) * real(nSnowLayers,kind=RKIND))  !!!CHECK THIS!!!
-                   snowDensityViaCompaction(iCell) = snowDensityViaCompaction(iCell)/ &
-                      (snowVolumeCell(iCell) * real(nSnowLayers,kind=RKIND))
+                if (snowVolumeCell(iCell) .gt. seaicePuny) then
+                   snowDensityViaCompaction(iCell) = config_new_snow_density
                 else
-                   snowDensityViaContent(iCell)    = 0.0_RKIND
                    snowDensityViaCompaction(iCell) = 0.0_RKIND
-                endif !snowVolumeCell
-
-             enddo ! iCell
+                endif
+             enddo
           else
-
-             snowDensityViaContent(:)    = 0.0_RKIND
              snowDensityViaCompaction(:) = 0.0_RKIND
-             snowMeltMassCategory(:,:)   = 0.0_RKIND
-             snowMeltMassCell(:)         = 0.0_RKIND
 
              do iCell = 1, nCellsSolve
 
                 do iCategory = 1, nCategories
                    if (snowVolumeCategory(1,iCategory,iCell) .gt. 0.0_RKIND) then
                       do iSnowLayer = 1, nSnowLayers
-                         snowDensityViaContent(iCell) = snowDensityViaContent(iCell) &
-                            + snowVolumeCategory(1,iCategory,iCell) * &
-                            (snowIceMass(iSnowLayer,iCategory,iCell) + &
-                            snowLiquidMass(iSnowLayer,iCategory,iCell))
                          snowDensityViaCompaction(iCell) = snowDensityViaCompaction(iCell) &
                             + snowVolumeCategory(1,iCategory,iCell) * &
                             snowDensity(iSnowLayer,iCategory,iCell)
@@ -615,12 +581,9 @@ contains
                    endif !snowVolumeCategory
                 enddo !iCategory
                 if (snowVolumeCell(iCell) .gt.  seaicePuny) then
-                   snowDensityViaContent(iCell) = snowDensityViaContent(iCell)/ &
-                      (snowVolumeCell(iCell) * real(nSnowLayers,kind=RKIND))  !!!CHECK THIS!!!
                    snowDensityViaCompaction(iCell) = snowDensityViaCompaction(iCell)/ &
                       (snowVolumeCell(iCell) * real(nSnowLayers,kind=RKIND))
                 else
-                   snowDensityViaContent(iCell)    = 0.0_RKIND
                    snowDensityViaCompaction(iCell) = 0.0_RKIND
                 endif !snowVolumeCell
 
@@ -629,18 +592,41 @@ contains
        endif !config_use_effective_snow_density
 
        if (config_use_snow_grain_radius) then
-
-          call MPAS_pool_get_array(tracers, "snowGrainRadius", snowGrainRadius, 1)
-
           if (.not. config_do_restart_snow_grain_radius) then
 
-             snowGrainRadius(:,:,:) = config_fallen_snow_radius
+             call MPAS_pool_get_array(tracers, "snowIceMass", snowIceMass, 1)
+             call MPAS_pool_get_array(tracers, "snowLiquidMass", snowLiquidMass, 1)
+             call MPAS_pool_get_array(tracers, "snowGrainRadius", snowGrainRadius, 1)
 
+             snowGrainRadius(:,:,:)      = config_fallen_snow_radius
+             snowIceMass(:,:,:)          = seaiceDensitySnow
+             snowLiquidMass(:,:,:)       = 0.0_RKIND
+             snowDensityViaContent(:)    = seaiceDensitySnow
+
+          else
+             do iCell = 1, nCellsSolve
+                snowDensityViaContent(iCell) = 0.0_RKIND
+                do iCategory = 1, nCategories
+                   if (snowVolumeCategory(1,iCategory,iCell) .gt. 0.0_RKIND) then
+                      do iSnowLayer = 1, nSnowLayers
+                         snowDensityViaContent(iCell) = snowDensityViaContent(iCell) &
+                             + snowVolumeCategory(1,iCategory,iCell) * &
+                             (snowIceMass(iSnowLayer,iCategory,iCell) + &
+                             snowLiquidMass(iSnowLayer,iCategory,iCell))
+                       enddo !iSnowLayer
+                   endif !snowVolumeCategory
+                enddo !iCategory
+                if (snowVolumeCell(iCell) .gt.  seaicePuny) then
+                   snowDensityViaContent(iCell) = snowDensityViaContent(iCell)/ &
+                       (snowVolumeCell(iCell) * real(nSnowLayers,kind=RKIND))  !!!CHECK THIS!!!
+                else
+                   snowDensityViaContent(iCell)    = seaiceDensitySnow
+                endif !snowVolumeCell
+             enddo ! iCell
           endif ! config_do_restart_snow_grain_radius
-       endif ! config_use_snow_grain_radius
-
-       block => block % next
-    end do
+        endif ! config_use_snow_grain_radius
+        block => block % next
+     end do
 
   end subroutine init_column_snow_tracers
 
@@ -2690,7 +2676,8 @@ contains
          colpkg_get_warnings
 
     use seaice_constants, only: &
-         seaicePuny
+         seaicePuny, &
+         seaiceDensitySnow
 
     type(domain_type), intent(inout) :: domain
 
@@ -2771,9 +2758,6 @@ contains
          setGetPhysicsTracers, &
          setGetBGCTracers
 
-    real(kind=RKIND), dimension(:,:), allocatable :: &
-         effectiveSnowDensityCategory
-
     character(len=strKIND) :: &
          abortMessage, &
          abortLocation
@@ -2845,11 +2829,7 @@ contains
        setGetPhysicsTracers = .true.
        setGetBGCTracers     = config_use_column_biogeochemistry
 
-       allocate(effectiveSnowDensityCategory(1:nSnowLayers,1:nCategories))
-
        do iCell = 1, nCellsSolve
-
-          effectiveSnowDensityCategory(:,:) = 0.0_RKIND
 
           abortFlag = .false.
           abortMessage = ""
@@ -2869,8 +2849,6 @@ contains
                levelIceVolume(1,:,iCell), &
                snowIceMass(:,:,iCell), &
                snowLiquidMass(:,:,iCell), &
-               effectiveSnowDensityCategory(:,:), &
-               snowDensityViaContent(iCell), &
                snowDensity(:,:,iCell), &
                snowDensityViaCompaction(iCell), &
                snowGrainRadius(:,:,iCell), &
@@ -2897,9 +2875,27 @@ contains
 
           call column_write_warnings(abortFlag)
 
-       enddo !iCell
+          if (config_use_snow_grain_radius) then
+             snowDensityViaContent(iCell) = 0.0_RKIND
+             do iCategory = 1, nCategories
+                if (snowVolumeCategory(1,iCategory,iCell) .gt. 0.0_RKIND) then
+                   do iSnowLayer = 1, nSnowLayers
+                      snowDensityViaContent(iCell) = snowDensityViaContent(iCell) &
+                         + snowVolumeCategory(1,iCategory,iCell) * &
+                         (snowIceMass(iSnowLayer,iCategory,iCell) + &
+                         snowLiquidMass(iSnowLayer,iCategory,iCell))
+                   enddo !iSnowLayer
+                endif !snowVolumeCategory
+             enddo !iCategory
+             if (snowVolumeCell(iCell) .gt.  seaicePuny) then
+                snowDensityViaContent(iCell) = snowDensityViaContent(iCell)/ &
+                   (snowVolumeCell(iCell) * real(nSnowLayers,kind=RKIND))  !!!CHECK THIS!!!
+             else
+                snowDensityViaContent(iCell)    = seaiceDensitySnow
+             endif !snowVolumeCell
+          endif
 
-       deallocate(effectiveSnowDensityCategory)
+       enddo !iCell
 
        block => block % next
     end do
@@ -6464,14 +6460,14 @@ contains
         config_use_topo_meltponds) &
          tracerObject % nTracers = tracerObject % nTracers + 1
 
-    ! snow density (ice mass, liquid mass, density)
+    ! snow density (density tracer is density from compaction)
     if (config_use_effective_snow_density) then
-       tracerObject % nTracers = tracerObject % nTracers + nSnowLayers*3
+       tracerObject % nTracers = tracerObject % nTracers + nSnowLayers
     endif
 
-    ! snow grain radius
+    ! snow grain radius (ice mass, liquid mass, and snow grain radius)
     if (config_use_snow_grain_radius) then
-       tracerObject % nTracers = tracerObject % nTracers + nSnowLayers
+       tracerObject % nTracers = tracerObject % nTracers + nSnowLayers*3
     endif
 
     ! aerosols
@@ -6724,21 +6720,21 @@ contains
     endif
 
     ! snow density
-    tracerObject % index_snowIceMass = indexMissingValue
-    tracerObject % index_snowLiquidMass = indexMissingValue
     tracerObject % index_snowDensity = indexMissingValue
     if (config_use_effective_snow_density) then
-       tracerObject % index_snowIceMass = nTracers + 1
-       nTracers = nTracers + nSnowLayers
-       tracerObject % index_snowLiquidMass = nTracers + 1
-       nTracers = nTracers + nSnowLayers
        tracerObject % index_snowDensity = nTracers + 1
        nTracers = nTracers + nSnowLayers
     endif
 
     ! snow grain radius
+    tracerObject % index_snowIceMass = indexMissingValue
+    tracerObject % index_snowLiquidMass = indexMissingValue
     tracerObject % index_snowGrainRadius = indexMissingValue
     if (config_use_snow_grain_radius) then
+       tracerObject % index_snowIceMass = nTracers + 1
+       nTracers = nTracers + nSnowLayers
+       tracerObject % index_snowLiquidMass = nTracers + 1
+       nTracers = nTracers + nSnowLayers
        tracerObject % index_snowGrainRadius = nTracers + 1
        nTracers = nTracers + nSnowLayers
     endif
@@ -6861,8 +6857,6 @@ contains
     ! snow density
     if (config_use_effective_snow_density) then
        do iSnowLayer = 1, nSnowLayers
-          tracerObject % parentIndex(tracerObject % index_snowIceMass + iSnowLayer - 1) = 2
-          tracerObject % parentIndex(tracerObject % index_snowLiquidMass + iSnowLayer - 1) = 2
           tracerObject % parentIndex(tracerObject % index_snowDensity + iSnowLayer - 1) = 2
        enddo ! iSnowLayer
     endif
@@ -6870,6 +6864,8 @@ contains
     ! snow grain radius
     if (config_use_snow_grain_radius) then
        do iSnowLayer = 1, nSnowLayers
+          tracerObject % parentIndex(tracerObject % index_snowIceMass + iSnowLayer - 1) = 2
+          tracerObject % parentIndex(tracerObject % index_snowLiquidMass + iSnowLayer - 1) = 2
           tracerObject % parentIndex(tracerObject % index_snowGrainRadius + iSnowLayer - 1) = 2
        enddo ! iSnowLayer
     endif
@@ -7348,18 +7344,18 @@ contains
        nTracers = nTracers + 1
     end if
 
-    ! snow density (ice mass, liquid mass, density)
+    ! snow density (density from compaction)
     if (config_use_effective_snow_density) then
-       tracerArrayCategory(nTracers:nTracers+nSnowLayers-1,:) = snowIceMass(:,:,iCell)
-       nTracers = nTracers + nSnowLayers
-       tracerArrayCategory(nTracers:nTracers+nSnowLayers-1,:) = snowLiquidMass(:,:,iCell)
-       nTracers = nTracers + nSnowLayers
        tracerArrayCategory(nTracers:nTracers+nSnowLayers-1,:) = snowDensity(:,:,iCell)
        nTracers = nTracers + nSnowLayers
     endif
 
     ! snow grain radius
     if (config_use_snow_grain_radius) then
+       tracerArrayCategory(nTracers:nTracers+nSnowLayers-1,:) = snowIceMass(:,:,iCell)
+       nTracers = nTracers + nSnowLayers
+       tracerArrayCategory(nTracers:nTracers+nSnowLayers-1,:) = snowLiquidMass(:,:,iCell)
+       nTracers = nTracers + nSnowLayers
        tracerArrayCategory(nTracers:nTracers+nSnowLayers-1,:) = snowGrainRadius(:,:,iCell)
        nTracers = nTracers + nSnowLayers
     endif
@@ -7537,18 +7533,18 @@ contains
        nTracers = nTracers + 1
     end if
 
-    ! snow density (ice mass, liquid mass, density)
+    ! snow density (density from compaction)
     if (config_use_effective_snow_density) then
-       snowIceMass(:,:,iCell) = tracerArrayCategory(nTracers:nTracers+nSnowLayers-1,:)
-       nTracers = nTracers + nSnowLayers
-       snowLiquidMass(:,:,iCell) = tracerArrayCategory(nTracers:nTracers+nSnowLayers-1,:)
-       nTracers = nTracers + nSnowLayers
        snowDensity(:,:,iCell) = tracerArrayCategory(nTracers:nTracers+nSnowLayers-1,:)
        nTracers = nTracers + nSnowLayers
     endif
 
     ! snow grain radius
     if (config_use_snow_grain_radius) then
+       snowIceMass(:,:,iCell) = tracerArrayCategory(nTracers:nTracers+nSnowLayers-1,:)
+       nTracers = nTracers + nSnowLayers
+       snowLiquidMass(:,:,iCell) = tracerArrayCategory(nTracers:nTracers+nSnowLayers-1,:)
+       nTracers = nTracers + nSnowLayers
        snowGrainRadius(:,:,iCell) = tracerArrayCategory(nTracers:nTracers+nSnowLayers-1,:)
        nTracers = nTracers + nSnowLayers
     endif
@@ -7727,18 +7723,18 @@ contains
        nTracers = nTracers + 1
     end if
 
-    ! snow density (ice mass, liquid mass, density)
+    ! snow density (density from compaction)
     if (config_use_effective_snow_density) then
-       tracerArrayCell(nTracers:nTracers+nSnowLayers-1) = snowIceMassCell(:,iCell)
-       nTracers = nTracers + nSnowLayers
-       tracerArrayCell(nTracers:nTracers+nSnowLayers-1) = snowLiquidMassCell(:,iCell)
-       nTracers = nTracers + nSnowLayers
        tracerArrayCell(nTracers:nTracers+nSnowLayers-1) = snowDensityCell(:,iCell)
        nTracers = nTracers + nSnowLayers
     endif
 
     ! snow grain radius
     if (config_use_snow_grain_radius) then
+       tracerArrayCell(nTracers:nTracers+nSnowLayers-1) = snowIceMassCell(:,iCell)
+       nTracers = nTracers + nSnowLayers
+       tracerArrayCell(nTracers:nTracers+nSnowLayers-1) = snowLiquidMassCell(:,iCell)
+       nTracers = nTracers + nSnowLayers
        tracerArrayCell(nTracers:nTracers+nSnowLayers-1) = snowGrainRadiusCell(:,iCell)
        nTracers = nTracers + nSnowLayers
     endif
@@ -7917,18 +7913,18 @@ contains
        nTracers = nTracers + 1
     end if
 
-    ! snow density (ice mass, liquid mass, density)
+    ! snow density (density from compaction)
     if (config_use_effective_snow_density) then
-       snowIceMassCell(:,iCell) = tracerArrayCell(nTracers:nTracers+nSnowLayers-1)
-       nTracers = nTracers + nSnowLayers
-       snowLiquidMassCell(:,iCell) = tracerArrayCell(nTracers:nTracers+nSnowLayers-1)
-       nTracers = nTracers + nSnowLayers
        snowDensityCell(:,iCell) = tracerArrayCell(nTracers:nTracers+nSnowLayers-1)
        nTracers = nTracers + nSnowLayers
     endif
 
     ! snow grain radius
     if (config_use_snow_grain_radius) then
+       snowIceMassCell(:,iCell) = tracerArrayCell(nTracers:nTracers+nSnowLayers-1)
+       nTracers = nTracers + nSnowLayers
+       snowLiquidMassCell(:,iCell) = tracerArrayCell(nTracers:nTracers+nSnowLayers-1)
+       nTracers = nTracers + nSnowLayers
        snowGrainRadiusCell(:,iCell) = tracerArrayCell(nTracers:nTracers+nSnowLayers-1)
        nTracers = nTracers + nSnowLayers
     endif
@@ -10409,7 +10405,7 @@ contains
          tr_iage_in      = config_use_ice_age, &
          tr_FY_in        = config_use_first_year_ice, &
          tr_lvl_in       = config_use_level_ice, &
-         tr_snow_in      = use_snow, &
+         tr_snow_in      = config_use_effective_snow_density, &
          tr_pond_in      = use_meltponds, &
          !tr_pond_cesm_in = config_use_cesm_meltponds, & ! deprecated
          tr_pond_lvl_in  = config_use_level_meltponds, &
@@ -14641,15 +14637,15 @@ contains
           call set_stand_in_tracer_array(block, "verticalSalinity")
        endif
 
-       ! snow density tracers
+       ! snow density tracer
        if (.not. pkgColumnTracerEffectiveSnowDensityActive) then
           call set_stand_in_tracer_array(block, "snowDensity")
-          call set_stand_in_tracer_array(block, "snowLiquidMass")
-          call set_stand_in_tracer_array(block, "snowIceMass")
        endif
 
        ! snow grain radius
        if (.not. pkgColumnTracerSnowGrainRadiusActive) then
+          call set_stand_in_tracer_array(block, "snowLiquidMass")
+          call set_stand_in_tracer_array(block, "snowIceMass")
           call set_stand_in_tracer_array(block, "snowGrainRadius")
        endif
        !-----------------------------------------------------------------------
@@ -14971,16 +14967,16 @@ contains
           call finalize_stand_in_tracer_array(block, "verticalSalinity")
        endif
 
-       ! snow density tracers
+       ! snow density tracer
        if (.not. pkgColumnTracerEffectiveSnowDensityActive) then
           call finalize_stand_in_tracer_array(block, "snowDensity")
-          call finalize_stand_in_tracer_array(block, "snowLiquidMass")
-          call finalize_stand_in_tracer_array(block, "snowIceMass")
        endif
 
        ! snow grain radius
        if (.not. pkgColumnTracerSnowGrainRadiusActive) then
           call finalize_stand_in_tracer_array(block, "snowGrainRadius")
+          call finalize_stand_in_tracer_array(block, "snowLiquidMass")
+          call finalize_stand_in_tracer_array(block, "snowIceMass")
        endif
        !-----------------------------------------------------------------------
        ! other column packages

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -9801,7 +9801,8 @@ contains
          config_pond_refreezing_type, &
          config_salt_flux_coupling_type, &
          config_ocean_heat_transfer_type, &
-         config_sea_freezing_temperature_type
+         config_sea_freezing_temperature_type, &
+         config_snow_redistribution_scheme
 
     logical, pointer :: &
          config_calc_surface_stresses, &
@@ -9829,7 +9830,11 @@ contains
          config_use_DON, &
          config_use_iron, &
          config_use_modal_aerosols, &
-         config_use_column_biogeochemistry
+         config_use_column_biogeochemistry, &
+         config_use_column_snow_tracers, &
+         config_use_effective_snow_density, &
+         config_use_snow_liquid_ponds, &
+         config_use_snow_grain_radius
 
     logical :: &
          use_meltponds
@@ -9893,6 +9898,11 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_use_column_biogeochemistry", config_use_column_biogeochemistry)
     call MPAS_pool_get_config(domain % configs, "config_nSnowLayers", config_nSnowLayers)
     call MPAS_pool_get_config(domain % configs, "config_nIceLayers", config_nIceLayers)
+    call MPAS_pool_get_config(domain % configs, "config_use_column_snow_tracers", config_use_column_snow_tracers)
+    call MPAS_pool_get_config(domain % configs, "config_use_effective_snow_density", config_use_effective_snow_density)
+    call MPAS_pool_get_config(domain % configs, "config_snow_redistribution_scheme", config_snow_redistribution_scheme)
+    call MPAS_pool_get_config(domain % configs, "config_use_snow_liquid_ponds", config_use_snow_liquid_ponds)
+    call MPAS_pool_get_config(domain % configs, "config_use_snow_grain_radius", config_use_snow_grain_radius)
 
     !-----------------------------------------------------------------------
     ! Check values
@@ -10028,6 +10038,35 @@ contains
     if (config_use_level_meltponds .and. abs(config_snow_to_ice_transition_depth) > seaicePuny) then
        call mpas_log_write(&
             "check_column_package_configs: config_use_level_meltponds = .true. and config_snow_to_ice_transition_depth /= 0", &
+            messageType=MPAS_LOG_CRIT)
+    endif
+
+    ! check config_snow_redistribution_scheme
+      if ((trim(config_snow_redistribution_scheme) == "ITDrdg" .or. &
+         trim(config_snow_redistribution_scheme) == "ITDsd") .and. .not. config_use_effective_snow_density) then
+       call mpas_log_write(&
+         "check_column_package_configs: config_snow_redistribution = 'ITD' but config_use_effective_snow_density is false", &
+            messageType=MPAS_LOG_CRIT)
+    endif
+
+    ! check config_use_snow_liquid_ponds and config_use_snow_grain_radius
+    if (config_use_snow_liquid_ponds .and. .not. config_use_snow_grain_radius) then
+       call mpas_log_write(&
+         "check_column_package_configs: config_use_snow_liquid_ponds = true but config_use_snow_grain_radius = false", &
+            messageType=MPAS_LOG_CRIT)
+    endif
+
+    ! check config_use_snow_grain_radius and config_use_column_snow_tracers
+    if (config_use_snow_grain_radius .and. .not. config_use_column_snow_tracers) then
+       call mpas_log_write(&
+         "check_column_package_configs: config_use_snow_grain_radius = true but config_use_column_snow_tracers = false", &
+            messageType=MPAS_LOG_CRIT)
+    endif
+
+    ! check config_use_snow_grain_radius and config_use_column_snow_tracers
+    if (config_use_column_snow_tracers .and. .not. config_use_snow_grain_radius) then
+       call mpas_log_write(&
+         "check_column_package_configs: config_use_column_snow_tracers but config_use_snow_grain_radius = false", &
             messageType=MPAS_LOG_CRIT)
     endif
 


### PR DESCRIPTION
-Config_use_effective_density activates density from compaction only which is needed for ITD snow redistribution
-Config_use_snow_grain_radius activates snow grain radius and also needs snow liquid and snow ice tracers
-Includes a bugfix in snow_redistribution when using 1 snow layer. Will need to be fixed in Icepack

BFB with snow flag defaults
except for the very initial value of effective snow density