### PR TITLE
Adds mpassi-icepack interface for snow flag options

### DIFF
--- a/components/mpas-seaice/bld/build-namelist
+++ b/components/mpas-seaice/bld/build-namelist
@@ -841,6 +841,7 @@ add_default($nl, 'config_new_snow_density');
 add_default($nl, 'config_max_snow_density');
 add_default($nl, 'config_minimum_wind_compaction');
 add_default($nl, 'config_wind_compaction_factor');
+add_default($nl, 'config_wind_snow_loss_factor');
 add_default($nl, 'config_max_dry_snow_radius');
 
 #############################

--- a/components/mpas-seaice/bld/build-namelist-section
+++ b/components/mpas-seaice/bld/build-namelist-section
@@ -364,6 +364,7 @@ add_default($nl, 'config_new_snow_density');
 add_default($nl, 'config_max_snow_density');
 add_default($nl, 'config_minimum_wind_compaction');
 add_default($nl, 'config_wind_compaction_factor');
+add_default($nl, 'config_wind_snow_loss_factor');
 add_default($nl, 'config_max_dry_snow_radius');
 
 #############################

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -357,6 +357,7 @@
 <config_max_snow_density>450.0</config_max_snow_density>
 <config_minimum_wind_compaction>10.0</config_minimum_wind_compaction>
 <config_wind_compaction_factor>27.3</config_wind_compaction_factor>
+<config_wind_snow_loss_factor>0.3</config_wind_snow_loss_factor>
 <config_max_dry_snow_radius>2800.0</config_max_dry_snow_radius>
 
 <!-- meltponds -->

--- a/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
@@ -2249,6 +2249,14 @@ Valid values: positive real
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_wind_snow_loss_factor" type="real"
+	category="snow" group="snow">
+snow loss factor for wind redistribution
+
+Valid values: positive real less than or equal to 1
+Default: Defined in namelist_defaults.xml
+</entry>
+
 <entry id="config_max_dry_snow_radius" type="real"
 	category="snow" group="snow">
 maximum dry metamorphism snow grain radius

--- a/components/mpas-seaice/src/Registry.xml
+++ b/components/mpas-seaice/src/Registry.xml
@@ -1600,6 +1600,11 @@
 			possible_values="positive real"
 			icepack_name="drhosdwind"
 		/>
+		<nml_option name="config_wind_snow_loss_factor" type="real" default_value="0.3" units="none"
+			description="snow loss factor for wind redistribution"
+			possible_values="positive real less than or equal to 1"
+			icepack_name="snwlvlfac"
+		/>
 		<nml_option name="config_max_dry_snow_radius" type="real" default_value="2800.0" units="um"
 			description="maximum dry metamorphism snow grain radius"
 			possible_values="positive real"
@@ -2563,7 +2568,7 @@
 		<package name="pkgColumnTracerPonds" description=""/>
 		<package name="pkgColumnTracerLidThickness" description=""/>
 		<package name="pkgColumnTracerAerosols" description=""/>
-		<package name="pkgColumnTracerEffectiveSnowDensity" description="Computes effective snow density based on liquid and ice snow content and snow compaction"/>
+		<package name="pkgColumnTracerEffectiveSnowDensity" description="Computes effective snow density based on snow compaction"/>
 		<package name="pkgColumnTracerSnowGrainRadius" description="Evolves snow grain radius for radiative transfer based on dry and wet metamorphism"/>
 		<package name="pkgTracerBrine" description=""/>
 		<package name="pkgTracerMobileFraction" description=""/>
@@ -2658,13 +2663,13 @@
 		     type="real"
 		     dimensions="nSnowLayers nCategories nCells Time"
 		     units="kg m-3"
-		     packages="pkgColumnTracerEffectiveSnowDensity"
+		     packages="pkgColumnTracerSnowGrainRadius"
 		/>
 		<var name="snowLiquidMass"
 		     type="real"
 		     dimensions="nSnowLayers nCategories nCells Time"
 		     units="kg m-3"
-		     packages="pkgColumnTracerEffectiveSnowDensity"
+		     packages="pkgColumnTracerSnowGrainRadius"
 		/>
 		<var name="snowGrainRadius"
 		     type="real"
@@ -3104,14 +3109,14 @@
 		     dimensions="nSnowLayers nCells Time"
 		     units="kg m-3"
 		     description="Mass of ice in snow layer"
-		     packages="pkgColumnTracerEffectiveSnowDensity"
+		     packages="pkgColumnTracerSnowGrainRadius"
 		/>
 		<var name="snowLiquidMassCell"
 		     type="real"
 		     dimensions="nSnowLayers nCells Time"
 		     units="kg m-3"
 		     description="Mass of liquid in snow layer"
-		     packages="pkgColumnTracerEffectiveSnowDensity"
+		     packages="pkgColumnTracerSnowGrainRadius"
 		/>
 		<var name="snowGrainRadiusCell"
 		     type="real"

--- a/components/mpas-seaice/src/column/constants/cesm/ice_constants_colpkg.F90
+++ b/components/mpas-seaice/src/column/constants/cesm/ice_constants_colpkg.F90
@@ -129,8 +129,6 @@
 
       ! snow parameters
       real (kind=dbl_kind), parameter, public :: &
-         snwlvlfac =   0.3_dbl_kind, & ! 30% rule: fractional increase in snow depth
-                                       ! over ridged ice, compared with level ice
          rhosmin   = 100.0_dbl_kind    ! minimum snow density (kg/m^3)
 
       !-----------------------------------------------------------------

--- a/components/mpas-seaice/src/column/constants/cice/ice_constants_colpkg.F90
+++ b/components/mpas-seaice/src/column/constants/cice/ice_constants_colpkg.F90
@@ -112,11 +112,9 @@
       real(kind=dbl_kind),public :: decln  ! solar declination angle in radians
       real(kind=dbl_kind),public :: eccf   ! earth orbit eccentricity factor
       logical(kind=log_kind),public :: log_print ! Flags print of status/error
-    
+
       ! snow parameters
       real (kind=dbl_kind), parameter, public :: &
-         snwlvlfac =   0.3_dbl_kind, & ! 30% rule: fractional increase in snow depth
-                                       ! over ridged ice, compared with level ice
          rhosmin   = 100.0_dbl_kind    ! minimum snow density (kg/m^3)
 
       !-----------------------------------------------------------------

--- a/components/mpas-seaice/src/column/ice_colpkg_shared.F90
+++ b/components/mpas-seaice/src/column/ice_colpkg_shared.F90
@@ -191,6 +191,7 @@
          rhosnew   , & ! new snow density (kg/m^3)
          rhosmax   , & ! maximum snow density (kg/m^3)
          windmin   , & ! minimum wind speed to compact snow (m/s)
+         snwlvlfac , & ! snow loss factor for wind redistribution
          drhosdwind    ! wind compaction factor (kg s/m^4)
 
       character(len=char_len), public :: & 

--- a/components/mpas-seaice/src/column/ice_itd.F90
+++ b/components/mpas-seaice/src/column/ice_itd.F90
@@ -1044,9 +1044,9 @@
 
       use ice_colpkg_tracers, only: nt_Tsfc, nt_qice, nt_qsno, nt_aero, &
                              nt_apnd, nt_hpnd, nt_fbri, tr_brine, nt_bgc_S, &
-                             bio_index
+                             bio_index, nt_rhos, nt_rsnw, nt_smice, tr_rsnw, tr_snow
       use ice_colpkg_shared, only:  solve_zsal, skl_bgc, z_tracers, min_salin, &
-                             rhosi
+                             rhosi, rhosnew, rsnw_fall
       use ice_constants_colpkg, only: sk_l
       use ice_zbgc_shared, only: zap_small_bgc
 
@@ -1225,6 +1225,17 @@
                   else
                      trcrn(it,n) = c0
                   endif
+               enddo
+            endif
+            if (tr_snow) then
+               do k = 1, nslyr
+                  trcrn(nt_rhos +k-1,n) = rhosnew
+               enddo
+            endif
+            if (tr_rsnw) then
+               do k = 1, nslyr
+                  trcrn(nt_smice+k-1,n) = rhos
+                  trcrn(nt_rsnw +k-1,n) = rsnw_fall
                enddo
             endif
             first_ice(n) = .true.

--- a/components/mpas-seaice/src/column/ice_shortwave.F90
+++ b/components/mpas-seaice/src/column/ice_shortwave.F90
@@ -45,10 +45,10 @@
       use ice_constants_colpkg, only: c0, c1, c1p5, c2, c3, c4, c10, &
           p01, p1, p15, p25, p5, p75, puny, &
           albocn, Timelt, snowpatch, awtvdr, awtidr, awtvdf, awtidf, &
-          kappav, hs_min, rhofresh, rhos, nspint, nspint_5bd, snwlvlfac
+          kappav, hs_min, rhofresh, rhos, nspint, nspint_5bd
       use ice_colpkg_shared, only: hi_ssl, hs_ssl, modal_aero, max_aero
       use ice_colpkg_shared, only: hi_ssl, hs_ssl, modal_aero, rsnw_fall, &
-          rsnw_tmax
+          rsnw_tmax, snwlvlfac
       use ice_warnings, only: add_warning
 
       implicit none
@@ -982,7 +982,7 @@
                apeffn(n) = fpn ! for history
             elseif (tr_pond_lvl) then
                hsnlvl = hsn ! initialize
-               if (trim(snwredist) == '30percentsw') then
+               if (trim(snwredist) == '30percent') then
                   hsnlvl = hsn / (c1 + snwlvlfac*(c1-alvln(n)))
                   ! snow volume over level ice
                   alvl = aicen(n) * alvln(n)

--- a/components/mpas-seaice/src/column/ice_snow.F90
+++ b/components/mpas-seaice/src/column/ice_snow.F90
@@ -8,8 +8,7 @@
 
       use ice_kinds_mod
       use ice_constants_colpkg, only: puny, c0, c1, c10, rhos, Lfresh, &
-                                      rhow, rhoi, rhofresh, snwlvlfac, &
-                                      rhosmin
+                                      rhow, rhoi, rhofresh, rhosmin
       use ice_warnings, only: add_warning
 
       implicit none
@@ -108,7 +107,7 @@
 
       subroutine snow_redist(dt, nslyr, ncat, wind, ain, vin, vsn, zqsn, &
          snwredist, alvl, vlvl, fresh, fhocn, fsloss, rhos_cmpn, &
-         fsnow, rhosmax, windmin, drhosdwind, l_stop, stop_label)
+         fsnow, rhosmax, windmin, drhosdwind, snwlvlfac, l_stop, stop_label)
 
       use ice_therm_vertical, only: adjust_enthalpy
 
@@ -122,7 +121,8 @@
          fsnow     , & ! snowfall rate (kg m-2 s-1)
          rhosmax   , & ! maximum snow density (kg/m^3)
          windmin   , & ! minimum wind speed to compact snow (m/s)
-         drhosdwind    ! wind compaction factor (kg s/m^4)
+         drhosdwind, & ! wind compaction factor (kg s/m^4)
+         snwlvlfac     ! snow loss factor for wind redistribution
 
       real (kind=dbl_kind), dimension(:), intent(in) :: &
          ain       , & ! ice area fraction

--- a/components/mpas-seaice/src/column/ice_therm_vertical.F90
+++ b/components/mpas-seaice/src/column/ice_therm_vertical.F90
@@ -83,6 +83,8 @@
                                   mlt_onset,   frz_onset, &
                                   yday,        dsnow,     &
                                   tr_rsnw,                &
+                                  !NJ: for bulk conservation fix
+                                  !tr_rsnw,     fsloss,    &
                                   l_stop,      stop_label,&
                                   prescribed_ice)
 
@@ -95,6 +97,9 @@
       real (kind=dbl_kind), intent(in) :: &
          dt      , & ! time step
          frain       ! rainfall rate (kg/m2/s)
+         !NJ: for bulk conservation fix
+         !frain   , & ! rainfall rate (kg/m2/s)
+         !fsloss      ! blowing snow loss to leads (kg/m2/s)
 
       ! ice state variables
       real (kind=dbl_kind), intent(inout) :: &
@@ -413,6 +418,10 @@
                              zSin,        sss,       &
                              dsnow,       tr_snow,   &
                              rsnw,        tr_rsnw)
+                             !NJL for bulk conservation fix
+                             !rsnw,        tr_rsnw,   &
+                             !fsloss)
+
 
       !-----------------------------------------------------------------
       ! Check for energy conservation by comparing the change in energy
@@ -427,6 +436,8 @@
                                       fcondtopn, fcondbot, &
                                       fadvocn,   fbotUse,  &
                                       l_stop,    stop_label)
+                                      !NJ: for bulk conservation fix
+                                      !l_stop,    stop_label, fsloss)
       
       if (l_stop) return
 
@@ -448,25 +459,27 @@
       ! evapn < 0 => sublimation, evapn > 0 => condensation
       ! aerosol flux is accounted for in ice_aerosol.F90
       !-----------------------------------------------------------------
-            
+
       dhi = hin - worki
       dhs = hsn - works - hsn_new
-      
+
       freshn = freshn + evapn - (rhoi*dhi + rhos*dhs) / dt
+      !NJ: for bulk conservation fix
+      !freshn = freshn + evapn - (rhoi*dhi + rhos*dhs) / dt + fsloss
       fsaltn = fsaltn - rhoi*dhi*ice_ref_salinity*p001/dt
-      fhocnn = fhocnn + fadvocn ! for ktherm=2 
+      fhocnn = fhocnn + fadvocn ! for ktherm=2
 
       if (hin == c0) then
          if (tr_pond_topo) fpond = fpond - aicen * apond * hpond
       endif
 
       !-----------------------------------------------------------------
-      !  Given the vertical thermo state variables, compute the new ice 
+      !  Given the vertical thermo state variables, compute the new ice
       !   state variables.
       !-----------------------------------------------------------------
 
       call update_state_vthermo(nilyr,   nslyr,   &
-                                Tbot,    Tsf,     &     
+                                Tbot,    Tsf,     &
                                 hin,     hsn,     &
                                 zqin,    zSin,    &
                                 zqsn,             &
@@ -1052,6 +1065,9 @@
                                     zSin,      sss,      &
                                     dsnow,     tr_snow,  &
                                     rsnw,      tr_rsnw)
+                                    !NJ: for bulk conservation fix
+                                    !rsnw,      tr_rsnw,  &
+                                    !fsloss)
 
       use ice_colpkg_shared, only: phi_i_mushy
       use ice_mushy_physics, only: enthalpy_mush, enthalpy_of_melting, &
@@ -1070,6 +1086,8 @@
          fbot        , & ! ice-ocean heat flux at bottom surface (W/m^2)
          Tbot        , & ! ice bottom surface temperature (deg C)
          fsnow       , & ! snowfall rate (kg m-2 s-1)
+         !NJ: for bulk conservation fix
+         !fsloss      , & ! snow loss to leads (kg m-2 s-1)
          flatn       , & ! surface downward latent heat (W m-2)
          fsurfn      , & ! net flux to top surface, excluding fcondtopn
          fcondtopn   , & ! downward cond flux at top surface (W m-2)
@@ -1158,6 +1176,9 @@
          Tmlts       , & ! melting temperature
          smtot       , & ! total ice + liquid mass of snow
          smice_precs     ! ice mass added to snow due to snowfall (kg/m^2)
+         !NJ: for bulk conservation fix
+         !smice_precs , & ! ice mass added to snow due to snowfall (kg/m^2)
+         !fsnw            ! snow fall rate minus loss to leads (kg m-2 s-1)
 
       real (kind=dbl_kind), dimension (nilyr+1) :: &
          zi1         , & ! depth of ice layer boundaries (m)
@@ -1182,7 +1203,9 @@
       real (kind=dbl_kind) :: &
          qbotm       , &
          qbotp       , &
-         qbot0
+         qbot0       , &
+         mass        , & ! total snow ice + liq (kg/m2)
+         massi           ! ice mass change factor
 
       !-----------------------------------------------------------------
       ! Initialize
@@ -1374,9 +1397,11 @@
 
          qsub = zqsn(k) - rhos*Lvap ! qsub < 0
          dhs  = max (-dzs(k), esub/qsub)  ! esub > 0, dhs < 0
-         smice_precs = c0
-         if (abs(dzs(k)) > puny) smice_precs = dhs * smicetot(k)/dzs(k)
-         smicetot(k) = max(c0,smicetot(k) + smice_precs)
+         mass = smicetot(k) + smliqtot(k)
+         massi = c0
+         if (dzs(k) > puny) massi = c1 + dhs/dzs(k)
+         smicetot(k) = smicetot(k) * massi
+         smliqtot(k) = max(c0, mass + rhos*dhs - smicetot(k)) ! conserve new total mass
          dzs(k) = dzs(k) + dhs
          esub = esub - dhs*qsub
          esub = max(esub, c0)   ! in case of roundoff error
@@ -1465,8 +1490,18 @@
          !--------------------------------------------------------------
          ! Melt snow (only if all the ice has melted)
          !--------------------------------------------------------------
-         
+
+         ! NJ: if all the ice is melted, should all remaining snow be added to fresh
+         ! and latent heat to fhocnn?
+
          dhs = max(-dzs(k), ebot_mlt/zqsn(k))
+
+         mass = smicetot(k) + smliqtot(k)
+         massi = c0
+         if (dzs(k) > puny) massi = max(c0, c1 + dhs/dzs(k))
+         smicetot(k) = smicetot(k) * massi
+         smliqtot(k) = mass - smicetot(k) ! conserve mass
+
          dzs(k) = dzs(k) + dhs         ! zqsn < 0, dhs < 0
          ebot_mlt = ebot_mlt - dhs*zqsn(k)
          ebot_mlt = max(ebot_mlt, c0)
@@ -1493,9 +1528,15 @@
       !       have T = 0 (i.e. q = -rhos*Lfresh) and should not be
       !       converted to rain.
       !----------------------------------------------------------------
+      !NJ: for bulk conservation fix
+      !fsnw = fsnow - fsloss
+      !if (fsnw > c0) then
 
       if (fsnow > c0) then
 
+         !NJ: for bulk conservation fix
+         !fhocnn = fhocnn - Lfresh * fsloss
+         !hsn_new = fsnw/rhos * dt
          hsn_new = fsnow/rhos * dt
          zqsnew = -rhos*Lfresh
          hstot = dzs(1) + hsn_new
@@ -1510,14 +1551,15 @@
 
               smtot = c0
               if (abs(dzs(1)) > c0) smtot = smicetot(1)/dzs(1) !smice(1) ! save for now
-         
+
                ! ice mass in snow due to snowfall (precs)
                ! new snow density = rhos for now
               smice_precs = hsn_new * rhos ! kg/m^2
 
                ! update ice mass tracer due to snowfall
+              !NJ: for bulk conservation fix
+              !smicetot(1) = smicetot(1) + fsnw * dt
               smicetot(1) = smicetot(1) + smice_precs
-               ! smice(1) = (dzs(1)*smice(1) + smice_precs) / hstot
 
                ! mass fraction of ice due to snowfall
                smtot = c0
@@ -1968,6 +2010,8 @@
                                             fcondtopn,fcondbot, &
                                             fadvocn,  fbot,     &
                                             l_stop,   stop_label)
+                                            !NJ: for bulk conservation fix
+                                            !l_stop,   stop_label, fsloss)
 
       real (kind=dbl_kind), intent(in) :: &
          dt              ! time step
@@ -1980,7 +2024,10 @@
          fsnow       , & ! snowfall rate (kg m-2 s-1)
          fcondtopn   , &
          fadvocn     , &
-         fbot           
+         fbot
+         !NJ: for bulk conservation fix
+         !fbot        , &
+         !fsloss          ! snow loss factor for wind redistribution
 
       real (kind=dbl_kind), intent(in) :: &
          einit       , & ! initial energy of melting (J m-2)
@@ -2036,8 +2083,12 @@
          write(warning,*) 'efinal - einit  =', efinal-einit
          call add_warning(warning)
          write(warning,*) 'fsurfn,flatn,fswint,fhocn, fsnow*Lfresh:'
+         !NJ: for bulk conservation fix
+         !write(warning,*) 'fsurfn,flatn,fswint,fhocn, fsnow*Lfresh, fsloss*Lfresh:'
          call add_warning(warning)
          write(warning,*) fsurfn,flatn,fswint,fhocnn, fsnow*Lfresh
+         !NJ: for bulk conservation fix
+         !write(warning,*) fsurfn,flatn,fswint,fhocnn, fsnow*Lfresh, fsloss*Lfresh
          call add_warning(warning)
          write(warning,*) 'Input energy =', einp
          call add_warning(warning)
@@ -2075,12 +2126,16 @@
 
          !         write(warning,*) fsurfn,flatn,fswint,fhocnn
          !         call add_warning(warning)
-         
+
          write(warning,*) 'dt*(fsurfn, flatn, fswint, fhocn, fsnow*Lfresh, fadvocn):'
+         !NJ: for bulk conservation fix
+         !write(warning,*) 'dt*(fsurfn, flatn, fswint, fhocn, fsnow*Lfresh, fadvocn, fsloss*Lfresh):'
          call add_warning(warning)
          write(warning,*) fsurfn*dt, flatn*dt, &
               fswint*dt, fhocnn*dt, &
               fsnow*Lfresh*dt, fadvocn*dt
+         !NJ: for bulk conservation fix
+         !     fsnow*Lfresh*dt, fadvocn*dt, fsloss*Lfresh*dt
          call add_warning(warning)
          return
       endif

--- a/components/mpas-seaice/src/shared/mpas_seaice_column.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_column.F
@@ -2698,7 +2698,8 @@ contains
          config_new_snow_density, &
          config_max_snow_density, &
          config_minimum_wind_compaction, &
-         config_wind_compaction_factor
+         config_wind_compaction_factor, &
+         config_wind_snow_loss_factor
 
     integer, pointer :: &
          nCellsSolve, &
@@ -2745,6 +2746,7 @@ contains
        call MPAS_pool_get_config(block % configs, "config_max_snow_density", config_max_snow_density)
        call MPAS_pool_get_config(block % configs, "config_minimum_wind_compaction", config_minimum_wind_compaction)
        call MPAS_pool_get_config(block % configs, "config_wind_compaction_factor", config_wind_compaction_factor)
+       call MPAS_pool_get_config(block % configs, "config_wind_snow_loss_factor", config_wind_snow_loss_factor)
        call MPAS_pool_get_config(block % configs, "config_use_column_biogeochemistry", config_use_column_biogeochemistry)
 
        call MPAS_pool_get_dimension(block % dimensions, "nCellsSolve", nCellsSolve)
@@ -2827,6 +2829,7 @@ contains
                config_max_snow_density, &
                config_minimum_wind_compaction, &
                config_wind_compaction_factor, &
+               config_wind_snow_loss_factor, &
                snowEmpiricalGrowthParameterTau(:,:,:), &
                snowEmpiricalGrowthParameterKappa(:,:,:), &
                snowPropertyRate(:,:,:), &
@@ -10164,20 +10167,6 @@ contains
             messageType=MPAS_LOG_CRIT)
     endif
 
-    ! check config_use_snow_grain_radius and config_use_column_snow_tracers
-    if (config_use_snow_grain_radius .and. .not. config_use_column_snow_tracers) then
-       call mpas_log_write(&
-         "check_column_package_configs: config_use_snow_grain_radius = true but config_use_column_snow_tracers = false", &
-            messageType=MPAS_LOG_CRIT)
-    endif
-
-    ! check config_use_snow_grain_radius and config_use_column_snow_tracers
-    if (config_use_column_snow_tracers .and. .not. config_use_snow_grain_radius) then
-       call mpas_log_write(&
-         "check_column_package_configs: config_use_column_snow_tracers but config_use_snow_grain_radius = false", &
-            messageType=MPAS_LOG_CRIT)
-    endif
-
     ! check cesm ponds and freezing lids inconsistency
     if (config_use_cesm_meltponds .and. trim(config_pond_refreezing_type) /= "cesm") then
        call mpas_log_write(&
@@ -11138,6 +11127,7 @@ contains
          config_new_snow_density, &
          config_max_snow_density, &
          config_minimum_wind_compaction, &
+         config_wind_snow_loss_factor, &
          config_wind_compaction_factor, &
          config_max_dry_snow_radius
 
@@ -11341,6 +11331,7 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_new_snow_density", config_new_snow_density)
     call MPAS_pool_get_config(domain % configs, "config_max_snow_density", config_max_snow_density)
     call MPAS_pool_get_config(domain % configs, "config_minimum_wind_compaction", config_minimum_wind_compaction)
+    call MPAS_pool_get_config(domain % configs, "config_wind_snow_loss_factor", config_wind_snow_loss_factor)
     call MPAS_pool_get_config(domain % configs, "config_wind_compaction_factor", config_wind_compaction_factor)
     call MPAS_pool_get_config(domain % configs, "config_max_dry_snow_radius", config_max_dry_snow_radius)
 
@@ -11530,6 +11521,7 @@ contains
          config_new_snow_density, &
          config_max_snow_density, &
          config_minimum_wind_compaction, &
+         config_wind_snow_loss_factor, &
          config_wind_compaction_factor)
 
     !-----------------------------------------------------------------------
@@ -12327,6 +12319,10 @@ contains
     ! windmin:
     ! minimum wind speed to compact snow (m/s)
     ! windmin = config_minimum_wind_compaction
+
+    ! snwlvlfac:
+    ! snow loss factor for wind redistribution
+    ! snwlvlfac = config_wind_snow_loss_factor
 
     ! drhosdwind:
     ! wind compaction factor (kg s/m^4)

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -287,7 +287,7 @@ contains
        ! snow
        call MPAS_pool_get_config(domain % configs, "config_use_column_snow_tracers", config_use_column_snow_tracers)
        if (config_use_column_snow_tracers) &
-            call init_column_snow_tracers(domain)
+            call init_icepack_snow_tracers(domain)
 
        ! shortwave
        call MPAS_pool_get_config(domain % configs, "config_do_restart", config_do_restart)
@@ -452,12 +452,12 @@ contains
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!  init_column_snow_tracers
+!  init_icepack_snow_tracers
 !
 !> \brief Initializes snow physics tracers
 !>
 !> \author Nicole Jeffery, LANL
-!> \date 1 April 2017
+!> \date 1 April 2017; modified for icepack July 2023
 !> \details
 !>
 !> The following snow tracers are initialized:
@@ -469,11 +469,14 @@ contains
 !
 !-----------------------------------------------------------------------
 
-  subroutine init_column_snow_tracers(domain)
+  subroutine init_icepack_snow_tracers(domain)
 
     use seaice_constants, only: &
          seaicePuny, &
          seaiceDensitySnow
+
+    use icepack_intfc, only: &
+         icepack_init_snow
 
     type(domain_type), intent(in) :: &
          domain
@@ -522,6 +525,8 @@ contains
          iCell, &
          iSnowLayer, &
          iCategory
+
+    call icepack_init_snow()
 
     call MPAS_pool_get_config(domain % configs, "config_use_effective_snow_density", config_use_effective_snow_density)
     call MPAS_pool_get_config(domain % configs, "config_use_snow_grain_radius", config_use_snow_grain_radius)
@@ -628,7 +633,7 @@ contains
         block => block % next
      end do
 
-  end subroutine init_column_snow_tracers
+  end subroutine init_icepack_snow_tracers
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
@@ -1255,7 +1260,7 @@ contains
 
        call mpas_timer_start("Column snow")
        if (config_use_column_snow_tracers) &
-            call column_snow(domain)
+            call icepack_snow(domain)
        call mpas_timer_stop("Column snow")
 
        !-----------------------------------------------------------------
@@ -2649,12 +2654,12 @@ contains
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!  column_snow
+!  icepack_snow
 !
 !> \brief Enable snow grain aging, effective snow density, wind compaction and redistribution
 !>
 !> \author Nicole Jeffery, LANL
-!> \date 3rd April 2017
+!> \date 3rd April 2017. Modified for icepack July 2023
 !> \details
 !>
 !> Snow physics improvements include:
@@ -2668,12 +2673,12 @@ contains
 !
 !-----------------------------------------------------------------------
 
-  subroutine column_snow(domain)
+  subroutine icepack_snow(domain)
 
-    use ice_colpkg, only: &
-         colpkg_step_snow, &
-         colpkg_clear_warnings, &
-         colpkg_get_warnings
+    use icepack_intfc, only: &
+         icepack_step_snow, &
+         icepack_warnings_clear, &
+         icepack_warnings_aborted
 
     use seaice_constants, only: &
          seaicePuny, &
@@ -2732,20 +2737,13 @@ contains
          snowMeltMassCell
 
     real(kind=RKIND), pointer :: &
-         config_dt, &
-         config_new_snow_density, &
-         config_max_snow_density, &
-         config_minimum_wind_compaction, &
-         config_wind_compaction_factor
+         config_dt
 
     integer, pointer :: &
          nCellsSolve, &
          nSnowLayers, &
          nIceLayers, &
-         nCategories, &
-         nGrainAgingTemperature, &
-         nGrainAgingTempGradient, &
-         nGrainAgingSnowDensity
+         nCategories
 
     integer :: &
          iCell, &
@@ -2762,9 +2760,6 @@ contains
          abortMessage, &
          abortLocation
 
-    character(len=strKINDWarnings), dimension(:), allocatable :: &
-         warnings
-
     block => domain % blocklist
     do while (associated(block))
 
@@ -2779,28 +2774,18 @@ contains
        call MPAS_pool_get_config(block % configs, "config_use_effective_snow_density", config_use_effective_snow_density)
        call MPAS_pool_get_config(block % configs, "config_use_snow_grain_radius", config_use_snow_grain_radius)
        call MPAS_pool_get_config(block % configs, "config_dt", config_dt)
-       call MPAS_pool_get_config(block % configs, "config_new_snow_density", config_new_snow_density)
-       call MPAS_pool_get_config(block % configs, "config_max_snow_density", config_max_snow_density)
-       call MPAS_pool_get_config(block % configs, "config_minimum_wind_compaction", config_minimum_wind_compaction)
-       call MPAS_pool_get_config(block % configs, "config_wind_compaction_factor", config_wind_compaction_factor)
        call MPAS_pool_get_config(block % configs, "config_use_column_biogeochemistry", config_use_column_biogeochemistry)
 
        call MPAS_pool_get_dimension(block % dimensions, "nCellsSolve", nCellsSolve)
        call MPAS_pool_get_dimension(block % dimensions, "nCategories", nCategories)
        call MPAS_pool_get_dimension(block % dimensions, "nSnowLayers", nSnowLayers)
        call MPAS_pool_get_dimension(block % dimensions, "nIceLayers", nIceLayers)
-       call MPAS_pool_get_dimension(block % dimensions, "nGrainAgingTemperature", nGrainAgingTemperature)
-       call MPAS_pool_get_dimension(block % dimensions, "nGrainAgingTempGradient", nGrainAgingTempGradient)
-       call MPAS_pool_get_dimension(block % dimensions, "nGrainAgingSnowDensity", nGrainAgingSnowDensity)
 
        call MPAS_pool_get_array(snow, "snowDensityViaContent", snowDensityViaContent)
        call MPAS_pool_get_array(snow, "snowDensityViaCompaction", snowDensityViaCompaction)
        call MPAS_pool_get_array(snow, "snowMeltMassCategory", snowMeltMassCategory)
        call MPAS_pool_get_array(snow, "snowMeltMassCell", snowMeltMassCell)
        call MPAS_pool_get_array(snow, "snowLossToLeads", snowLossToLeads)
-       call MPAS_pool_get_array(snow, "snowEmpiricalGrowthParameterTau", snowEmpiricalGrowthParameterTau)
-       call MPAS_pool_get_array(snow, "snowEmpiricalGrowthParameterKappa", snowEmpiricalGrowthParameterKappa)
-       call MPAS_pool_get_array(snow, "snowPropertyRate", snowPropertyRate)
 
        call MPAS_pool_get_array(tracers, "snowVolumeCategory", snowVolumeCategory, 1)
        call MPAS_pool_get_array(tracers, "iceVolumeCategory", iceVolumeCategory, 1)
@@ -2834,46 +2819,38 @@ contains
           abortFlag = .false.
           abortMessage = ""
 
-          call colpkg_clear_warnings()
-          call colpkg_step_snow (&
-               config_dt, &
-               windSpeed(iCell), &
-               nIceLayers, &
-               nSnowLayers, &
-               nCategories, &
-               iceAreaCell(iCell), &
-               iceAreaCategory(1,:,iCell), &
-               iceVolumeCategory(1,:,iCell), &
-               snowVolumeCategory(1,:,iCell), &
-               levelIceArea(1,:,iCell), &
-               levelIceVolume(1,:,iCell), &
-               snowIceMass(:,:,iCell), &
-               snowLiquidMass(:,:,iCell), &
-               snowDensity(:,:,iCell), &
-               snowDensityViaCompaction(iCell), &
-               snowGrainRadius(:,:,iCell), &
-               iceEnthalpy(1,:,iCell), &
-               iceSalinity(1,:,iCell), &
-               surfaceTemperature(1,:,iCell), &
-               snowEnthalpy(:,:,iCell), &
-               oceanFreshWaterFlux(iCell), &
-               oceanHeatFlux(iCell), &
-               snowLossToLeads(iCell), &
-               snowfallRate(iCell), &
-               config_new_snow_density, &
-               config_max_snow_density, &
-               config_minimum_wind_compaction, &
-               config_wind_compaction_factor, &
-               snowEmpiricalGrowthParameterTau(:,:,:), &
-               snowEmpiricalGrowthParameterKappa(:,:,:), &
-               snowPropertyRate(:,:,:), &
-               nGrainAgingTemperature, &
-               nGrainAgingTempGradient, &
-               nGrainAgingSnowDensity, &
-               abortFlag, &
-               abortMessage)
+          call icepack_warnings_clear()
+          call icepack_step_snow (&
+               dt=config_dt, &
+               wind=windSpeed(iCell), &
+               nilyr=nIceLayers, &
+               nslyr=nSnowLayers, &
+               ncat=nCategories, &
+               aice=iceAreaCell(iCell), &
+               aicen=iceAreaCategory(1,:,iCell), &
+               vicen=iceVolumeCategory(1,:,iCell), &
+               vsnon=snowVolumeCategory(1,:,iCell), &
+               alvl=levelIceArea(1,:,iCell), &
+               vlvl=levelIceVolume(1,:,iCell), &
+               smice=snowIceMass(:,:,iCell), &
+               smliq=snowLiquidMass(:,:,iCell), &
+               rhos_cmpn=snowDensity(:,:,iCell), &
+               rsnw=snowGrainRadius(:,:,iCell), &
+               zqin1=iceEnthalpy(1,:,iCell), &
+               zSin1=iceSalinity(1,:,iCell), &
+               Tsfc=surfaceTemperature(1,:,iCell), &
+               zqsn=snowEnthalpy(:,:,iCell), &
+               fresh=oceanFreshWaterFlux(iCell), &
+               fhocn=oceanHeatFlux(iCell), &
+               fsloss=snowLossToLeads(iCell), &
+               fsnow=snowfallRate(iCell) &
+               )
 
-          call column_write_warnings(abortFlag)
+          abortFlag = icepack_warnings_aborted()
+          call seaice_icepack_write_warnings(abortFlag)
+          if (abortFlag) then
+              call mpas_log_write("step_snow: "//trim(abortMessage) , messageType=MPAS_LOG_ERR)
+          end if
 
           if (config_use_snow_grain_radius) then
              snowDensityViaContent(iCell) = 0.0_RKIND
@@ -2900,7 +2877,7 @@ contains
        block => block % next
     end do
 
-  end subroutine column_snow
+  end subroutine icepack_snow
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
@@ -10042,10 +10019,9 @@ contains
     endif
 
     ! check config_snow_redistribution_scheme
-      if ((trim(config_snow_redistribution_scheme) == "ITDrdg" .or. &
-         trim(config_snow_redistribution_scheme) == "ITDsd") .and. .not. config_use_effective_snow_density) then
+      if (trim(config_snow_redistribution_scheme) == "ITDrdg".and. .not. config_use_effective_snow_density) then
        call mpas_log_write(&
-         "check_column_package_configs: config_snow_redistribution = 'ITD' but config_use_effective_snow_density is false", &
+         "check_column_package_configs: config_snow_redistribution = 'ITDrdg' but config_use_effective_snow_density is false", &
             messageType=MPAS_LOG_CRIT)
     endif
 
@@ -10053,20 +10029,6 @@ contains
     if (config_use_snow_liquid_ponds .and. .not. config_use_snow_grain_radius) then
        call mpas_log_write(&
          "check_column_package_configs: config_use_snow_liquid_ponds = true but config_use_snow_grain_radius = false", &
-            messageType=MPAS_LOG_CRIT)
-    endif
-
-    ! check config_use_snow_grain_radius and config_use_column_snow_tracers
-    if (config_use_snow_grain_radius .and. .not. config_use_column_snow_tracers) then
-       call mpas_log_write(&
-         "check_column_package_configs: config_use_snow_grain_radius = true but config_use_column_snow_tracers = false", &
-            messageType=MPAS_LOG_CRIT)
-    endif
-
-    ! check config_use_snow_grain_radius and config_use_column_snow_tracers
-    if (config_use_column_snow_tracers .and. .not. config_use_snow_grain_radius) then
-       call mpas_log_write(&
-         "check_column_package_configs: config_use_column_snow_tracers but config_use_snow_grain_radius = false", &
             messageType=MPAS_LOG_CRIT)
     endif
 
@@ -10335,7 +10297,6 @@ contains
     !tr_pond_cesm = config_use_cesm_meltponds
     !tr_pond_lvl  = config_use_level_meltponds
     !tr_pond_topo = config_use_topo_meltponds
-    !tr_snow      = config_use_effective_snow_density
     !tr_rsnw      = config_use_snow_grain_radius
     !tr_aero      = config_use_aerosols
     !tr_brine     = config_use_brine
@@ -10401,7 +10362,6 @@ contains
          config_use_snow_grain_radius
 
     logical :: &
-         use_snow, &
          use_meltponds, &
          use_nitrogen
 
@@ -10430,10 +10390,6 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_use_effective_snow_density", config_use_effective_snow_density)
     call MPAS_pool_get_config(domain % configs, "config_use_snow_grain_radius", config_use_snow_grain_radius)
 
-    use_snow = .false.
-    if (config_use_effective_snow_density .or. config_use_snow_grain_radius) &
-         use_snow = .true.
-
     use_nitrogen = .false.
     if (config_use_skeletal_biochemistry .or. config_use_vertical_biochemistry) &
          use_nitrogen = .true.
@@ -10444,7 +10400,6 @@ contains
          tr_iage_in      = config_use_ice_age, &
          tr_FY_in        = config_use_first_year_ice, &
          tr_lvl_in       = config_use_level_ice, &
-         tr_snow_in      = config_use_effective_snow_density, &
          tr_pond_in      = use_meltponds, &
          !tr_pond_cesm_in = config_use_cesm_meltponds, & ! deprecated
          tr_pond_lvl_in  = config_use_level_meltponds, &
@@ -11313,6 +11268,7 @@ contains
          config_max_snow_density, &
          config_minimum_wind_compaction, &
          config_wind_compaction_factor, &
+         config_wind_snow_loss_factor, &
          config_max_dry_snow_radius
 
     integer, pointer :: &
@@ -11516,6 +11472,7 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_max_snow_density", config_max_snow_density)
     call MPAS_pool_get_config(domain % configs, "config_minimum_wind_compaction", config_minimum_wind_compaction)
     call MPAS_pool_get_config(domain % configs, "config_wind_compaction_factor", config_wind_compaction_factor)
+    call MPAS_pool_get_config(domain % configs, "config_wind_snow_loss_factor", config_wind_snow_loss_factor)
     call MPAS_pool_get_config(domain % configs, "config_max_dry_snow_radius", config_max_dry_snow_radius)
 
     call colpkg_init_parameters(&
@@ -11704,7 +11661,8 @@ contains
          config_new_snow_density, &
          config_max_snow_density, &
          config_minimum_wind_compaction, &
-         config_wind_compaction_factor)
+         config_wind_compaction_factor, &
+         config_wind_snow_loss_factor)
 
     !-----------------------------------------------------------------------
     ! Parameters for thermodynamics
@@ -12502,6 +12460,10 @@ contains
     ! minimum wind speed to compact snow (m/s)
     ! windmin = config_minimum_wind_compaction
 
+    ! snwlvlfac:
+    ! snow loss factor for wind redistribution
+    ! snwlvlfac = config_wind_snow_loss_factor
+
     ! drhosdwind:
     ! wind compaction factor (kg s/m^4)
     ! drhosdwind = config_wind_compaction_factor
@@ -12564,6 +12526,9 @@ contains
 
     type(domain_type), intent(inout) :: &
          domain
+
+    type(MPAS_pool_type), pointer :: &
+         snow
 
     character(len=strKIND), pointer :: &
          config_thermodynamics_type, &
@@ -12757,10 +12722,19 @@ contains
          config_max_snow_density, &
          config_minimum_wind_compaction, &
          config_wind_compaction_factor, &
+         config_wind_snow_loss_factor, &
          config_max_dry_snow_radius
 
+    real(kind=RKIND), dimension(:,:,:), pointer :: &
+         snowEmpiricalGrowthParameterTau, &
+         snowEmpiricalGrowthParameterKappa, &
+         snowPropertyRate
+
     integer, pointer :: &
-         config_boundary_layer_iteration_number
+         config_boundary_layer_iteration_number, &
+         nGrainAgingTemperature, &
+         nGrainAgingTempGradient, &
+         nGrainAgingSnowDensity
 
     integer :: &
          config_thermodynamics_type_int, &
@@ -12772,6 +12746,7 @@ contains
 
     character(len=strKIND) :: tmp_config_shortwave
     character(len=strKIND) :: tmp_config_snw_ssp_table
+    character(len=strKIND) :: snw_aging_table = 'snicar'
 
     ! debugging
     integer :: itmp1, itmp2
@@ -12977,8 +12952,16 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_max_snow_density", config_max_snow_density)
     call MPAS_pool_get_config(domain % configs, "config_minimum_wind_compaction", config_minimum_wind_compaction)
     call MPAS_pool_get_config(domain % configs, "config_wind_compaction_factor", config_wind_compaction_factor)
+    call MPAS_pool_get_config(domain % configs, "config_wind_snow_loss_factor", config_wind_snow_loss_factor)
     call MPAS_pool_get_config(domain % configs, "config_max_dry_snow_radius", config_max_dry_snow_radius)
     call MPAS_pool_get_config(domain % configs, "config_use_snow_grain_radius", config_use_snow_grain_radius)
+    call MPAS_pool_get_dimension(domain % blocklist % dimensions, "nGrainAgingTemperature", nGrainAgingTemperature)
+    call MPAS_pool_get_dimension(domain % blocklist % dimensions, "nGrainAgingTempGradient", nGrainAgingTempGradient)
+    call MPAS_pool_get_dimension(domain % blocklist % dimensions, "nGrainAgingSnowDensity", nGrainAgingSnowDensity)
+    call MPAS_pool_get_subpool(domain % blocklist % structs, "snow", snow)
+    call MPAS_pool_get_array(snow, "snowEmpiricalGrowthParameterTau", snowEmpiricalGrowthParameterTau)
+    call MPAS_pool_get_array(snow, "snowEmpiricalGrowthParameterKappa", snowEmpiricalGrowthParameterKappa)
+    call MPAS_pool_get_array(snow, "snowPropertyRate", snowPropertyRate)
 
     config_thermodynamics_type_int = config_cice_int("config_thermodynamics_type", config_thermodynamics_type)
     config_ice_strength_formulation_int = config_cice_int("config_ice_strength_formulation", config_ice_strength_formulation)
@@ -13281,25 +13264,22 @@ contains
          !sw_frac_in              = , &        ! not yet implemented in MPAS-SI (stealth feature)
          !sw_dtemp_in             = , &        ! not yet implemented in MPAS-SI (stealth feature)
          snwgrain_in             = config_use_snow_grain_radius, &
-         !snwredist_in            = config_snow_redistribution_scheme, &
-         !use_smliq_pnd_in        = config_use_snow_liquid_ponds, &
-         !rsnw_fall_in            = config_fallen_snow_radius, &
-         !rsnw_tmax_in            = config_max_dry_snow_radius, &
-         !rhosnew_in              = config_new_snow_density, &
-         !rhosmax_in              = config_max_snow_density, &
-         !windmin_in              = config_minimum_wind_compaction, &
-         !drhosdwind_in           = config_wind_compaction_factor), &
-         !snwlvlfac_in            = , &        ! namelist option needs to be added
-         !isnw_T_in               = , &
-         !isnw_Tgrd_in            = , &
-         !isnw_rhos_in            = , &
-         !snowage_rhos_in         = , &
-         !snowage_Tgrd_in         = , &
-         !snowage_T_in            = , &
-         !snowage_tau_in          = , &
-         !snowage_kappa_in        = , &
-         !snowage_drdt0_in        = , &
-         !snw_aging_table_in      = , &
+         snwredist_in            = config_snow_redistribution_scheme, &
+         use_smliq_pnd_in        = config_use_snow_liquid_ponds, &
+         rsnw_fall_in            = config_fallen_snow_radius, &
+         rsnw_tmax_in            = config_max_dry_snow_radius, &
+         rhosnew_in              = config_new_snow_density, &
+         rhosmax_in              = config_max_snow_density, &
+         windmin_in              = config_minimum_wind_compaction, &
+         drhosdwind_in           = config_wind_compaction_factor, &
+         snwlvlfac_in            = config_wind_snow_loss_factor, &
+         isnw_T_in               = nGrainAgingTemperature, &
+         isnw_Tgrd_in            = nGrainAgingTempGradient, &
+         isnw_rhos_in            = nGrainAgingSnowDensity, &
+         snowage_tau_in          = snowEmpiricalGrowthParameterTau(:,:,:), &
+         snowage_kappa_in        = snowEmpiricalGrowthParameterKappa(:,:,:), &
+         snowage_drdt0_in        = snowPropertyRate(:,:,:), &
+         snw_aging_table_in      = snw_aging_table, &
          snw_ssp_table_in        = tmp_config_snw_ssp_table &
          )
 


### PR DESCRIPTION
1. Changed 30percent/30percentsw option so that it works like the bulk option in icepack. Suggestions to fix conservation for this option is commented out for further testing but still needed in both column and icepack. (BFB in default option, nonBFB with 30percent or 30percentsw).
2. Added namelist field config_wind_snow_loss_fraction for constant snwlvlfac to pass to icepack (BFB)
3. Corrected snow packages in Registry and config warnings to allow for multiple snow tracer flag options (BFB) 4.Initialization values for snow tracers added to ice_itd.F (nonBFB bugfix, consistent with icepack)
5. Modify the expression for snow ice and snow liquid tracer change due to sublimation - Allows for additional mass loss to come from the snow liquid tracer if the snow ice tracer has a value < rhos.  (nonBFB, consistent with icepack)
6. Adds missing changes to snow ice/liquid tracers from bottom melt. Bugfix. (nonBFB, consistent with icepack)
7. Adds mpas-icepack interface for step-snow in mpas_seaice_icepack.F