### PR TITLE
Update icepack to hash cb0d946, fix mass conservation

### DIFF
--- a/components/mpas-seaice/bld/build-namelist
+++ b/components/mpas-seaice/bld/build-namelist
@@ -568,6 +568,7 @@ add_default($nl, 'config_forcing_cycle_duration');
 add_default($nl, 'config_forcing_precipitation_units');
 add_default($nl, 'config_forcing_sst_type');
 add_default($nl, 'config_update_ocean_fluxes');
+add_default($nl, 'config_frazil_coupling_type');
 add_default($nl, 'config_include_pond_freshwater_feedback');
 
 ###########################

--- a/components/mpas-seaice/bld/build-namelist-section
+++ b/components/mpas-seaice/bld/build-namelist-section
@@ -110,6 +110,7 @@ add_default($nl, 'config_forcing_cycle_duration');
 add_default($nl, 'config_forcing_precipitation_units');
 add_default($nl, 'config_forcing_sst_type');
 add_default($nl, 'config_update_ocean_fluxes');
+add_default($nl, 'config_frazil_coupling_type');
 add_default($nl, 'config_include_pond_freshwater_feedback');
 
 ###########################

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -108,6 +108,7 @@
 <config_forcing_precipitation_units>'mm_per_sec'</config_forcing_precipitation_units>
 <config_forcing_sst_type>'ncar'</config_forcing_sst_type>
 <config_update_ocean_fluxes>true</config_update_ocean_fluxes>
+<config_frazil_coupling_type>'external'</config_frazil_coupling_type>
 <config_include_pond_freshwater_feedback>false</config_include_pond_freshwater_feedback>
 
 <!-- testing -->

--- a/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
@@ -485,7 +485,7 @@ Default: Defined in namelist_defaults.xml
 	category="forcing" group="forcing">
 Duration of the forcing cycle.
 
-Valid values: 'YYYY-MM-DD_HH:MM:SS
+Valid values: 'YYYY-MM-DD_HH:MM:SS'
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -507,9 +507,17 @@ Default: Defined in namelist_defaults.xml
 
 <entry id="config_update_ocean_fluxes" type="logical"
 	category="forcing" group="forcing">
-
+Include frazil ice fluxes in ocean flux fields.
 
 Valid values: true or false
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_frazil_coupling_type" type="char*1024"
+	category="forcing" group="forcing">
+Type of frazil ice coupling.
+
+Valid values: 'external', 'internal', 'fresh_ice_correction'
 Default: Defined in namelist_defaults.xml
 </entry>
 

--- a/components/mpas-seaice/src/Registry.xml
+++ b/components/mpas-seaice/src/Registry.xml
@@ -545,8 +545,12 @@
 			possible_values="'ncar'"
 		/>
 		<nml_option name="config_update_ocean_fluxes" type="logical" default_value="false" units="unitless"
-			description=""
+			description="Include frazil ice in ocean flux fields.s"
 			possible_values="true or false"
+		/>
+		<nml_option name="config_frazil_coupling_type" type="character" default_value="external" units="unitless"
+			description="Type of frazil ice coupling."
+			possible_values="'external', 'internal', 'fresh_ice_correction'"
 		/>
 		<nml_option name="config_include_pond_freshwater_feedback" type="logical" default_value="false" units="unitless"
 			description="Reduce the ocean fresh water flux by the pond fresh water flux for coupling."

--- a/components/mpas-seaice/src/Registry.xml
+++ b/components/mpas-seaice/src/Registry.xml
@@ -545,7 +545,7 @@
 			possible_values="'ncar'"
 		/>
 		<nml_option name="config_update_ocean_fluxes" type="logical" default_value="false" units="unitless"
-			description="Include frazil ice in ocean flux fields.s"
+			description="Include frazil ice in ocean flux fields."
 			possible_values="true or false"
 		/>
 		<nml_option name="config_frazil_coupling_type" type="character" default_value="external" units="unitless"

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -12333,6 +12333,7 @@ contains
          config_pond_refreezing_type, &
          config_salt_flux_coupling_type, &
          config_ocean_heat_transfer_type, &
+         config_frazil_coupling_type, &
          config_sea_freezing_temperature_type, &
          config_skeletal_bgc_flux_type, &
          config_snow_redistribution_scheme
@@ -12539,7 +12540,6 @@ contains
     character(len=strKIND) :: tmp_config_shortwave
     character(len=strKIND) :: tmp_config_snw_ssp_table
     character(len=strKIND) :: snw_aging_table = 'snicar'
-    character(len=strKIND) :: tmp_config_cpl_frazil !echmod - temporary
 
     ! debugging
     integer :: itmp1, itmp2
@@ -12551,6 +12551,7 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_ocean_heat_transfer_type", config_ocean_heat_transfer_type)
     call MPAS_pool_get_config(domain % configs, "config_calc_surface_temperature", config_calc_surface_temperature)
     call MPAS_pool_get_config(domain % configs, "config_update_ocean_fluxes", config_update_ocean_fluxes)
+    call MPAS_pool_get_config(domain % configs, "config_frazil_coupling_type", config_frazil_coupling_type)
     call MPAS_pool_get_config(domain % configs, "config_min_friction_velocity", config_min_friction_velocity)
     call MPAS_pool_get_config(domain % configs, "config_rapid_mode_channel_radius", config_rapid_mode_channel_radius)
     call MPAS_pool_get_config(domain % configs, "config_rapid_model_critical_Ra", config_rapid_model_critical_Ra)
@@ -12774,7 +12775,6 @@ contains
        tmp_config_shortwave     = config_shortwave_type
        tmp_config_snw_ssp_table = 'test'
     endif
-    tmp_config_cpl_frazil = 'external' ! echmod set this somewhere else
 
 !echmod debugging
     call mpas_log_write(' ')
@@ -12909,7 +12909,7 @@ contains
     call icepack_query_parameters(snowpatch_out=rtmp2)
     if (rtmp1 /= rtmp2) call mpas_log_write('snowpatch differs $r $r',realArgs=(/rtmp1,rtmp2/))
 
-    ctmp1 = tmp_config_cpl_frazil
+    ctmp1 = config_frazil_coupling_type
     call icepack_query_parameters(cpl_frazil_out=ctmp2)
     if (trim(ctmp1) /= trim(ctmp2)) call mpas_log_write('cpl_frazil differs')
 
@@ -12986,7 +12986,7 @@ contains
          fbot_xfer_type_in       = config_ocean_heat_transfer_type, &
          calc_Tsfc_in            = config_calc_surface_temperature, &
          !dts_b_in                = , &        ! brine, zsalinity
-         cpl_frazil_in           = tmp_config_cpl_frazil, &
+         cpl_frazil_in           = config_frazil_coupling_type, &
          update_ocn_f_in         = config_update_ocean_fluxes, &
          ustar_min_in            = config_min_friction_velocity, &
          a_rapid_mode_in         = config_rapid_mode_channel_radius, &
@@ -13141,7 +13141,7 @@ contains
     call icepack_query_parameters(snowpatch_out=rtmp2)
     if (rtmp1 /= rtmp2) call mpas_log_write('snowpatch differs $r $r',realArgs=(/rtmp1,rtmp2/))
 
-    ctmp1 = tmp_config_cpl_frazil
+    ctmp1 = config_frazil_coupling_type
     call icepack_query_parameters(cpl_frazil_out=ctmp2)
     if (trim(ctmp1) /= trim(ctmp2)) call mpas_log_write('cpl_frazil differs')
 

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -2423,7 +2423,6 @@ contains
                fresh=oceanFreshWaterFlux(iCell), &
                fsalt=oceanSaltFlux(iCell), &
                fhocn=oceanHeatFlux(iCell), &
-               update_ocn_f=config_update_ocean_fluxes,  &
                bgrid=biologyGrid(:), &
                cgrid=verticalGrid(:), &
                igrid=interfaceBiologyGrid(:),  &
@@ -12540,10 +12539,12 @@ contains
     character(len=strKIND) :: tmp_config_shortwave
     character(len=strKIND) :: tmp_config_snw_ssp_table
     character(len=strKIND) :: snw_aging_table = 'snicar'
+    character(len=strKIND) :: tmp_config_cpl_frazil !echmod - temporary
 
     ! debugging
     integer :: itmp1, itmp2
     real(kind=RKIND) :: rtmp1, rtmp2
+    character(len=strKIND) :: ctmp1, ctmp2
 
     call MPAS_pool_get_config(domain % configs, "config_thermodynamics_type", config_thermodynamics_type)
     call MPAS_pool_get_config(domain % configs, "config_heat_conductivity_type", config_heat_conductivity_type)
@@ -12773,6 +12774,7 @@ contains
        tmp_config_shortwave     = config_shortwave_type
        tmp_config_snw_ssp_table = 'test'
     endif
+    tmp_config_cpl_frazil = 'external' ! echmod set this somewhere else
 
 !echmod debugging
     call mpas_log_write(' ')
@@ -12907,6 +12909,10 @@ contains
     call icepack_query_parameters(snowpatch_out=rtmp2)
     if (rtmp1 /= rtmp2) call mpas_log_write('snowpatch differs $r $r',realArgs=(/rtmp1,rtmp2/))
 
+    ctmp1 = tmp_config_cpl_frazil
+    call icepack_query_parameters(cpl_frazil_out=ctmp2)
+    if (trim(ctmp1) /= trim(ctmp2)) call mpas_log_write('cpl_frazil differs')
+
 !    rtmp1 = skeletalLayerThickness
 !    call icepack_query_parameters(sk_l_out=rtmp2)
 !    if (rtmp1 /= rtmp2) call mpas_log_write('sk_l differs $r $r',realArgs=(/rtmp1,rtmp2/))
@@ -12980,6 +12986,7 @@ contains
          fbot_xfer_type_in       = config_ocean_heat_transfer_type, &
          calc_Tsfc_in            = config_calc_surface_temperature, &
          !dts_b_in                = , &        ! brine, zsalinity
+         cpl_frazil_in           = tmp_config_cpl_frazil, &
          update_ocn_f_in         = config_update_ocean_fluxes, &
          ustar_min_in            = config_min_friction_velocity, &
          a_rapid_mode_in         = config_rapid_mode_channel_radius, &
@@ -13133,6 +13140,10 @@ contains
     rtmp1 = seaiceSnowPatchiness
     call icepack_query_parameters(snowpatch_out=rtmp2)
     if (rtmp1 /= rtmp2) call mpas_log_write('snowpatch differs $r $r',realArgs=(/rtmp1,rtmp2/))
+
+    ctmp1 = tmp_config_cpl_frazil
+    call icepack_query_parameters(cpl_frazil_out=ctmp2)
+    if (trim(ctmp1) /= trim(ctmp2)) call mpas_log_write('cpl_frazil differs')
 
     call mpas_log_write(" ----- end debugging parameters -----")
     call mpas_log_write(' ')


### PR DESCRIPTION
This update brings in a new namelist/config from the Consortium to fix the mass conservation errors when running Icepack in E3SM.  It also fixes the thin-ice enthalpy problem as in https://github.com/E3SM-Project/E3SM/pull/5630 and deprecates zsalinity in the icepack submodule.

In 3-month D cases:
column is BFB
icepack is not BFB

Results are posted at https://acme-climate.atlassian.net/wiki/spaces/ICE/pages/3537993995/Icepack+Integration+Branch+Status+and+Testing