### PR TITLE
Move constants from ice_constants_colpkg.F90 to mpas_seaice_constants.F

### DIFF
--- a/components/mpas-seaice/driver/ice_comp_mct.F
+++ b/components/mpas-seaice/driver/ice_comp_mct.F
@@ -46,9 +46,18 @@ module ice_comp_mct
 
    ! MPASSI modules
    use seaice_analysis_driver
-   use seaice_column, only: seaice_column_reinitialize_fluxes, &
+   use seaice_column, only: seaice_column_reinitialize_fluxes, & !colpkg
                             seaice_column_coupling_prep
-   use seaice_constants
+   use seaice_constants, only: coupleAlarmID, &
+                               seaiceFreshWaterFreezingPoint, &
+                               seaiceDensityIce, &
+                               seaiceDensitySnow, &
+                               seaiceDensitySeaWater, &
+                               seaiceGravity, &
+                               seaiceLatentHeatMelting, &
+                               seaiceReferenceSalinity, &
+                               pii
+
    use seaice_core
    use seaice_core_interface
    use seaice_forcing
@@ -56,8 +65,6 @@ module ice_comp_mct
    use seaice_mesh, only: seaice_latlon_vector_rotation_backward
    use seaice_time_integration
    use seaice_error, only: seaice_check_critical_error
-
-   use ice_constants_colpkg, only: Tffresh, ice_ref_salinity, p001
 
    use ice_colpkg, only: colpkg_sea_freezing_temperature
 
@@ -2571,7 +2578,7 @@ contains
             i2x_i % rAttr(index_i2x_Fioi_melth,n) = oceanHeatFlux(i)
             i2x_i % rAttr(index_i2x_Fioi_swpen,n) = oceanShortwaveFlux(i)
             i2x_i % rAttr(index_i2x_Fioi_meltw,n) = oceanFreshWaterFlux(i) + frazilMassAdjust(i)/ailohi
-            i2x_i % rAttr(index_i2x_Fioi_salt ,n) = oceanSaltFlux(i) + ice_ref_salinity*p001*frazilMassAdjust(i)/ailohi
+            i2x_i % rAttr(index_i2x_Fioi_salt ,n) = oceanSaltFlux(i) + seaiceReferenceSalinity*0.001_RKIND*frazilMassAdjust(i)/ailohi
             i2x_i % rAttr(index_i2x_Fioi_taux ,n) = tauxo
             i2x_i % rAttr(index_i2x_Fioi_tauy ,n) = tauyo
 

--- a/components/mpas-seaice/driver/ice_comp_mct.F
+++ b/components/mpas-seaice/driver/ice_comp_mct.F
@@ -56,6 +56,8 @@ module ice_comp_mct
                                seaiceGravity, &
                                seaiceLatentHeatMelting, &
                                seaiceReferenceSalinity, &
+                               seaiceFrazilSalinityReduction, &
+                               seaiceFrazilIcePorosity, &
                                pii
 
    use seaice_core
@@ -2767,10 +2769,6 @@ contains
          liquidus_temperature_mush, &
          enthalpy_mush
 
-      use ice_colpkg_shared, only: &
-         dSin0_frazil,             &
-         phi_init
-
 ! !INPUT PARAMETERS:
       real (kind=RKIND),      intent(in)   :: freezingPotential
       real (kind=RKIND),      intent(in)   :: seaSurfaceSalinity
@@ -2796,12 +2794,12 @@ contains
    if (freezingPotential > 0.0_RKIND) then
 
       if (trim(config_thermodynamics_type) == "mushy") then  ! mushy
-         if (seaSurfaceSalinity > 2.0_RKIND * dSin0_frazil) then
-             Si0new = seaSurfaceSalinity - dSin0_frazil
+         if (seaSurfaceSalinity > 2.0_RKIND * seaiceFrazilSalinityReduction) then
+             Si0new = seaSurfaceSalinity - seaiceFrazilSalinityReduction
          else
-             Si0new = seaSurfaceSalinity**2 / (4.0_RKIND*dSin0_frazil)
+             Si0new = seaSurfaceSalinity**2 / (4.0_RKIND*seaiceFrazilSalinityReduction)
          endif
-         Ti = liquidus_temperature_mush(Si0new/phi_init)
+         Ti = liquidus_temperature_mush(Si0new/seaiceFrazilIcePorosity)
          qi0new = enthalpy_mush(Ti, Si0new)
       else
          qi0new = -seaiceDensityIce*seaiceLatentHeatMelting

--- a/components/mpas-seaice/src/analysis_members/mpas_seaice_high_frequency_output.F
+++ b/components/mpas-seaice/src/analysis_members/mpas_seaice_high_frequency_output.F
@@ -17,7 +17,6 @@ module seaice_high_frequency_output
    use mpas_dmpar
    use mpas_timekeeping
    use mpas_stream_manager
-   use ice_constants_colpkg
 
    implicit none
    private

--- a/components/mpas-seaice/src/analysis_members/mpas_seaice_miscellaneous.F
+++ b/components/mpas-seaice/src/analysis_members/mpas_seaice_miscellaneous.F
@@ -215,11 +215,11 @@ contains
 
    subroutine seaice_compute_miscellaneous(domain, instance, timeLevel, err)!{{{
 
-     use ice_constants_colpkg, only: &
-          awtvdr, &
-          awtidr, &
-          awtvdf, &
-          awtidf
+      use seaice_constants, only: &
+          seaiceAlbedoWtVisibleDirect, &
+          seaiceAlbedoWtNearIRDirect, &
+          seaiceAlbedoWtVisibleDiffuse, &
+          seaiceAlbedoWtNearIRDiffuse
 
       !-----------------------------------------------------------------
       !
@@ -345,10 +345,10 @@ contains
             do iCell = 1, nCellsSolve
 
                broadbandAlbedo(iCell) = &
-                    (awtvdr * albedoVisibleDirectCell(iCell) + &
-                    awtidr * albedoIRDirectCell(iCell) + &
-                    awtvdf * albedoVisibleDiffuseCell(iCell) + &
-                    awtidf * albedoIRDiffuseCell(iCell)) * &
+                   (seaiceAlbedoWtVisibleDirect * albedoVisibleDirectCell(iCell) + &
+                    seaiceAlbedoWtNearIRDirect * albedoIRDirectCell(iCell) + &
+                    seaiceAlbedoWtVisibleDiffuse * albedoVisibleDiffuseCell(iCell) + &
+                    seaiceAlbedoWtNearIRDiffuse * albedoIRDiffuseCell(iCell)) * &
                     iceAreaCellInitial(iCell)
 
             enddo ! iCell

--- a/components/mpas-seaice/src/analysis_members/mpas_seaice_regional_statistics.F
+++ b/components/mpas-seaice/src/analysis_members/mpas_seaice_regional_statistics.F
@@ -963,13 +963,13 @@ contains
       use seaice_mesh, only: &
            seaice_interpolate_vertex_to_cell
 
-      use ice_constants_colpkg, only: &
-           awtvdr, &
-           awtidr, &
-           awtvdf, &
-           awtidf, &
-           rhoi, &
-           rhos
+      use seaice_constants, only: &
+           seaiceAlbedoWtVisibleDirect, &
+           seaiceAlbedoWtNearIRDirect, &
+           seaiceAlbedoWtVisibleDiffuse, &
+           seaiceAlbedoWtNearIRDiffuse, &
+           seaiceDensityIce, &
+           seaiceDensitySnow
 
       type(domain_type), intent(inout) :: &
           domain
@@ -1138,13 +1138,13 @@ contains
                   ! kinetic energy
                   iSum = (iRegion-1) * nSums + 5
                   globalSumsIn(iSum) = globalSumsIn(iSum) + 0.5_RKIND * areaCell(iCell) * &
-                       (snowVolumeCell(iCell) * rhos + iceVolumeCell(iCell) * rhoi) * &
+                       (snowVolumeCell(iCell) * seaiceDensitySnow + iceVolumeCell(iCell) * seaiceDensityIce) * &
                        (uVelocityCell(iCell)**2 + vVelocityCell(iCell)**2)
 
                   ! total mass (for RMS ice speed)
                   iSum = (iRegion-1) * nSums + 6
                   globalSumsIn(iSum) = globalSumsIn(iSum) + areaCell(iCell) * &
-                       (snowVolumeCell(iCell) * rhos + iceVolumeCell(iCell) * rhoi)
+                       (snowVolumeCell(iCell) * seaiceDensitySnow + iceVolumeCell(iCell) * seaiceDensityIce)
 
                   ! average albedo
                   if (solarZenithAngleCosine(iCell) > 0.0_RKIND) then
@@ -1152,10 +1152,10 @@ contains
                      iSum = (iRegion-1) * nSums + 7
                      globalSumsIn(iSum) = globalSumsIn(iSum) + &
                           areaCell(iCell) * &
-                          (awtvdr * albedoVisibleDirectCell(iCell) + &
-                           awtidr * albedoIRDirectCell(iCell) + &
-                           awtvdf * albedoVisibleDiffuseCell(iCell) + &
-                           awtidf * albedoIRDiffuseCell(iCell))
+                          (seaiceAlbedoWtVisibleDirect * albedoVisibleDirectCell(iCell) + &
+                           seaiceAlbedoWtNearIRDirect * albedoIRDirectCell(iCell) + &
+                           seaiceAlbedoWtVisibleDiffuse * albedoVisibleDiffuseCell(iCell) + &
+                           seaiceAlbedoWtNearIRDiffuse * albedoIRDiffuseCell(iCell))
 
                      iSum = (iRegion-1) * nSums + 8
                      globalSumsIn(iSum) = globalSumsIn(iSum) + &

--- a/components/mpas-seaice/src/shared/mpas_seaice_constants.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_constants.F
@@ -245,11 +245,15 @@ module seaice_constants
 
   ! thermodynamic constants
   real(kind=RKIND), public :: &
+       seaiceStabilityReferenceHeight     = 10._RKIND     ,&! reference height for stability (m)
+       seaiceSnowSurfaceScatteringLayer   = 0.040_RKIND   ,&! snow surface scattering layer thickness (m)
        seaiceMeltingTemperatureDepression = 0.054_RKIND   ,&! melting temp. depression factor (C/ppt)
        seaiceOceanAlbedo                  = 0.06_RKIND    ,&! ocean albedo
        seaiceIceSurfaceRoughness          = 0.0005_RKIND  ,&! ice surface roughness (m)
        seaiceMaximumSalinity              = 3.2_RKIND     ,&! max salinity at ice base for BL99 (ppt)
-       seaiceStabilityReferenceHeight     = 10._RKIND       ! reference height for stability (m)
+                                                            ! for mushy thermo:
+       seaiceFrazilSalinityReduction      = 3.0_RKIND     ,&! bulk salinity reduction of newly formed frazil (ppt)
+       seaiceFrazilIcePorosity            = 0.75_RKIND      ! initial liquid fraction of frazil 
 
   ! dynamics constants
   real(kind=RKIND), public :: &

--- a/components/mpas-seaice/src/shared/mpas_seaice_constants.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_constants.F
@@ -19,117 +19,6 @@ module seaice_constants
   private
   save
 
-!echmod move constants in gradually
-#ifdef addconstants
-
-      !-----------------------------------------------------------------
-      ! physical constants
-      !-----------------------------------------------------------------
-
-      real (kind=RKIND), parameter, public :: &
-         viscosity_dyn = 1.79e-3_RKIND, & ! dynamic viscosity of brine (kg/m/s)
-         Tocnfrz   = -1.8_RKIND    ,&! freezing temp of seawater (C), used 
-                                        ! as Tsfcn for open water only when 
-                                        ! tfrz_option is 'minus1p8' or null
-
-         cprho    = cp_ocn*rhow       ,&! for ocean mixed layer (J kg / K m^3)
-
-         ! for ice strength
-         Cf       = 17._RKIND      ,&! ratio of ridging work to PE change in ridging 
-         Cp       = 0.5_RKIND*gravit*(rhow-rhoi)*rhoi/rhow ,&! proport const for PE 
-
-         ! (Ebert, Schramm and Curry JGR 100 15965-15975 Aug 1995)
-         kappav = 1.4_RKIND ,&! vis extnctn coef in ice, wvlngth<700nm (1/m)
-         !kappan = 17.6_RKIND,&! vis extnctn coef in ice, wvlngth<700nm (1/m)
-
-         ! kice is not used for mushy thermo
-         kice   = 2.03_RKIND  ,&! thermal conductivity of fresh ice(W/m/deg)
-         ! kseaice is used only for zero-layer thermo
-         kseaice= 2.00_RKIND  ,&! thermal conductivity of sea ice (W/m/deg)
-                                   ! (used in zero layer thermodynamics option)
-         ksno   = 0.30_RKIND  ,&! thermal conductivity of snow  (W/m/deg)
-         hs_min = 1.e-4_RKIND ,&! min snow thickness for computing zTsn (m)
-
-         ! biogeochemistry
-!         sk_l = 0.03_RKIND      ! (m) skeletal layer thickness
-
-      integer, parameter, public :: & 
-         nspint = 3              ,& ! number of solar spectral intervals
-         nspint_5bd = 5            ! number of solar spectral intervals used in SNICAR
-
-      ! weights for albedos 
-      ! 4 Jan 2007 BPB  Following are appropriate for complete cloud
-      ! in a summer polar atmosphere with 1.5m bare sea ice surface:
-      ! .636/.364 vis/nir with only 0.5% direct for each band.
-      real (kind=RKIND), parameter, public :: &           ! currently used only
-         awtvdr = 0.00318_RKIND, &! visible, direct  ! for history and
-         awtidr = 0.00182_RKIND, &! near IR, direct  ! diagnostics
-         awtvdf = 0.63282_RKIND, &! visible, diffuse
-         awtidf = 0.36218_RKIND   ! near IR, diffuse
-
-      real (kind=RKIND), parameter, public :: &
-         qqqice  = 11637800._RKIND   ,&! for qsat over ice
-         TTTice  = 5897.8_RKIND      ,&! for qsat over ice
-         qqqocn  = 627572.4_RKIND    ,&! for qsat over ocn
-         TTTocn  = 5107.4_RKIND        ! for qsat over ocn
-
-      ! orbital parameters
-      integer, public :: iyear_AD  ! Year to calculate orbit for
-      real(kind=RKIND),public :: eccen  ! Earth's orbital eccentricity
-      real(kind=RKIND),public :: obliqr ! Earth's obliquity in radians
-      real(kind=RKIND),public :: lambm0 ! Mean longitude of perihelion at the
-                                           ! vernal equinox (radians)
-      real(kind=RKIND),public :: mvelpp ! Earth's moving vernal equinox longitude
-                                           ! of perihelion + pi (radians)
-      real(kind=RKIND),public :: obliq  ! obliquity in degrees
-      real(kind=RKIND),public :: mvelp  ! moving vernal equinox long
-      real(kind=RKIND),public :: decln  ! solar declination angle in radians
-      real(kind=RKIND),public :: eccf   ! earth orbit eccentricity factor
-      logical,public :: log_print ! Flags print of status/error
-
-      ! snow parameters
-      real (kind=RKIND), parameter, public :: &
-         rhosmin   = 100.0_RKIND    ! minimum snow density (kg/m^3)
-
-      !-----------------------------------------------------------------
-      ! numbers used in column package
-      !-----------------------------------------------------------------
-
-      real (kind=RKIND), parameter, public :: &
-        c0   = 0.0_RKIND, &
-        c1   = 1.0_RKIND, &
-        c1p5 = 1.5_RKIND, &
-        c2   = 2.0_RKIND, &
-        c3   = 3.0_RKIND, &
-        c4   = 4.0_RKIND, &
-        c5   = 5.0_RKIND, &
-        c6   = 6.0_RKIND, &
-        c8   = 8.0_RKIND, &
-        c10  = 10.0_RKIND, &
-        c15  = 15.0_RKIND, &
-        c16  = 16.0_RKIND, &
-        c20  = 20.0_RKIND, &
-        c25  = 25.0_RKIND, &
-        c100 = 100.0_RKIND, &
-        c1000= 1000.0_RKIND, &
-        p001 = 0.001_RKIND, &
-        p01  = 0.01_RKIND, &
-        p1   = 0.1_RKIND, &
-        p2   = 0.2_RKIND, &
-        p4   = 0.4_RKIND, &
-        p5   = 0.5_RKIND, &
-        p6   = 0.6_RKIND, &
-        p05  = 0.05_RKIND, &
-        p15  = 0.15_RKIND, &
-        p25  = 0.25_RKIND, &
-        p75  = 0.75_RKIND, &
-        p333 = c1/c3, &
-        p666 = c2/c3, &
-        puny   
-        bignum = 1.0e+30_RKIND, &
-        pih    = p5*pi
-#endif
-
 #ifdef CCSMCOUPLED
       real (kind=RKIND), parameter, public :: &
   ! fundamental constants
@@ -187,9 +76,7 @@ module seaice_constants
 
   ! thermodynamic constants
        seaiceStefanBoltzmann           = 567.0e-10_RKIND,&! W/m^2/K^4
-         ! (Briegleb JGR 97 11475-11485  July 1992)
-       seaiceIceSnowEmissivity         = 0.95_RKIND    ,&! emissivity of snow and ice
-!echmod         emissivity= 0.985_RKIND
+       seaiceIceSnowEmissivity         = 0.95_RKIND    ,&! emissivity of snow and ice ! 0.985_RKIND in Icepack
        seaiceFreshWaterFreezingPoint   = 273.15_RKIND  ,&! freezing temp of fresh ice (K)
        seaiceFreshIceSpecificHeat      = 2106._RKIND   ,&! specific heat of fresh ice (J/kg/K)
        seaiceAirSpecificHeat           = 1005.0_RKIND  ,&! specific heat of air (J/kg/K)
@@ -217,7 +104,7 @@ module seaice_constants
        pii = 3.141592653589793_RKIND, & ! echmod - why is this different from pi above?
        seaiceDegreesToRadians = pii / 180.0_RKIND, &
        seaiceRadiansToDegrees = 180.0_RKIND / pii, &
-!echmod - BFB but 20% slower???
+!echmod - BFB but slower???
 !       pii = pi, &
 !       seaiceDegreesToRadians = pi / 180.0_RKIND, &
 !       seaiceRadiansToDegrees = 180.0_RKIND / pi, &
@@ -226,12 +113,8 @@ module seaice_constants
 
   real (kind=RKIND), public :: &
        seaicePi
-!echmod - BFB but 20% slower???
+!echmod - BFB but slower???
 !       seaicePi                           = pi ! pi
-
-  ! Earth constants
-  real (kind=RKIND), parameter, public :: &
-       omega                              = 7.29212e-5_RKIND ! angular rotation rate of the Earth [s-1]
 
   character (len=*), public, parameter :: &
        coupleAlarmID = 'coupling'
@@ -240,20 +123,24 @@ module seaice_constants
        seaicePuny                         = 1.0e-11_RKIND   ! a small value
 
   ! physical constants
+  real (kind=RKIND), parameter, public :: &
+       omega                              = 7.29212e-5_RKIND ! angular rotation rate of the Earth [s-1]
+
   real(kind=RKIND), public :: &
        seaiceDensitySnow                  = 330.0_RKIND     ! density of snow (kg/m^3)
 
   ! thermodynamic constants
   real(kind=RKIND), public :: &
-       seaiceStabilityReferenceHeight     = 10._RKIND     ,&! reference height for stability (m)
-       seaiceSnowSurfaceScatteringLayer   = 0.040_RKIND   ,&! snow surface scattering layer thickness (m)
-       seaiceMeltingTemperatureDepression = 0.054_RKIND   ,&! melting temp. depression factor (C/ppt)
-       seaiceOceanAlbedo                  = 0.06_RKIND    ,&! ocean albedo
-       seaiceIceSurfaceRoughness          = 0.0005_RKIND  ,&! ice surface roughness (m)
-       seaiceMaximumSalinity              = 3.2_RKIND     ,&! max salinity at ice base for BL99 (ppt)
+       seaiceStabilityReferenceHeight     = 10._RKIND   , & ! reference height for stability (m)
+       seaiceSnowSurfaceScatteringLayer   = 0.040_RKIND , & ! snow surface scattering layer thickness (m)
+       seaiceMeltingTemperatureDepression = 0.054_RKIND , & ! melting temp. depression factor (C/ppt)
+       seaiceOceanAlbedo                  = 0.06_RKIND  , & ! ocean albedo
+       seaiceIceSurfaceRoughness          = 0.0005_RKIND, & ! ice surface roughness (m)
+       seaiceMaximumSalinity              = 3.2_RKIND   , & ! max salinity at ice base for BL99 (ppt)
                                                             ! for mushy thermo:
-       seaiceFrazilSalinityReduction      = 3.0_RKIND     ,&! bulk salinity reduction of newly formed frazil (ppt)
-       seaiceFrazilIcePorosity            = 0.75_RKIND      ! initial liquid fraction of frazil 
+       seaiceFrazilSalinityReduction      = 3.0_RKIND   , & ! bulk salinity reduction of newly formed frazil (ppt)
+       seaiceFrazilIcePorosity            = 0.75_RKIND  , & ! initial liquid fraction of frazil 
+       seaiceFrazilMinimumThickness       = 0.05_RKIND      ! min thickness of new frazil i
 
   ! dynamics constants
   real(kind=RKIND), public :: &
@@ -266,26 +153,68 @@ module seaice_constants
        iceThicknessMinimum, &
        snowThicknessMinimum
 
+!echmod - declare and define these constants explicitly in case Icepack changes its defaults
+  real(kind=RKIND), public :: &
+       seaiceBigNumber                   = 1.0e+30_RKIND, & ! a large number
+       seaiceSnowMinimumDensity          = 100.0_RKIND  , & ! minimum snow density (kg/m^3)
+       seaiceBrineDynamicViscosity       = 1.79e-3_RKIND, & ! dynamic viscosity of brine (kg/m/s)
+       seaiceFreezingTemperatureConstant = -1.8_RKIND   , & ! freezing temp of seawater (C), used 
+                                                            ! as Tsfcn for open water only when 
+                                                            ! tfrz_option is 'minus1p8' or null
+       seaiceExtinctionCoef              = 1.4_RKIND    , & ! vis extnctn coef in ice, wvlngth<700nm (1/m)
+       seaiceFreshIceConductivity        = 2.03_RKIND   , & ! thermal conductivity of fresh ice(W/m/deg)
+                                                            ! (kice) is not used for mushy thermo
+       seaiceSnowConductivity            = 0.30_RKIND   , & ! thermal conductivity of snow  (W/m/deg)
+       seaiceSnowMinimumThickness        = 1.e-4_RKIND  , & ! min snow thickness for computing zTsn (m)
+       ! weights for albedos for history and diagnostics
+       ! 4 Jan 2007 BPB  Following are appropriate for complete cloud
+       ! in a summer polar atmosphere with 1.5m bare sea ice surface:
+       ! .636/.364 vis/nir with only 0.5% direct for each band.
+       seaiceAlbedoWtVisibleDirect       = 0.00318_RKIND, & ! visible, direct
+       seaiceAlbedoWtNearIRDirect        = 0.00182_RKIND, & ! near IR, direct
+       seaiceAlbedoWtVisibleDiffuse      = 0.63282_RKIND, & ! visible, diffuse
+       seaiceAlbedoWtNearIRDiffuse       = 0.36218_RKIND, & ! near IR, diffuse
+       ! constants for saturation humidity over ice and ocean
+       seaiceQsatQiceConstant            = 11637800._RKIND   ,&
+       seaiceQsatTiceConstant            = 5897.8_RKIND      ,&
+       seaiceQsatQocnConstant            = 627572.4_RKIND    ,&
+       seaiceQsatTocnConstant            = 5107.4_RKIND
+
+!echmod - Are these needed for standalone runs?
+!      ! orbital parameters
+!      integer, public :: iyear_AD  ! Year to calculate orbit for
+!      real(kind=RKIND),public :: eccen  ! Earth's orbital eccentricity
+!      real(kind=RKIND),public :: obliqr ! Earth's obliquity in radians
+!      real(kind=RKIND),public :: lambm0 ! Mean longitude of perihelion at the
+!                                           ! vernal equinox (radians)
+!      real(kind=RKIND),public :: mvelpp ! Earth's moving vernal equinox longitude
+!                                           ! of perihelion + pi (radians)
+!      real(kind=RKIND),public :: obliq  ! obliquity in degrees
+!      real(kind=RKIND),public :: mvelp  ! moving vernal equinox long
+!      real(kind=RKIND),public :: decln  ! solar declination angle in radians
+!      real(kind=RKIND),public :: eccf   ! earth orbit eccentricity factor
+!      logical,public :: log_print ! Flags print of status/error
+
   ! biogeochemistry constants
   real(kind=RKIND), public :: &
        skeletalLayerThickness             = 0.03_RKIND    ,&! (m) skeletal layer thickness
        gramsCarbonPerMolCarbon   ! g carbon per mol carbon
 
-   ! ocean biogeochemistry ISPOL values
-   real(kind=RKIND), parameter, public :: &
-         oceanAmmoniumISPOL        = 1.0_RKIND, & ! mmol N m-3
-         oceanDMSISPOL             = 0.1_RKIND, & ! mmol S m-3
-         oceanDMSPISPOL            = 0.1_RKIND, & ! mmol S m-3
-         oceanDiatomsISPOL         = 1.0_RKIND, & ! mmol N m-3
-         oceanSmallAlgaeISPOL      = 0.0057_RKIND, & ! mmol N m-3
-         oceanPhaeocystisISPOL     = 0.0027_RKIND, & ! mmol N m-3
-         oceanPolysaccharidsISPOL  = 16.2_RKIND, & ! mmol C m-3
-         oceanLipidsISPOL          = 9.0_RKIND, & ! mmol C m-3
-         oceanProteinsCarbonISPOL  = 9.0_RKIND, & ! mmol C m-3
-         oceanDICISPOL             = 1.0_RKIND, & ! mmol C m-3
-         oceanProteinsISPOL        = 12.9_RKIND, & ! mmol N m-3
-         oceanDissolvedIronISPOL   = 0.4_RKIND, & ! mmol Fe m-3
-         oceanParticulateIronISPOL = 2.0_RKIND,& ! mmol Fe m-3
-         oceanHumicsISPOL          = 1.0_RKIND ! mmol C m-3
+  ! ocean biogeochemistry ISPOL values
+  real(kind=RKIND), parameter, public :: &
+       oceanAmmoniumISPOL        = 1.0_RKIND   , & ! mmol N m-3
+       oceanDMSISPOL             = 0.1_RKIND   , & ! mmol S m-3
+       oceanDMSPISPOL            = 0.1_RKIND   , & ! mmol S m-3
+       oceanDiatomsISPOL         = 1.0_RKIND   , & ! mmol N m-3
+       oceanSmallAlgaeISPOL      = 0.0057_RKIND, & ! mmol N m-3
+       oceanPhaeocystisISPOL     = 0.0027_RKIND, & ! mmol N m-3
+       oceanPolysaccharidsISPOL  = 16.2_RKIND  , & ! mmol C m-3
+       oceanLipidsISPOL          = 9.0_RKIND   , & ! mmol C m-3
+       oceanProteinsCarbonISPOL  = 9.0_RKIND   , & ! mmol C m-3
+       oceanDICISPOL             = 1.0_RKIND   , & ! mmol C m-3
+       oceanProteinsISPOL        = 12.9_RKIND  , & ! mmol N m-3
+       oceanDissolvedIronISPOL   = 0.4_RKIND   , & ! mmol Fe m-3
+       oceanParticulateIronISPOL = 2.0_RKIND   , & ! mmol Fe m-3
+       oceanHumicsISPOL          = 1.0_RKIND       ! mmol C m-3
 
 end module seaice_constants

--- a/components/mpas-seaice/src/shared/mpas_seaice_constants.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_constants.F
@@ -21,16 +21,6 @@ module seaice_constants
 
 !echmod move constants in gradually
 #ifdef addconstants
-#ifdef CCSMCOUPLED
-      real (kind=RKIND), parameter :: &
-         R_gC2molC = SHR_CONST_MWC    ,&! molar mass of carbon
-         pi        = SHR_CONST_PI       ! pi
-#else
-
-      real (kind=RKIND), parameter, public :: &
-         R_gC2molC = 12.0107_RKIND, & ! molar mass of carbon
-         pi     = 3.14159265358979323846_RKIND
-#endif
 
       !-----------------------------------------------------------------
       ! physical constants
@@ -61,7 +51,7 @@ module seaice_constants
          hs_min = 1.e-4_RKIND ,&! min snow thickness for computing zTsn (m)
 
          ! biogeochemistry
-         sk_l = 0.03_RKIND      ! (m) skeletal layer thickness
+!         sk_l = 0.03_RKIND      ! (m) skeletal layer thickness
 
       integer, parameter, public :: & 
          nspint = 3              ,& ! number of solar spectral intervals
@@ -143,6 +133,7 @@ module seaice_constants
 #ifdef CCSMCOUPLED
       real (kind=RKIND), parameter, public :: &
   ! fundamental constants
+       pi                              = SHR_CONST_PI     ,&! pi
        seaiceSecondsPerDay             = SHR_CONST_CDAY     ! seconds in calendar day
 
       real (kind=RKIND), public :: &
@@ -179,11 +170,11 @@ module seaice_constants
 #endif
 
 !         R_gC2molC = SHR_CONST_MWC    ,&! molar mass of carbon
-!         pi        = SHR_CONST_PI       ! pi
 
 #else
       real (kind=RKIND), parameter, public :: &
   ! fundamental constants
+       pi                              = 3.14159265358979323846_RKIND
        seaiceSecondsPerDay             = 24.0_RKIND * 3600.0_RKIND
  
       real (kind=RKIND), public :: &
@@ -219,7 +210,6 @@ module seaice_constants
        seaiceIceOceanDragCoefficient   = 0.00536_RKIND   ! ice-ocn drag coefficient
 
 !         R_gC2molC = 12.0107_RKIND, & ! molar mass of carbon
-!         pi     = 3.14159265358979323846_RKIND
 #endif
 
   ! fundamental constants
@@ -227,11 +217,17 @@ module seaice_constants
        pii = 3.141592653589793_RKIND, & ! echmod - why is this different from pi above?
        seaiceDegreesToRadians = pii / 180.0_RKIND, &
        seaiceRadiansToDegrees = 180.0_RKIND / pii, &
-       seaiceSecondsPerYear = 24.0_RKIND * 3600.0_RKIND * 365.0_RKIND, &
+!echmod - BFB but 20% slower???
+!       pii = pi, &
+!       seaiceDegreesToRadians = pi / 180.0_RKIND, &
+!       seaiceRadiansToDegrees = 180.0_RKIND / pi, &
+       seaiceSecondsPerYear = 24.0_RKIND * 3600.0_RKIND * 365.0_RKIND, & !echmod - incorrect for leap years
        seaiceDaysPerSecond = 1.0_RKIND/seaiceSecondsPerDay
 
   real (kind=RKIND), public :: &
-       seaicePi                           ! pi
+       seaicePi
+!echmod - BFB but 20% slower???
+!       seaicePi                           = pi ! pi
 
   ! Earth constants
   real (kind=RKIND), parameter, public :: &
@@ -257,8 +253,8 @@ module seaice_constants
 
   ! dynamics constants
   real(kind=RKIND), public :: &
-       seaiceIceStrengthConstantHiblerP   = 2.75e4_RKIND   ,&! P* constant in Hibler strength formula
-       seaiceIceStrengthConstantHiblerC   = 20._RKIND        ! C* constant in Hibler strength formula
+       seaiceIceStrengthConstantHiblerP   = 2.75e4_RKIND  ,&! P* constant in Hibler strength formula
+       seaiceIceStrengthConstantHiblerC   = 20._RKIND       ! C* constant in Hibler strength formula
 
   ! minimum sea ice area
   real(kind=RKIND), public :: &
@@ -268,7 +264,7 @@ module seaice_constants
 
   ! biogeochemistry constants
   real(kind=RKIND), public :: &
-       skeletalLayerThickness, &
+       skeletalLayerThickness             = 0.03_RKIND    ,&! (m) skeletal layer thickness
        gramsCarbonPerMolCarbon   ! g carbon per mol carbon
 
 end module seaice_constants

--- a/components/mpas-seaice/src/shared/mpas_seaice_constants.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_constants.F
@@ -236,7 +236,7 @@ module seaice_constants
        seaiceSeaWaterSpecificHeat      = SHR_CONST_CPSW   ,&! specific heat of ocn    (J/kg/K)
                                                             ! freshwater value needed for enthalpy
        seaiceLatentHeatVaporization    = SHR_CONST_LATVAP ,&! latent heat, vaporization freshwater (J/kg)
-       seaiceReferenceSalinity= SHR_CONST_ICE_REF_SAL     ,&! ice reference salinity (ppt)
+       seaiceReferenceSalinity         = SHR_CONST_ICE_REF_SAL,&! ice reference salinity (ppt)
        seaiceSnowPatchiness            = 0.005_RKIND      ,&! parameter for fractional snow area (m)
 
 #ifdef RASM_MODS

--- a/components/mpas-seaice/src/shared/mpas_seaice_constants.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_constants.F
@@ -6,8 +6,9 @@
 !> \author Adrian K. Turner, LANL
 !> \date 2013-2014
 !> \details
-!>
-!
+!> Values in this module have been copied from the two ice_constants_colpkg.F90 
+!  modules in the column physics package (colpkg, in column/).  They will remain 
+!  duplicates until the column physic package is deprecated.
 !-----------------------------------------------------------------------
 
 module seaice_constants
@@ -22,72 +23,11 @@ module seaice_constants
 #ifdef addconstants
 #ifdef CCSMCOUPLED
       real (kind=RKIND), parameter :: &
-         secday    = SHR_CONST_CDAY   ,&! seconds in calendar day
-         rhoi      = SHR_CONST_RHOICE ,&! density of ice (kg/m^3)
-         rhow      = SHR_CONST_RHOSW  ,&! density of seawater (kg/m^3)
-         cp_air    = SHR_CONST_CPDAIR ,&! specific heat of air (J/kg/K)
-
-         ! Emissivity has been changed to unity here so that coupling is
-         ! physically correct - instantaneous radiative coupling in CIME
-         emissivity= 1.0_RKIND     ,&! emissivity of snow and ice
-
-         cp_ice    = SHR_CONST_CPICE  ,&! specific heat of fresh ice (J/kg/K)
-         cp_ocn    = SHR_CONST_CPSW   ,&! specific heat of ocn    (J/kg/K)
-                                        ! freshwater value needed for enthalpy
-#ifdef RASM_MODS
-         dragio    = 0.00962_RKIND ,&! ice-ocn drag coefficient for RASM as temporary measure
-#else
-         dragio    = 0.00536_RKIND ,&! ice-ocn drag coefficient
-#endif
-         gravit    = SHR_CONST_G      ,&! gravitational acceleration (m/s^2)
-         rhofresh  = SHR_CONST_RHOFW  ,&! density of fresh water (kg/m^3)
-         zvir      = SHR_CONST_ZVIR   ,&! rh2o/rair - 1.0
-         vonkar    = SHR_CONST_KARMAN ,&! von Karman constant
-         cp_wv     = SHR_CONST_CPWV   ,&! specific heat of water vapor (J/kg/K)
-         stefan_boltzmann = SHR_CONST_STEBOL ,&!  W/m^2/K^4
-         Tffresh   = SHR_CONST_TKFRZ  ,&! freezing temp of fresh ice (K)
-         Lsub      = SHR_CONST_LATSUB ,&! latent heat, sublimation freshwater (J/kg)
-         Lvap      = SHR_CONST_LATVAP ,&! latent heat, vaporization freshwater (J/kg)
-         Lfresh    = SHR_CONST_LATICE ,&! latent heat of melting of fresh ice (J/kg)
-         Timelt    = SHR_CONST_TKFRZ-SHR_CONST_TKFRZ ,&! melting temp. ice top surface  (C)
-         Tsmelt    = SHR_CONST_TKFRZ-SHR_CONST_TKFRZ ,&! melting temp. snow top surface (C)
-         ice_ref_salinity = SHR_CONST_ICE_REF_SAL ,&! (psu)
-!        ocn_ref_salinity = SHR_CONST_OCN_REF_SAL ,&! (psu)
-
-         snowpatch = 0.005_RKIND   ,&! parameter for fractional snow area (m)
          R_gC2molC = SHR_CONST_MWC    ,&! molar mass of carbon
          pi        = SHR_CONST_PI       ! pi
-
 #else
 
       real (kind=RKIND), parameter, public :: &
-         secday    = 86400.0_RKIND ,&! seconds in calendar day
-         rhoi      = 917.0_RKIND   ,&! density of ice (kg/m^3)
-         rhow      = 1026.0_RKIND  ,&! density of seawater (kg/m^3)
-         cp_air    = 1005.0_RKIND  ,&! specific heat of air (J/kg/K)
-         ! (Briegleb JGR 97 11475-11485  July 1992)
-         emissivity= 0.95_RKIND    ,&! emissivity of snow and ice
-!echmod         emissivity= 0.985_RKIND    ,&! emissivity of snow and ice
-         cp_ice    = 2106._RKIND   ,&! specific heat of fresh ice (J/kg/K)
-         cp_ocn    = 4218._RKIND   ,&! specific heat of ocn    (J/kg/K)
-                                        ! freshwater value needed for enthalpy
-         dragio    = 0.00536_RKIND ,&! ice-ocn drag coefficient
-         gravit    = 9.80616_RKIND ,&! gravitational acceleration (m/s^2)
-         rhofresh  = 1000.0_RKIND  ,&! density of fresh water (kg/m^3)
-         zvir      = 0.606_RKIND   ,&! rh2o/rair - 1.0
-         vonkar    = 0.4_RKIND     ,&! von Karman constant
-         cp_wv     = 1.81e3_RKIND  ,&! specific heat of water vapor (J/kg/K)
-         stefan_boltzmann = 567.0e-10_RKIND,&!  W/m^2/K^4
-         Tffresh   = 273.15_RKIND  ,&! freezing temp of fresh ice (K)
-         Lsub      = 2.835e6_RKIND ,&! latent heat, sublimation freshwater (J/kg)
-         Lvap      = 2.501e6_RKIND ,&! latent heat, vaporization freshwater (J/kg)
-         Lfresh    = Lsub-Lvap        ,&! latent heat of melting of fresh ice (J/kg)
-         Timelt    = 0.0_RKIND     ,&! melting temperature, ice top surface  (C)
-         Tsmelt    = 0.0_RKIND     ,&! melting temperature, snow top surface (C)
-         ice_ref_salinity = 4._RKIND ,&! (ppt)
-         ! ocn_ref_salinity = 34.7_RKIND,&! (ppt)
-
-         snowpatch = 0.02_RKIND, & ! parameter for fractional snow area (m)
          R_gC2molC = 12.0107_RKIND, & ! molar mass of carbon
          pi     = 3.14159265358979323846_RKIND
 #endif
@@ -97,24 +37,16 @@ module seaice_constants
       !-----------------------------------------------------------------
 
       real (kind=RKIND), parameter, public :: &
-         rhos      = 330.0_RKIND  ,&! density of snow (kg/m^3)
-         depressT  = 0.054_RKIND   ,&! Tf:brine salinity ratio (C/ppt)
-         albocn    = 0.06_RKIND    ,&! ocean albedo
          viscosity_dyn = 1.79e-3_RKIND, & ! dynamic viscosity of brine (kg/m/s)
          Tocnfrz   = -1.8_RKIND    ,&! freezing temp of seawater (C), used 
                                         ! as Tsfcn for open water only when 
                                         ! tfrz_option is 'minus1p8' or null
 
-         iceruf   = 0.0005_RKIND   ,&! ice surface roughness (m)
          cprho    = cp_ocn*rhow       ,&! for ocean mixed layer (J kg / K m^3)
 
          ! for ice strength
          Cf       = 17._RKIND      ,&! ratio of ridging work to PE change in ridging 
          Cp       = 0.5_RKIND*gravit*(rhow-rhoi)*rhoi/rhow ,&! proport const for PE 
-         Pstar    = 2.75e4_RKIND   ,&! constant in Hibler strength formula 
-                                        ! (kstrength = 0) 
-         Cstar    = 20._RKIND      ,&! constant in Hibler strength formula 
-                                        ! (kstrength = 0) 
 
          ! (Ebert, Schramm and Curry JGR 100 15965-15975 Aug 1995)
          kappav = 1.4_RKIND ,&! vis extnctn coef in ice, wvlngth<700nm (1/m)
@@ -126,7 +58,6 @@ module seaice_constants
          kseaice= 2.00_RKIND  ,&! thermal conductivity of sea ice (W/m/deg)
                                    ! (used in zero layer thermodynamics option)
          ksno   = 0.30_RKIND  ,&! thermal conductivity of snow  (W/m/deg)
-         zref   = 10._RKIND   ,&! reference height for stability (m)
          hs_min = 1.e-4_RKIND ,&! min snow thickness for computing zTsn (m)
 
          ! biogeochemistry
@@ -204,7 +135,7 @@ module seaice_constants
         p75  = 0.75_RKIND, &
         p333 = c1/c3, &
         p666 = c2/c3, &
-        puny   = 1.0e-11_RKIND, &
+        puny   
         bignum = 1.0e+30_RKIND, &
         pih    = p5*pi
 #endif
@@ -212,14 +143,15 @@ module seaice_constants
 #ifdef CCSMCOUPLED
       real (kind=RKIND), parameter, public :: &
   ! fundamental constants
-       seaiceSecondsPerDay  = SHR_CONST_CDAY     ! seconds in calendar day
+       seaiceSecondsPerDay             = SHR_CONST_CDAY     ! seconds in calendar day
 
       real (kind=RKIND), public :: &
-       seaiceGravity        = SHR_CONST_G      ,&! gravitational acceleration (m/s^2)
+       seaiceGravity                   = SHR_CONST_G      ,&! gravitational acceleration (m/s^2)
 
   ! physical constants
-       seaiceDensityIce     = SHR_CONST_RHOICE ,&! density of ice (kg/m^3)
-       seaiceDensitySeaWater= SHR_CONST_RHOSW  ,&! density of seawater (kg/m^3)
+       seaiceDensityIce                = SHR_CONST_RHOICE ,&! density of ice (kg/m^3)
+       seaiceDensitySeaWater           = SHR_CONST_RHOSW  ,&! density of seawater (kg/m^3)
+       seaiceDensityFreshwater         = SHR_CONST_RHOFW  ,&! density of fresh water (kg/m^3)
 
   ! thermodynamic constants
        seaiceStefanBoltzmann           = SHR_CONST_STEBOL ,&!  W/m^2/K^4
@@ -236,6 +168,7 @@ module seaice_constants
        seaiceSeaWaterSpecificHeat      = SHR_CONST_CPSW   ,&! specific heat of ocn    (J/kg/K)
                                                             ! freshwater value needed for enthalpy
        seaiceLatentHeatVaporization    = SHR_CONST_LATVAP ,&! latent heat, vaporization freshwater (J/kg)
+       seaiceLatentHeatMelting         = SHR_CONST_LATICE ,&! latent heat of melting of fresh ice (J/kg)
        seaiceReferenceSalinity         = SHR_CONST_ICE_REF_SAL,&! ice reference salinity (ppt)
        seaiceSnowPatchiness            = 0.005_RKIND      ,&! parameter for fractional snow area (m)
 
@@ -244,22 +177,22 @@ module seaice_constants
 #else
        seaiceIceOceanDragCoefficient   = 0.00536_RKIND      ! ice-ocn drag coefficient
 #endif
-!         rhofresh  = SHR_CONST_RHOFW  ,&! density of fresh water (kg/m^3)
-!         Lfresh    = SHR_CONST_LATICE ,&! latent heat of melting of fresh ice (J/kg)
+
 !         R_gC2molC = SHR_CONST_MWC    ,&! molar mass of carbon
 !         pi        = SHR_CONST_PI       ! pi
 
 #else
       real (kind=RKIND), parameter, public :: &
   ! fundamental constants
-       seaiceSecondsPerDay  = 24.0_RKIND * 3600.0_RKIND
+       seaiceSecondsPerDay             = 24.0_RKIND * 3600.0_RKIND
  
       real (kind=RKIND), public :: &
-       seaiceGravity        = 9.80616_RKIND            ,&! gravitational acceleration (m/s^2)
+       seaiceGravity                   = 9.80616_RKIND ,&! gravitational acceleration (m/s^2)
 
   ! physical constants
        seaiceDensityIce                = 917.0_RKIND   ,&! density of ice (kg/m^3)
        seaiceDensitySeaWater           = 1026.0_RKIND  ,&! density of seawater (kg/m^3)
+       seaiceDensityFreshwater         = 1000.0_RKIND  ,&! density of fresh water (kg/m^3)
 
   ! thermodynamic constants
        seaiceStefanBoltzmann           = 567.0e-10_RKIND,&! W/m^2/K^4
@@ -278,20 +211,20 @@ module seaice_constants
        seaiceSeaWaterSpecificHeat      = 4218._RKIND   ,&! specific heat of ocn    (J/kg/K)
                                                          ! freshwater value needed for enthalpy
        seaiceLatentHeatVaporization    = 2.501e6_RKIND ,&! latent heat, vaporization freshwater (J/kg)
+       seaiceLatentHeatMelting         = seaiceLatentHeatSublimation & ! latent heat of melting of fresh ice (J/kg)
+                                       - seaiceLatentHeatVaporization, &
        seaiceReferenceSalinity         = 4._RKIND      ,&! ice reference salinity (ppt)
        seaiceSnowPatchiness            = 0.02_RKIND    ,&! parameter for fractional snow area (m)
 
        seaiceIceOceanDragCoefficient   = 0.00536_RKIND   ! ice-ocn drag coefficient
 
-!         rhofresh  = 1000.0_RKIND  ,&! density of fresh water (kg/m^3)
-!         Lfresh    = Lsub-Lvap        ,&! latent heat of melting of fresh ice (J/kg)
 !         R_gC2molC = 12.0107_RKIND, & ! molar mass of carbon
 !         pi     = 3.14159265358979323846_RKIND
 #endif
 
   ! fundamental constants
   real (kind=RKIND), parameter, public :: &
-       pii = 3.141592653589793_RKIND, &          ! echmod - why is this different from pi above?
+       pii = 3.141592653589793_RKIND, & ! echmod - why is this different from pi above?
        seaiceDegreesToRadians = pii / 180.0_RKIND, &
        seaiceRadiansToDegrees = 180.0_RKIND / pii, &
        seaiceSecondsPerYear = 24.0_RKIND * 3600.0_RKIND * 365.0_RKIND, &
@@ -302,32 +235,30 @@ module seaice_constants
 
   ! Earth constants
   real (kind=RKIND), parameter, public :: &
-       omega         = 7.29212e-5_RKIND   ! angular rotation rate of the Earth [s-1]
+       omega                              = 7.29212e-5_RKIND ! angular rotation rate of the Earth [s-1]
 
   character (len=*), public, parameter :: &
        coupleAlarmID = 'coupling'
 
   real(kind=RKIND), public :: &
-       seaicePuny
+       seaicePuny                         = 1.0e-11_RKIND   ! a small value
 
   ! physical constants
   real(kind=RKIND), public :: &
-       seaiceDensitySnow, &     ! density of snow (kg/m^3)
-       seaiceDensityFreshwater  ! density of freshwater (kg/m^3)
+       seaiceDensitySnow                  = 330.0_RKIND     ! density of snow (kg/m^3)
 
   ! thermodynamic constants
   real(kind=RKIND), public :: &
-       seaiceLatentHeatMelting, &       ! latent heat of melting of fresh ice (J/kg)
-       seaiceMeltingTemperatureDepression, &  ! melting temp. depression factor (C/ppt)
-       seaiceOceanAlbedo, &             ! Ocean albedo
-       seaiceIceSurfaceRoughness, &     ! ice surface roughness (m)
-       seaiceMaximumSalinity, &         ! ice maximum salinity (ppt)
-       seaiceStabilityReferenceHeight   ! stability reference height (m)
+       seaiceMeltingTemperatureDepression = 0.054_RKIND   ,&! melting temp. depression factor (C/ppt)
+       seaiceOceanAlbedo                  = 0.06_RKIND    ,&! ocean albedo
+       seaiceIceSurfaceRoughness          = 0.0005_RKIND  ,&! ice surface roughness (m)
+       seaiceMaximumSalinity              = 3.2_RKIND     ,&! max salinity at ice base for BL99 (ppt)
+       seaiceStabilityReferenceHeight     = 10._RKIND       ! reference height for stability (m)
 
   ! dynamics constants
   real(kind=RKIND), public :: &
-       seaiceIceStrengthConstantHiblerP, & ! P* constant in Hibler strength formulation
-       seaiceIceStrengthConstantHiblerC    ! C* constant in Hibler strength formulation
+       seaiceIceStrengthConstantHiblerP   = 2.75e4_RKIND   ,&! P* constant in Hibler strength formula
+       seaiceIceStrengthConstantHiblerC   = 20._RKIND        ! C* constant in Hibler strength formula
 
   ! minimum sea ice area
   real(kind=RKIND), public :: &

--- a/components/mpas-seaice/src/shared/mpas_seaice_constants.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_constants.F
@@ -13,25 +13,294 @@
 module seaice_constants
 
   use mpas_derived_types
+  use shr_const_mod
 
   private
   save
 
+!echmod move constants in gradually
+#ifdef addconstants
+#ifdef CCSMCOUPLED
+      real (kind=RKIND), parameter :: &
+         secday    = SHR_CONST_CDAY   ,&! seconds in calendar day
+         rhoi      = SHR_CONST_RHOICE ,&! density of ice (kg/m^3)
+         rhow      = SHR_CONST_RHOSW  ,&! density of seawater (kg/m^3)
+         cp_air    = SHR_CONST_CPDAIR ,&! specific heat of air (J/kg/K)
+
+         ! Emissivity has been changed to unity here so that coupling is
+         ! physically correct - instantaneous radiative coupling in CIME
+         emissivity= 1.0_RKIND     ,&! emissivity of snow and ice
+
+         cp_ice    = SHR_CONST_CPICE  ,&! specific heat of fresh ice (J/kg/K)
+         cp_ocn    = SHR_CONST_CPSW   ,&! specific heat of ocn    (J/kg/K)
+                                        ! freshwater value needed for enthalpy
+#ifdef RASM_MODS
+         dragio    = 0.00962_RKIND ,&! ice-ocn drag coefficient for RASM as temporary measure
+#else
+         dragio    = 0.00536_RKIND ,&! ice-ocn drag coefficient
+#endif
+         gravit    = SHR_CONST_G      ,&! gravitational acceleration (m/s^2)
+         rhofresh  = SHR_CONST_RHOFW  ,&! density of fresh water (kg/m^3)
+         zvir      = SHR_CONST_ZVIR   ,&! rh2o/rair - 1.0
+         vonkar    = SHR_CONST_KARMAN ,&! von Karman constant
+         cp_wv     = SHR_CONST_CPWV   ,&! specific heat of water vapor (J/kg/K)
+         stefan_boltzmann = SHR_CONST_STEBOL ,&!  W/m^2/K^4
+         Tffresh   = SHR_CONST_TKFRZ  ,&! freezing temp of fresh ice (K)
+         Lsub      = SHR_CONST_LATSUB ,&! latent heat, sublimation freshwater (J/kg)
+         Lvap      = SHR_CONST_LATVAP ,&! latent heat, vaporization freshwater (J/kg)
+         Lfresh    = SHR_CONST_LATICE ,&! latent heat of melting of fresh ice (J/kg)
+         Timelt    = SHR_CONST_TKFRZ-SHR_CONST_TKFRZ ,&! melting temp. ice top surface  (C)
+         Tsmelt    = SHR_CONST_TKFRZ-SHR_CONST_TKFRZ ,&! melting temp. snow top surface (C)
+         ice_ref_salinity = SHR_CONST_ICE_REF_SAL ,&! (psu)
+!        ocn_ref_salinity = SHR_CONST_OCN_REF_SAL ,&! (psu)
+
+         snowpatch = 0.005_RKIND   ,&! parameter for fractional snow area (m)
+         R_gC2molC = SHR_CONST_MWC    ,&! molar mass of carbon
+         pi        = SHR_CONST_PI       ! pi
+
+#else
+
+      real (kind=RKIND), parameter, public :: &
+         secday    = 86400.0_RKIND ,&! seconds in calendar day
+         rhoi      = 917.0_RKIND   ,&! density of ice (kg/m^3)
+         rhow      = 1026.0_RKIND  ,&! density of seawater (kg/m^3)
+         cp_air    = 1005.0_RKIND  ,&! specific heat of air (J/kg/K)
+         ! (Briegleb JGR 97 11475-11485  July 1992)
+         emissivity= 0.95_RKIND    ,&! emissivity of snow and ice
+!echmod         emissivity= 0.985_RKIND    ,&! emissivity of snow and ice
+         cp_ice    = 2106._RKIND   ,&! specific heat of fresh ice (J/kg/K)
+         cp_ocn    = 4218._RKIND   ,&! specific heat of ocn    (J/kg/K)
+                                        ! freshwater value needed for enthalpy
+         dragio    = 0.00536_RKIND ,&! ice-ocn drag coefficient
+         gravit    = 9.80616_RKIND ,&! gravitational acceleration (m/s^2)
+         rhofresh  = 1000.0_RKIND  ,&! density of fresh water (kg/m^3)
+         zvir      = 0.606_RKIND   ,&! rh2o/rair - 1.0
+         vonkar    = 0.4_RKIND     ,&! von Karman constant
+         cp_wv     = 1.81e3_RKIND  ,&! specific heat of water vapor (J/kg/K)
+         stefan_boltzmann = 567.0e-10_RKIND,&!  W/m^2/K^4
+         Tffresh   = 273.15_RKIND  ,&! freezing temp of fresh ice (K)
+         Lsub      = 2.835e6_RKIND ,&! latent heat, sublimation freshwater (J/kg)
+         Lvap      = 2.501e6_RKIND ,&! latent heat, vaporization freshwater (J/kg)
+         Lfresh    = Lsub-Lvap        ,&! latent heat of melting of fresh ice (J/kg)
+         Timelt    = 0.0_RKIND     ,&! melting temperature, ice top surface  (C)
+         Tsmelt    = 0.0_RKIND     ,&! melting temperature, snow top surface (C)
+         ice_ref_salinity = 4._RKIND ,&! (ppt)
+         ! ocn_ref_salinity = 34.7_RKIND,&! (ppt)
+
+         snowpatch = 0.02_RKIND, & ! parameter for fractional snow area (m)
+         R_gC2molC = 12.0107_RKIND, & ! molar mass of carbon
+         pi     = 3.14159265358979323846_RKIND
+#endif
+
+      !-----------------------------------------------------------------
+      ! physical constants
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), parameter, public :: &
+         rhos      = 330.0_RKIND  ,&! density of snow (kg/m^3)
+         depressT  = 0.054_RKIND   ,&! Tf:brine salinity ratio (C/ppt)
+         albocn    = 0.06_RKIND    ,&! ocean albedo
+         viscosity_dyn = 1.79e-3_RKIND, & ! dynamic viscosity of brine (kg/m/s)
+         Tocnfrz   = -1.8_RKIND    ,&! freezing temp of seawater (C), used 
+                                        ! as Tsfcn for open water only when 
+                                        ! tfrz_option is 'minus1p8' or null
+
+         iceruf   = 0.0005_RKIND   ,&! ice surface roughness (m)
+         cprho    = cp_ocn*rhow       ,&! for ocean mixed layer (J kg / K m^3)
+
+         ! for ice strength
+         Cf       = 17._RKIND      ,&! ratio of ridging work to PE change in ridging 
+         Cp       = 0.5_RKIND*gravit*(rhow-rhoi)*rhoi/rhow ,&! proport const for PE 
+         Pstar    = 2.75e4_RKIND   ,&! constant in Hibler strength formula 
+                                        ! (kstrength = 0) 
+         Cstar    = 20._RKIND      ,&! constant in Hibler strength formula 
+                                        ! (kstrength = 0) 
+
+         ! (Ebert, Schramm and Curry JGR 100 15965-15975 Aug 1995)
+         kappav = 1.4_RKIND ,&! vis extnctn coef in ice, wvlngth<700nm (1/m)
+         !kappan = 17.6_RKIND,&! vis extnctn coef in ice, wvlngth<700nm (1/m)
+
+         ! kice is not used for mushy thermo
+         kice   = 2.03_RKIND  ,&! thermal conductivity of fresh ice(W/m/deg)
+         ! kseaice is used only for zero-layer thermo
+         kseaice= 2.00_RKIND  ,&! thermal conductivity of sea ice (W/m/deg)
+                                   ! (used in zero layer thermodynamics option)
+         ksno   = 0.30_RKIND  ,&! thermal conductivity of snow  (W/m/deg)
+         zref   = 10._RKIND   ,&! reference height for stability (m)
+         hs_min = 1.e-4_RKIND ,&! min snow thickness for computing zTsn (m)
+
+         ! biogeochemistry
+         sk_l = 0.03_RKIND      ! (m) skeletal layer thickness
+
+      integer, parameter, public :: & 
+         nspint = 3              ,& ! number of solar spectral intervals
+         nspint_5bd = 5            ! number of solar spectral intervals used in SNICAR
+
+      ! weights for albedos 
+      ! 4 Jan 2007 BPB  Following are appropriate for complete cloud
+      ! in a summer polar atmosphere with 1.5m bare sea ice surface:
+      ! .636/.364 vis/nir with only 0.5% direct for each band.
+      real (kind=RKIND), parameter, public :: &           ! currently used only
+         awtvdr = 0.00318_RKIND, &! visible, direct  ! for history and
+         awtidr = 0.00182_RKIND, &! near IR, direct  ! diagnostics
+         awtvdf = 0.63282_RKIND, &! visible, diffuse
+         awtidf = 0.36218_RKIND   ! near IR, diffuse
+
+      real (kind=RKIND), parameter, public :: &
+         qqqice  = 11637800._RKIND   ,&! for qsat over ice
+         TTTice  = 5897.8_RKIND      ,&! for qsat over ice
+         qqqocn  = 627572.4_RKIND    ,&! for qsat over ocn
+         TTTocn  = 5107.4_RKIND        ! for qsat over ocn
+
+      ! orbital parameters
+      integer, public :: iyear_AD  ! Year to calculate orbit for
+      real(kind=RKIND),public :: eccen  ! Earth's orbital eccentricity
+      real(kind=RKIND),public :: obliqr ! Earth's obliquity in radians
+      real(kind=RKIND),public :: lambm0 ! Mean longitude of perihelion at the
+                                           ! vernal equinox (radians)
+      real(kind=RKIND),public :: mvelpp ! Earth's moving vernal equinox longitude
+                                           ! of perihelion + pi (radians)
+      real(kind=RKIND),public :: obliq  ! obliquity in degrees
+      real(kind=RKIND),public :: mvelp  ! moving vernal equinox long
+      real(kind=RKIND),public :: decln  ! solar declination angle in radians
+      real(kind=RKIND),public :: eccf   ! earth orbit eccentricity factor
+      logical,public :: log_print ! Flags print of status/error
+
+      ! snow parameters
+      real (kind=RKIND), parameter, public :: &
+         rhosmin   = 100.0_RKIND    ! minimum snow density (kg/m^3)
+
+      !-----------------------------------------------------------------
+      ! numbers used in column package
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), parameter, public :: &
+        c0   = 0.0_RKIND, &
+        c1   = 1.0_RKIND, &
+        c1p5 = 1.5_RKIND, &
+        c2   = 2.0_RKIND, &
+        c3   = 3.0_RKIND, &
+        c4   = 4.0_RKIND, &
+        c5   = 5.0_RKIND, &
+        c6   = 6.0_RKIND, &
+        c8   = 8.0_RKIND, &
+        c10  = 10.0_RKIND, &
+        c15  = 15.0_RKIND, &
+        c16  = 16.0_RKIND, &
+        c20  = 20.0_RKIND, &
+        c25  = 25.0_RKIND, &
+        c100 = 100.0_RKIND, &
+        c1000= 1000.0_RKIND, &
+        p001 = 0.001_RKIND, &
+        p01  = 0.01_RKIND, &
+        p1   = 0.1_RKIND, &
+        p2   = 0.2_RKIND, &
+        p4   = 0.4_RKIND, &
+        p5   = 0.5_RKIND, &
+        p6   = 0.6_RKIND, &
+        p05  = 0.05_RKIND, &
+        p15  = 0.15_RKIND, &
+        p25  = 0.25_RKIND, &
+        p75  = 0.75_RKIND, &
+        p333 = c1/c3, &
+        p666 = c2/c3, &
+        puny   = 1.0e-11_RKIND, &
+        bignum = 1.0e+30_RKIND, &
+        pih    = p5*pi
+#endif
+
+#ifdef CCSMCOUPLED
+      real (kind=RKIND), parameter, public :: &
+  ! fundamental constants
+       seaiceSecondsPerDay  = SHR_CONST_CDAY     ! seconds in calendar day
+
+      real (kind=RKIND), public :: &
+       seaiceGravity        = SHR_CONST_G      ,&! gravitational acceleration (m/s^2)
+
+  ! physical constants
+       seaiceDensityIce     = SHR_CONST_RHOICE ,&! density of ice (kg/m^3)
+       seaiceDensitySeaWater= SHR_CONST_RHOSW  ,&! density of seawater (kg/m^3)
+
+  ! thermodynamic constants
+       seaiceStefanBoltzmann           = SHR_CONST_STEBOL ,&!  W/m^2/K^4
+       seaiceIceSnowEmissivity         = 1.0_RKIND        ,&! emissivity of snow and ice
+       seaiceFreshWaterFreezingPoint   = SHR_CONST_TKFRZ  ,&! freezing temp of fresh ice (K)
+       seaiceFreshIceSpecificHeat      = SHR_CONST_CPICE  ,&! specific heat of fresh ice (J/kg/K)
+       seaiceAirSpecificHeat           = SHR_CONST_CPDAIR ,&! specific heat of air (J/kg/K)
+       seaiceWaterVaporSpecificHeat    = SHR_CONST_CPWV   ,&! specific heat of water vapor (J/kg/K)
+       seaiceZvir                      = SHR_CONST_ZVIR   ,&! rh2o/rair - 1.0
+       seaiceLatentHeatSublimation     = SHR_CONST_LATSUB ,&! latent heat, sublimation freshwater (J/kg)
+       seaiceIceSurfaceMeltingTemperature= SHR_CONST_TKFRZ-SHR_CONST_TKFRZ ,&! melting temp. ice top surface  (C)
+       seaiceSnowSurfaceMeltingTemperature= SHR_CONST_TKFRZ-SHR_CONST_TKFRZ ,&! melting temp. snow top surface (C)
+       seaiceVonKarmanConstant         = SHR_CONST_KARMAN ,&! von Karman constant
+       seaiceSeaWaterSpecificHeat      = SHR_CONST_CPSW   ,&! specific heat of ocn    (J/kg/K)
+                                                            ! freshwater value needed for enthalpy
+       seaiceLatentHeatVaporization    = SHR_CONST_LATVAP ,&! latent heat, vaporization freshwater (J/kg)
+       seaiceReferenceSalinity= SHR_CONST_ICE_REF_SAL     ,&! ice reference salinity (ppt)
+       seaiceSnowPatchiness            = 0.005_RKIND      ,&! parameter for fractional snow area (m)
+
+#ifdef RASM_MODS
+       seaiceIceOceanDragCoefficient   = 0.00962_RKIND      ! ice-ocn drag coefficient for RASM as temporary measure
+#else
+       seaiceIceOceanDragCoefficient   = 0.00536_RKIND      ! ice-ocn drag coefficient
+#endif
+!         rhofresh  = SHR_CONST_RHOFW  ,&! density of fresh water (kg/m^3)
+!         Lfresh    = SHR_CONST_LATICE ,&! latent heat of melting of fresh ice (J/kg)
+!         R_gC2molC = SHR_CONST_MWC    ,&! molar mass of carbon
+!         pi        = SHR_CONST_PI       ! pi
+
+#else
+      real (kind=RKIND), parameter, public :: &
+  ! fundamental constants
+       seaiceSecondsPerDay  = 24.0_RKIND * 3600.0_RKIND
+ 
+      real (kind=RKIND), public :: &
+       seaiceGravity        = 9.80616_RKIND            ,&! gravitational acceleration (m/s^2)
+
+  ! physical constants
+       seaiceDensityIce                = 917.0_RKIND   ,&! density of ice (kg/m^3)
+       seaiceDensitySeaWater           = 1026.0_RKIND  ,&! density of seawater (kg/m^3)
+
+  ! thermodynamic constants
+       seaiceStefanBoltzmann           = 567.0e-10_RKIND,&! W/m^2/K^4
+         ! (Briegleb JGR 97 11475-11485  July 1992)
+       seaiceIceSnowEmissivity         = 0.95_RKIND    ,&! emissivity of snow and ice
+!echmod         emissivity= 0.985_RKIND
+       seaiceFreshWaterFreezingPoint   = 273.15_RKIND  ,&! freezing temp of fresh ice (K)
+       seaiceFreshIceSpecificHeat      = 2106._RKIND   ,&! specific heat of fresh ice (J/kg/K)
+       seaiceAirSpecificHeat           = 1005.0_RKIND  ,&! specific heat of air (J/kg/K)
+       seaiceWaterVaporSpecificHeat    = 1.81e3_RKIND  ,&! specific heat of water vapor (J/kg/K)
+       seaiceZvir                      = 0.606_RKIND   ,&! rh2o/rair - 1.0
+       seaiceLatentHeatSublimation     = 2.835e6_RKIND ,&! latent heat, sublimation freshwater (J/kg)
+       seaiceIceSurfaceMeltingTemperature  = 0.0_RKIND ,&! melting temperature, ice top surface  (C)
+       seaiceSnowSurfaceMeltingTemperature = 0.0_RKIND ,&! melting temperature, snow top surface  (C)
+       seaiceVonKarmanConstant         = 0.4_RKIND     ,&! von Karman constant
+       seaiceSeaWaterSpecificHeat      = 4218._RKIND   ,&! specific heat of ocn    (J/kg/K)
+                                                         ! freshwater value needed for enthalpy
+       seaiceLatentHeatVaporization    = 2.501e6_RKIND ,&! latent heat, vaporization freshwater (J/kg)
+       seaiceReferenceSalinity         = 4._RKIND      ,&! ice reference salinity (ppt)
+       seaiceSnowPatchiness            = 0.02_RKIND    ,&! parameter for fractional snow area (m)
+
+       seaiceIceOceanDragCoefficient   = 0.00536_RKIND   ! ice-ocn drag coefficient
+
+!         rhofresh  = 1000.0_RKIND  ,&! density of fresh water (kg/m^3)
+!         Lfresh    = Lsub-Lvap        ,&! latent heat of melting of fresh ice (J/kg)
+!         R_gC2molC = 12.0107_RKIND, & ! molar mass of carbon
+!         pi     = 3.14159265358979323846_RKIND
+#endif
+
   ! fundamental constants
   real (kind=RKIND), parameter, public :: &
-       pii = 3.141592653589793_RKIND, &          ! CESM uses SHR_CONST_PI
+       pii = 3.141592653589793_RKIND, &          ! echmod - why is this different from pi above?
        seaiceDegreesToRadians = pii / 180.0_RKIND, &
        seaiceRadiansToDegrees = 180.0_RKIND / pii, &
        seaiceSecondsPerYear = 24.0_RKIND * 3600.0_RKIND * 365.0_RKIND, &
-       seaiceSecondsPerDay  = 24.0_RKIND * 3600.0_RKIND, &
        seaiceDaysPerSecond = 1.0_RKIND/seaiceSecondsPerDay
 
   real (kind=RKIND), public :: &
        seaicePi                           ! pi
 
   ! Earth constants
-  real (kind=RKIND), public :: &
-       seaiceGravity                      ! gravitational acceleration (m/s^2)
   real (kind=RKIND), parameter, public :: &
        omega         = 7.29212e-5_RKIND   ! angular rotation rate of the Earth [s-1]
 
@@ -43,40 +312,22 @@ module seaice_constants
 
   ! physical constants
   real(kind=RKIND), public :: &
-       seaiceDensityIce, &      ! density of ice (kg/m^3)
        seaiceDensitySnow, &     ! density of snow (kg/m^3)
-       seaiceDensitySeaWater, & ! density of seawater (kg/m^3)
        seaiceDensityFreshwater  ! density of freshwater (kg/m^3)
 
   ! thermodynamic constants
   real(kind=RKIND), public :: &
-       seaiceStefanBoltzmann, &         ! J m-2 K-4 s-1
-       seaiceIceSnowEmissivity, &       ! emissivity of snow and ice
-       seaiceFreshWaterFreezingPoint, & ! freezing temp of fresh ice (K)
-       seaiceFreshIceSpecificHeat, &    ! specific heat of fresh ice (J/kg/K)
-       seaiceAirSpecificHeat, &         ! specific heat of air (J/kg/K)
-       seaiceWaterVaporSpecificHeat, &  ! specific heat of water vapor (J/kg/K)
-       seaiceZvir, &                    ! rh2o/rair - 1.0
-       seaiceLatentHeatSublimation, &   ! latent heat, sublimation freshwater (J/kg)
        seaiceLatentHeatMelting, &       ! latent heat of melting of fresh ice (J/kg)
-       seaiceIceSurfaceMeltingTemperature, &  ! melting temp. ice top surface  (C)
-       seaiceSnowSurfaceMeltingTemperature, & ! melting temp. snow top surface  (C)
        seaiceMeltingTemperatureDepression, &  ! melting temp. depression factor (C/ppt)
        seaiceOceanAlbedo, &             ! Ocean albedo
-       seaiceVonKarmanConstant, &       ! Von Karman constant
        seaiceIceSurfaceRoughness, &     ! ice surface roughness (m)
-       seaiceSeaWaterSpecificHeat, &    ! specific heat of ocn (J/kg/K)
-       seaiceLatentHeatVaporization, &  ! latent heat, vaporization freshwater (J/kg)
-       seaiceReferenceSalinity, &       ! ice reference salinity (ppt)
        seaiceMaximumSalinity, &         ! ice maximum salinity (ppt)
-       seaiceStabilityReferenceHeight, &! stability reference height (m)
-       seaiceSnowPatchiness             ! snow patchiness parameter
+       seaiceStabilityReferenceHeight   ! stability reference height (m)
 
   ! dynamics constants
   real(kind=RKIND), public :: &
        seaiceIceStrengthConstantHiblerP, & ! P* constant in Hibler strength formulation
-       seaiceIceStrengthConstantHiblerC, & ! C* constant in Hibler strength formulation
-       seaiceIceOceanDragCoefficient       ! ice ocean drag coefficient
+       seaiceIceStrengthConstantHiblerC    ! C* constant in Hibler strength formulation
 
   ! minimum sea ice area
   real(kind=RKIND), public :: &
@@ -84,9 +335,9 @@ module seaice_constants
        iceThicknessMinimum, &
        snowThicknessMinimum
 
-   ! biogeochemistry constants
-   real(kind=RKIND), public :: &
-        skeletalLayerThickness, &
-        gramsCarbonPerMolCarbon   ! g carbon per mol carbon
+  ! biogeochemistry constants
+  real(kind=RKIND), public :: &
+       skeletalLayerThickness, &
+       gramsCarbonPerMolCarbon   ! g carbon per mol carbon
 
 end module seaice_constants

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -5877,82 +5877,16 @@ contains
          iceAreaMinimum, &
          iceThicknessMinimum, &
          snowThicknessMinimum
+    !gramsCarbonPerMolCarbon          = R_gC2molC
 
-!echmod: These constants will need to be defined in the MPAS-SI driver (or a shared E3SM constants file) 
-!echmod: eventually, rather than in the old column package. For now, use the column package's values.
-!echmod: If E3SM/MPAS-SI wants to use icepack's default values (not recommended), then they should be 
-!echmod: obtained using icepack_query_parameters instead of 'using' them.  In that case, initializing 
-!echmod: them with the icepack_init_parameters call is unnecessary.
     use ice_constants_colpkg, only: &  ! for E3SM runs this is currently in src/column/constants/cesm/
-         pi, &
-!         gravit, &
-!         rhoi, &
-!         rhos, &
-!         rhow, &
-!         puny, &
-!         stefan_boltzmann, &
-!         emissivity, &
-!         Tffresh, &
-!         cp_ice, &
-!         cp_air, &
-!         cp_ocn, &
-!         cp_wv, &
-!         Lvap, &
-!         Lsub, &
-!         Lfresh, &
-!         Timelt, &
-!         Tsmelt, &
-!         zvir, &
-!         ice_ref_salinity, &
-!         depressT, &
-!         Pstar, &
-!         Cstar, &
-!         dragio, &
-!         albocn, &
-!         rhofresh, &
-!         vonkar, &
-!         iceruf, &
-!         zref, &
-!         snowpatch, &
-         sk_l!, &
-         !R_gC2molC
+         pi
 
     call icepack_configure()
     call seaice_icepack_write_warnings(icepack_warnings_aborted())
 
+!echmod - BFB but 20% slower when this is set in seaice_constants instead???
     seaicePi                         = pi
-!    seaiceGravity                    = gravit
-!    seaicePuny                       = puny
-!    seaiceDensityIce                 = rhoi
-!    seaiceDensitySnow                = rhos
-!    seaiceDensitySeaWater            = rhow
-!    seaiceDensityFreshwater          = rhofresh
-!    seaiceStefanBoltzmann            = stefan_boltzmann
-!    seaiceIceSnowEmissivity          = emissivity
-!    seaiceFreshWaterFreezingPoint    = Tffresh
-!    seaiceSeaWaterSpecificHeat       = cp_ocn
-!    seaiceFreshIceSpecificHeat       = cp_ice
-!    seaiceAirSpecificHeat            = cp_air
-!    seaiceWaterVaporSpecificHeat     = cp_wv
-!    seaiceLatentHeatVaporization     = Lvap
-!    seaiceLatentHeatSublimation      = Lsub
-!    seaiceLatentHeatMelting          = Lfresh
-!    seaiceIceSurfaceMeltingTemperature  = Timelt
-!    seaiceSnowSurfaceMeltingTemperature = Tsmelt
-!    seaiceZvir                       = zvir
-!    seaiceReferenceSalinity          = ice_ref_salinity
-!    seaiceMaximumSalinity            = saltmax
-!    seaiceMeltingTemperatureDepression = depressT
-!    seaiceOceanAlbedo                = albocn
-!    seaiceVonKarmanConstant          = vonkar
-!    seaiceIceSurfaceRoughness        = iceruf
-!    seaiceStabilityReferenceHeight   = zref
-!    seaiceSnowPatchiness             = snowpatch
-!    seaiceIceStrengthConstantHiblerP = Pstar
-!    seaiceIceStrengthConstantHiblerC = Cstar
-!    seaiceIceOceanDragCoefficient    = dragio
-    skeletalLayerThickness           = sk_l
-    !gramsCarbonPerMolCarbon          = R_gC2molC
 
     iceAreaMinimum       = seaicePuny
     iceThicknessMinimum  = seaicePuny

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -5887,9 +5887,9 @@ contains
          pi, &
 !         gravit, &
 !         rhoi, &
-         rhos, &
+!         rhos, &
 !         rhow, &
-         puny, &
+!         puny, &
 !         stefan_boltzmann, &
 !         emissivity, &
 !         Tffresh, &
@@ -5899,38 +5899,34 @@ contains
 !         cp_wv, &
 !         Lvap, &
 !         Lsub, &
-         Lfresh, &
+!         Lfresh, &
 !         Timelt, &
 !         Tsmelt, &
 !         zvir, &
 !         ice_ref_salinity, &
-         depressT, &
-         Pstar, &
-         Cstar, &
+!         depressT, &
+!         Pstar, &
+!         Cstar, &
 !         dragio, &
-         albocn, &
-         rhofresh, &
+!         albocn, &
+!         rhofresh, &
 !         vonkar, &
-         iceruf, &
-         zref, &
+!         iceruf, &
+!         zref, &
 !         snowpatch, &
          sk_l!, &
          !R_gC2molC
-
-!echmod - move this somewhere else!
-      real (kind=RKIND) :: &
-         saltmax = 3.2_RKIND  ! max salinity at ice base for BL99 (ppt)
 
     call icepack_configure()
     call seaice_icepack_write_warnings(icepack_warnings_aborted())
 
     seaicePi                         = pi
 !    seaiceGravity                    = gravit
-    seaicePuny                       = puny
+!    seaicePuny                       = puny
 !    seaiceDensityIce                 = rhoi
-    seaiceDensitySnow                = rhos
+!    seaiceDensitySnow                = rhos
 !    seaiceDensitySeaWater            = rhow
-    seaiceDensityFreshwater          = rhofresh
+!    seaiceDensityFreshwater          = rhofresh
 !    seaiceStefanBoltzmann            = stefan_boltzmann
 !    seaiceIceSnowEmissivity          = emissivity
 !    seaiceFreshWaterFreezingPoint    = Tffresh
@@ -5940,20 +5936,20 @@ contains
 !    seaiceWaterVaporSpecificHeat     = cp_wv
 !    seaiceLatentHeatVaporization     = Lvap
 !    seaiceLatentHeatSublimation      = Lsub
-    seaiceLatentHeatMelting          = Lfresh
+!    seaiceLatentHeatMelting          = Lfresh
 !    seaiceIceSurfaceMeltingTemperature  = Timelt
 !    seaiceSnowSurfaceMeltingTemperature = Tsmelt
 !    seaiceZvir                       = zvir
 !    seaiceReferenceSalinity          = ice_ref_salinity
-    seaiceMaximumSalinity            = saltmax
-    seaiceMeltingTemperatureDepression = depressT
-    seaiceOceanAlbedo                = albocn
+!    seaiceMaximumSalinity            = saltmax
+!    seaiceMeltingTemperatureDepression = depressT
+!    seaiceOceanAlbedo                = albocn
 !    seaiceVonKarmanConstant          = vonkar
-    seaiceIceSurfaceRoughness        = iceruf
-    seaiceStabilityReferenceHeight   = zref
+!    seaiceIceSurfaceRoughness        = iceruf
+!    seaiceStabilityReferenceHeight   = zref
 !    seaiceSnowPatchiness             = snowpatch
-    seaiceIceStrengthConstantHiblerP = Pstar
-    seaiceIceStrengthConstantHiblerC = Cstar
+!    seaiceIceStrengthConstantHiblerP = Pstar
+!    seaiceIceStrengthConstantHiblerC = Cstar
 !    seaiceIceOceanDragCoefficient    = dragio
     skeletalLayerThickness           = sk_l
     !gramsCarbonPerMolCarbon          = R_gC2molC

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -23,8 +23,8 @@ module seaice_icepack
 
   use seaice_error
 
-  use ice_kinds_mod, only: &
-      char_len_long
+!  use ice_kinds_mod, only: &      !colpkg
+!      char_len_long
 
   implicit none
 
@@ -196,7 +196,8 @@ module seaice_icepack
        tracerArrayCell
 
   ! warnings string kind
-  integer, parameter :: strKINDWarnings = char_len_long
+!  integer, parameter :: strKINDWarnings = char_len_long
+  integer, parameter :: strKINDWarnings = strKIND
 
 contains
 
@@ -621,7 +622,7 @@ contains
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!  init_column_shortwave
+!  init_icepack_shortwave
 !
 !> \brief
 !> \author Adrian K. Turner, LANL
@@ -5770,6 +5771,7 @@ contains
   function seaice_icepack_enthalpy_ice(iceTemperature, iceSalinity) result(iceEnthalpy)
 
 !echmod - this function will be needed for the prescribed ice configuration - not tested
+!echmod - call enthalpy_mush from icepack_mushy_physics via icepack_intfc (not yet available)
 
     use ice_mushy_physics, only: enthalpy_mush
 
@@ -10025,65 +10027,6 @@ contains
 
   subroutine init_icepack_package_tracer_indices(tracerObject)
 
-    !use ice_colpkg_tracers, only: &
-    !     nt_Tsfc, &       ! ice/snow temperature
-    !     nt_qice, &       ! volume-weighted ice enthalpy (in layers)
-    !     nt_qsno, &       ! volume-weighted snow enthalpy (in layers)
-    !     nt_sice, &       ! volume-weighted ice bulk salinity (CICE grid layers)
-    !     nt_fbri, &       ! volume fraction of ice with dynamic salt (hinS/vicen*aicen)
-    !     nt_iage, &       ! volume-weighted ice age
-    !     nt_FY, &         ! area-weighted first-year ice area
-    !     nt_alvl, &       ! level ice area fraction
-    !     nt_vlvl, &       ! level ice volume fraction
-    !     nt_apnd, &       ! melt pond area fraction
-    !     nt_hpnd, &       ! melt pond depth
-    !     nt_ipnd, &       ! melt pond refrozen lid thickness
-    !     nt_aero, &       ! starting index for aerosols in ice
-    !     nt_smice, &      ! snow ice mass
-    !     nt_smliq, &      ! snow liquid mass
-    !     nt_rsnw, &       ! snow grain radius
-    !     nt_rhos, &       ! snow density tracer
-    !     nt_fbri, &       ! volume fraction of ice with dynamic salt (hinS/vicen*aicen)
-    !     nt_bgc_Nit, &    ! nutrients
-    !     nt_bgc_Am, &     !
-    !     nt_bgc_Sil, &    !
-    !     nt_bgc_DMSPp, &  ! trace gases (skeletal layer)
-    !     nt_bgc_DMSPd, &  !
-    !     nt_bgc_DMS, &    !
-    !     nt_bgc_PON, &    ! zooplankton and detritus
-    !     nt_bgc_hum, &    ! humic material
-    !                      ! bio layer indicess
-    !     nlt_bgc_Nit, &   ! nutrients
-    !     nlt_bgc_Am, &    !
-    !     nlt_bgc_Sil, &   !
-    !     nlt_bgc_DMSPp, & ! trace gases (skeletal layer)
-    !     nlt_bgc_DMSPd, & !
-    !     nlt_bgc_DMS, &   !
-    !     nlt_bgc_PON, &   ! zooplankton and detritus
-    !     nlt_bgc_hum, &   ! humic material
-    !     nlt_chl_sw, &    ! points to total chla in trcrn_sw
-    !     nt_zbgc_frac, &  ! fraction of tracer in the mobile phase
-    !     nt_bgc_S, &      ! Bulk salinity in fraction ice with dynamic salinity (Bio grid)
-    !     nt_bgc_N, &      ! diatoms, phaeocystis, pico/small
-    !     nt_bgc_C, &      ! diatoms, phaeocystis, pico/small
-    !     nt_bgc_chl, &    ! diatoms, phaeocystis, pico/small
-    !     nlt_bgc_N, &     ! diatoms, phaeocystis, pico/small
-    !     nlt_bgc_C, &     ! diatoms, phaeocystis, pico/small
-    !     nlt_bgc_chl, &   ! diatoms, phaeocystis, pico/small
-    !     nt_bgc_DOC, &    ! dissolved organic carbon
-    !     nlt_bgc_DOC, &   ! dissolved organic carbon
-    !     nt_bgc_DON, &    ! dissolved organic nitrogen
-    !     nlt_bgc_DON, &   ! dissolved organic nitrogen
-    !     nt_bgc_DIC, &    ! dissolved inorganic carbon
-    !     nlt_bgc_DIC, &   ! dissolved inorganic carbon
-    !     nt_bgc_Fed, &    ! dissolved iron
-    !     nt_bgc_Fep, &    ! particulate iron
-    !     nlt_bgc_Fed, &   ! dissolved iron
-    !     nlt_bgc_Fep, &   ! particulate iron
-    !     nt_zaero, &      ! black carbon and other aerosols
-    !     nlt_zaero, &     ! black carbon and other aerosols
-    !     nlt_zaero_sw     ! black carbon and other aerosols
-
     use icepack_intfc, only: &
          icepack_init_tracer_indices
 
@@ -11768,10 +11711,10 @@ contains
 
 !echmod: These constants will need to be defined in the MPAS-SI driver (or a shared E3SM constants file) 
 !echmod: eventually, rather than in the old column package. For now, use the column package's values.
-    use ice_colpkg_shared, only: &
-         dSin0_frazil,             &
-         phi_init, &
-         hs_ssl
+!    use ice_colpkg_shared, only: &
+!         dSin0_frazil,             &
+!         phi_init, &
+!         hs_ssl
 
     use seaice_constants, only: &
          pii, &                              ! pi                     !echmod: use SHR value instead?
@@ -11793,6 +11736,7 @@ contains
          seaiceSnowSurfaceMeltingTemperature, & ! melting temp. snow top surface  (C)
          seaiceStefanBoltzmann, &            ! J m-2 K-4 s-1
          seaiceIceSnowEmissivity, &          ! emissivity of snow and ice
+         seaiceSnowSurfaceScatteringLayer, & ! snow surface scattering layer thickness (m)
          seaiceStabilityReferenceHeight, &   ! stability reference height (m)
          seaiceFreshWaterFreezingPoint, &    ! freezing temp of fresh ice (K)
          seaiceIceOceanDragCoefficient, &    ! ice ocean drag coefficient
@@ -11802,6 +11746,8 @@ contains
          seaiceReferenceSalinity, &          ! ice reference salinity (ppt)
          seaiceMaximumSalinity, &            ! ice maximum salinity (ppt)
          seaiceMeltingTemperatureDepression, &  ! melting temperature depression factor (C/ppt)
+         seaiceFrazilSalinityReduction, &    ! bulk salinity reduction of newly formed frazil (ppt)
+         seaiceFrazilIcePorosity, &          ! initial liquid fraction of frazil
          seaicePi, &                         ! pi
          seaiceGravity, &                    ! gravitational acceleration (m/s^2)
          seaiceSnowPatchiness, &             ! snow patchiness parameter
@@ -12462,13 +12408,15 @@ contains
          !rhosi_in                = , &        ! brine, zbgc, zsalinity
          sk_l_in                 = skeletalLayerThickness, & !
          saltmax_in              = seaiceMaximumSalinity, &
-         phi_init_in             = phi_init, &        ! therm_itd  config_frazil_ice_porosity
+!         phi_init_in             = phi_init, &        ! therm_itd  config_frazil_ice_porosity
+         phi_init_in             = seaiceFrazilIcePorosity, &
          !min_salin_in            = , &        ! ktherm=1, brine, zsalinity
          !salt_loss_in            = , &        ! brine, zsalinity
          !min_bgc_in              = , &        ! shortwave
-         dSin0_frazil_in         = dSin0_frazil, & !config_frazil_salinity_reduction, &        ! therm_itd
-         !hi_ssl_in               = , &        ! shortwave, aerosol
-         hs_ssl_in               = hs_ssl, &  !config_snow_surface_scattering_layer_depth, &        ! shortwave, aerosol, itd, therm_itd, bgc
+!         dSin0_frazil_in         = dSin0_frazil, & !config_frazil_salinity_reduction, &        ! therm_itd
+         dSin0_frazil_in         = seaiceFrazilSalinityReduction, &
+!         hs_ssl_in               = hs_ssl, &  !config_snow_surface_scattering_layer_depth, &        ! shortwave, aerosol, itd, therm_itd, bgc
+         hs_ssl_in               = seaiceSnowSurfaceScatteringLayer, &
          !awtvdr_in               = , &        ! shortwave
          !awtidr_in               = , &        ! shortwave
          !awtvdf_in               = , &        ! shortwave
@@ -12822,15 +12770,13 @@ contains
     ! liquid fraction of congelation ice
     !phi_i_mushy = config_congelation_ice_porosity
 
-!echmod - fix as needed
-!    ! phi_init:
-!    ! initial liquid fraction of frazil ice
-!    !phi_init = config_frazil_ice_porosity
+    ! phi_init:
+    ! initial liquid fraction of frazil ice
+    !phi_init = seaiceFrazilIcePorosity
 
-!echmod - fix as needed
-!    ! dSin0_frazil:
-!    ! initial frazil salinity reduction
-!    !dSin0_frazil = config_frazil_salinity_reduction
+    ! dSin0_frazil:
+    ! initial frazil salinity reduction
+    !dSin0_frazil = seaiceFrazilSalinityReduction
 
     !-----------------------------------------------------------------------
     ! Parameters for radiation
@@ -12869,10 +12815,9 @@ contains
 
     ! dEdd tuning parameters, set in namelist
 
-!echmod - fix as needed
-!    ! hs_ssl:
-!    ! snow surface scattering layer depth
-!    !hs_ssl = config_snow_surface_scattering_layer_depth
+    ! hs_ssl:
+    ! snow surface scattering layer depth
+    !hs_ssl = seaiceSnowSurfaceScatteringLayer
 
     ! R_ice:
     ! sea ice tuning parameter; +1 > 1sig increase in albedo

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -11709,16 +11709,10 @@ contains
          icepack_configure, &
          icepack_query_parameters ! debugging
 
-!echmod: These constants will need to be defined in the MPAS-SI driver (or a shared E3SM constants file) 
-!echmod: eventually, rather than in the old column package. For now, use the column package's values.
-!    use ice_colpkg_shared, only: &
-!         dSin0_frazil,             &
-!         phi_init, &
-!         hs_ssl
-
     use seaice_constants, only: &
          pii, &                              ! pi                     !echmod: use SHR value instead?
          seaicePuny, &                       ! a small number
+         seaiceBigNumber, &                     ! a large number
          seaiceSecondsPerDay, &              ! number of seconds in 1 day
          seaiceDensityIce, &                 ! density of ice (kg/m^3)
          seaiceDensitySnow, &                ! density of snow (kg/m^3)
@@ -11753,7 +11747,23 @@ contains
          seaiceSnowPatchiness, &             ! snow patchiness parameter
          seaiceIceStrengthConstantHiblerP, & ! P* constant in Hibler strength formulation
          seaiceIceStrengthConstantHiblerC, & ! C* constant in Hibler strength formulation
-         skeletalLayerThickness              ! skeletal layer thickness
+         skeletalLayerThickness, &           ! skeletal layer thickness
+         seaiceSnowMinimumDensity, &         ! minimum snow density (kg/m^3)
+         seaiceBrineDynamicViscosity, &      ! dynamic viscosity of brine (kg/m/s)
+         seaiceFreezingTemperatureConstant, &! constant freezing temp of seawater (C)
+         seaiceExtinctionCoef, &             ! vis extnctn coef in ice, wvlngth<700nm (1/m)
+         seaiceFreshIceConductivity, &       ! thermal conductivity of fresh ice(W/m/deg)
+         seaiceSnowConductivity, &           ! thermal conductivity of snow  (W/m/deg)
+         seaiceSnowMinimumThickness, &       ! min snow thickness for computing zTsn (m)
+         seaiceFrazilMinimumThickness, &     ! min thickness of new frazil ice
+         seaiceAlbedoWtVisibleDirect, &      ! visible, direct
+         seaiceAlbedoWtNearIRDirect, &       ! near IR, direct
+         seaiceAlbedoWtVisibleDiffuse, &     ! visible, diffuse
+         seaiceAlbedoWtNearIRDiffuse, &      ! near IR, diffuse
+         seaiceQsatQiceConstant, &           ! constant for saturation humidity over ice
+         seaiceQsatTiceConstant, &           ! constant for saturation humidity over ice
+         seaiceQsatQocnConstant, &           ! constant for saturation humidity over ocean
+         seaiceQsatTocnConstant              ! constant for saturation humidity over ocean
 
     type(domain_type), intent(inout) :: &
          domain
@@ -12363,7 +12373,7 @@ contains
     call icepack_init_parameters(&
          !argcheck_in             = , &               ! may not be needed in the driver
          puny_in                 = seaicePuny, &
-         !bignum_in               = , &
+         bignum_in               = seaiceBigNumber, &
 !         pi_in                   = pii, &            ! use SHR value instead
          pi_in                   = seaicePi, &
          secday_in               = seaiceSecondsPerDay, &
@@ -12374,7 +12384,7 @@ contains
          emissivity_in           = seaiceIceSnowEmissivity, & !
          cp_ice_in               = seaiceFreshIceSpecificHeat, & !
          cp_ocn_in               = seaiceSeaWaterSpecificHeat, &
-         !hfrazilmin_in           = , &
+         hfrazilmin_in           = seaiceFrazilMinimumThickness, &
          !floediam_in             = , &
          depressT_in             = seaiceMeltingTemperatureDepression, &
          dragio_in               = seaiceIceOceanDragCoefficient, & ! note calc_dragio not implemented
@@ -12382,8 +12392,8 @@ contains
          !iceruf_ocn_in           = , &        ! under-ice roughness, not yet implemented
          albocn_in               = seaiceOceanAlbedo, &
          gravit_in               = seaiceGravity, &
-         !viscosity_dyn_in        = , &
-         !Tocnfrz_in              = , &
+         viscosity_dyn_in        = seaiceBrineDynamicViscosity, &
+         Tocnfrz_in              = seaiceFreezingTemperatureConstant, &
          rhofresh_in             = seaiceDensityFreshwater, &
          zvir_in                 = seaiceZvir, &
          vonkar_in               = seaiceVonKarmanConstant, &
@@ -12399,32 +12409,29 @@ contains
          Cf_in                   = config_ratio_ridging_work_to_PE, &
          Pstar_in                = seaiceIceStrengthConstantHiblerP, &
          Cstar_in                = seaiceIceStrengthConstantHiblerC, &
-         !kappav_in               = , &
-         !kice_in                 = , &
-         !ksno_in                 = , &
+         kappav_in               = seaiceExtinctionCoef, &
+         kice_in                 = seaiceFreshIceConductivity, &
+         ksno_in                 = seaiceSnowConductivity, &
          zref_in                 = seaiceStabilityReferenceHeight, &
-         !hs_min_in               = , &
+         hs_min_in               = seaiceSnowMinimumThickness, &
          snowpatch_in            = seaiceSnowPatchiness, & ! ccsm3 radiation scheme
          !rhosi_in                = , &        ! brine, zbgc, zsalinity
          sk_l_in                 = skeletalLayerThickness, & !
          saltmax_in              = seaiceMaximumSalinity, &
-!         phi_init_in             = phi_init, &        ! therm_itd  config_frazil_ice_porosity
          phi_init_in             = seaiceFrazilIcePorosity, &
          !min_salin_in            = , &        ! ktherm=1, brine, zsalinity
          !salt_loss_in            = , &        ! brine, zsalinity
          !min_bgc_in              = , &        ! shortwave
-!         dSin0_frazil_in         = dSin0_frazil, & !config_frazil_salinity_reduction, &        ! therm_itd
          dSin0_frazil_in         = seaiceFrazilSalinityReduction, &
-!         hs_ssl_in               = hs_ssl, &  !config_snow_surface_scattering_layer_depth, &        ! shortwave, aerosol, itd, therm_itd, bgc
          hs_ssl_in               = seaiceSnowSurfaceScatteringLayer, &
-         !awtvdr_in               = , &        ! shortwave
-         !awtidr_in               = , &        ! shortwave
-         !awtvdf_in               = , &        ! shortwave
-         !awtidf_in               = , &        ! shortwave
-         !qqqice_in               = , &        ! atmo, therm_shared
-         !TTTice_in               = , &        ! atmo, therm_shared
-         !qqqocn_in               = , &        ! atmo
-         !TTTocn_in               = , &        ! atmo
+         awtvdr_in               = seaiceAlbedoWtVisibleDirect, &
+         awtidr_in               = seaiceAlbedoWtNearIRDirect, &
+         awtvdf_in               = seaiceAlbedoWtVisibleDiffuse, &
+         awtidf_in               = seaiceAlbedoWtNearIRDiffuse, &
+         qqqice_in               = seaiceQsatQiceConstant, &
+         TTTice_in               = seaiceQsatTiceConstant, &
+         qqqocn_in               = seaiceQsatQocnConstant, &
+         TTTocn_in               = seaiceQsatTocnConstant, &
          ktherm_in               = config_thermodynamics_type_int, &
          conduct_in              = config_heat_conductivity_type, &
          fbot_xfer_type_in       = config_ocean_heat_transfer_type, &

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -5885,35 +5885,35 @@ contains
 !echmod: them with the icepack_init_parameters call is unnecessary.
     use ice_constants_colpkg, only: &  ! for E3SM runs this is currently in src/column/constants/cesm/
          pi, &
-         gravit, &
-         rhoi, &
+!         gravit, &
+!         rhoi, &
          rhos, &
-         rhow, &
+!         rhow, &
          puny, &
-         stefan_boltzmann, &
-         emissivity, &
-         Tffresh, &
-         cp_ice, &
-         cp_air, &
-         cp_ocn, &
-         cp_wv, &
-         Lvap, &
-         Lsub, &
+!         stefan_boltzmann, &
+!         emissivity, &
+!         Tffresh, &
+!         cp_ice, &
+!         cp_air, &
+!         cp_ocn, &
+!         cp_wv, &
+!         Lvap, &
+!         Lsub, &
          Lfresh, &
-         Timelt, &
-         Tsmelt, &
-         zvir, &
-         ice_ref_salinity, &
+!         Timelt, &
+!         Tsmelt, &
+!         zvir, &
+!         ice_ref_salinity, &
          depressT, &
          Pstar, &
          Cstar, &
-         dragio, &
+!         dragio, &
          albocn, &
          rhofresh, &
-         vonkar, &
+!         vonkar, &
          iceruf, &
          zref, &
-         snowpatch, &
+!         snowpatch, &
          sk_l!, &
          !R_gC2molC
 
@@ -5925,36 +5925,36 @@ contains
     call seaice_icepack_write_warnings(icepack_warnings_aborted())
 
     seaicePi                         = pi
-    seaiceGravity                    = gravit
+!    seaiceGravity                    = gravit
     seaicePuny                       = puny
-    seaiceDensityIce                 = rhoi
+!    seaiceDensityIce                 = rhoi
     seaiceDensitySnow                = rhos
-    seaiceDensitySeaWater            = rhow
+!    seaiceDensitySeaWater            = rhow
     seaiceDensityFreshwater          = rhofresh
-    seaiceStefanBoltzmann            = stefan_boltzmann
-    seaiceIceSnowEmissivity          = emissivity
-    seaiceFreshWaterFreezingPoint    = Tffresh
-    seaiceSeaWaterSpecificHeat       = cp_ocn
-    seaiceFreshIceSpecificHeat       = cp_ice
-    seaiceAirSpecificHeat            = cp_air
-    seaiceWaterVaporSpecificHeat     = cp_wv
-    seaiceLatentHeatVaporization     = Lvap
-    seaiceLatentHeatSublimation      = Lsub
+!    seaiceStefanBoltzmann            = stefan_boltzmann
+!    seaiceIceSnowEmissivity          = emissivity
+!    seaiceFreshWaterFreezingPoint    = Tffresh
+!    seaiceSeaWaterSpecificHeat       = cp_ocn
+!    seaiceFreshIceSpecificHeat       = cp_ice
+!    seaiceAirSpecificHeat            = cp_air
+!    seaiceWaterVaporSpecificHeat     = cp_wv
+!    seaiceLatentHeatVaporization     = Lvap
+!    seaiceLatentHeatSublimation      = Lsub
     seaiceLatentHeatMelting          = Lfresh
-    seaiceIceSurfaceMeltingTemperature  = Timelt
-    seaiceSnowSurfaceMeltingTemperature = Tsmelt
-    seaiceZvir                       = zvir
-    seaiceReferenceSalinity          = ice_ref_salinity
+!    seaiceIceSurfaceMeltingTemperature  = Timelt
+!    seaiceSnowSurfaceMeltingTemperature = Tsmelt
+!    seaiceZvir                       = zvir
+!    seaiceReferenceSalinity          = ice_ref_salinity
     seaiceMaximumSalinity            = saltmax
     seaiceMeltingTemperatureDepression = depressT
     seaiceOceanAlbedo                = albocn
-    seaiceVonKarmanConstant          = vonkar
+!    seaiceVonKarmanConstant          = vonkar
     seaiceIceSurfaceRoughness        = iceruf
     seaiceStabilityReferenceHeight   = zref
-    seaiceSnowPatchiness             = snowpatch
+!    seaiceSnowPatchiness             = snowpatch
     seaiceIceStrengthConstantHiblerP = Pstar
     seaiceIceStrengthConstantHiblerC = Cstar
-    seaiceIceOceanDragCoefficient    = dragio
+!    seaiceIceOceanDragCoefficient    = dragio
     skeletalLayerThickness           = sk_l
     !gramsCarbonPerMolCarbon          = R_gC2molC
 


### PR DESCRIPTION
Move column package parameters from both of the ice_constants_colpkg files (coupled and standalone) into mpas_seaice_constants.F.  
- Define MPAS-SI style names for those that were only used directly from colpkg.  Some of these parameters might need to be renamed if they are put in namelist/configs. Some might need to be renamed per MPAS-SI conventions (which do not seem to be entirely consistent)
- Initialize all of the parameters in Icepack.  
- Clean up.

Note that pi still has multiple values, for now.

The `column` option still uses ice_constants_colpkg.

BFB with the previous version in 3-month D cases.