### PR TITLE
FSD namelist flag and Abort. 

### DIFF
--- a/components/mpas-seaice/bld/build-namelist
+++ b/components/mpas-seaice/bld/build-namelist
@@ -530,6 +530,7 @@ add_default($nl, 'config_restart_timestamp_name');
 add_default($nl, 'config_nCategories');
 add_default($nl, 'config_nIceLayers');
 add_default($nl, 'config_nSnowLayers');
+add_default($nl, 'config_nFloeCategories');
 
 ##############################
 # Namelist group: initialize #
@@ -654,6 +655,7 @@ add_default($nl, 'config_use_aerosols');
 add_default($nl, 'config_use_effective_snow_density');
 add_default($nl, 'config_use_snow_grain_radius');
 add_default($nl, 'config_use_special_boundaries_tracers');
+add_default($nl, 'config_use_floe_size_distribution');
 
 ###################################
 # Namelist group: biogeochemistry #

--- a/components/mpas-seaice/bld/build-namelist
+++ b/components/mpas-seaice/bld/build-namelist
@@ -528,6 +528,7 @@ add_default($nl, 'config_restart_timestamp_name');
 ##############################
 
 add_default($nl, 'config_nCategories');
+add_default($nl, 'config_nFloeCategories');
 add_default($nl, 'config_nIceLayers');
 add_default($nl, 'config_nSnowLayers');
 add_default($nl, 'config_nFloeCategories');

--- a/components/mpas-seaice/bld/build-namelist-section
+++ b/components/mpas-seaice/bld/build-namelist-section
@@ -70,6 +70,7 @@ add_default($nl, 'config_do_restart_snow_grain_radius');
 add_default($nl, 'config_nCategories');
 add_default($nl, 'config_nIceLayers');
 add_default($nl, 'config_nSnowLayers');
+add_default($nl, 'config_nFloeCategories');
 
 ##############################
 # Namelist group: initialize #
@@ -186,6 +187,7 @@ add_default($nl, 'config_use_aerosols');
 add_default($nl, 'config_use_effective_snow_density');
 add_default($nl, 'config_use_snow_grain_radius');
 add_default($nl, 'config_use_special_boundaries_tracers');
+add_default($nl, 'config_use_floe_size_distribution');
 
 ###################################
 # Namelist group: biogeochemistry #

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -61,6 +61,7 @@
 <config_nCategories>5</config_nCategories>
 <config_nIceLayers>7</config_nIceLayers>
 <config_nSnowLayers>5</config_nSnowLayers>
+<config_nFloeCategories>1</config_nFloeCategories>
 
 <!-- initialize -->
 <config_earth_radius>6371229.0</config_earth_radius>
@@ -189,6 +190,7 @@
 <config_use_effective_snow_density>true</config_use_effective_snow_density>
 <config_use_snow_grain_radius>true</config_use_snow_grain_radius>
 <config_use_special_boundaries_tracers>false</config_use_special_boundaries_tracers>
+<config_use_floe_size_distribution>false</config_use_floe_size_distribution>
 
 <!-- biogeochemistry -->
 <config_use_brine>false</config_use_brine>

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -59,6 +59,7 @@
 
 <!-- dimensions -->
 <config_nCategories>5</config_nCategories>
+<config_nFloeCategories>1</config_nFloeCategories>
 <config_nIceLayers>7</config_nIceLayers>
 <config_nSnowLayers>5</config_nSnowLayers>
 <config_nFloeCategories>1</config_nFloeCategories>

--- a/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
@@ -304,6 +304,13 @@ Valid values: Any positive integer.
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_nFloeCategories" type="integer"
+	category="dimensions" group="dimensions">
+The number of ice floe categories to use.
+
+Valid values: 1(default), 12, 16, 24.
+Default: Defined in namelist_defaults.xml
+</entry>
 
 <!-- initialize -->
 

--- a/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
@@ -943,6 +943,13 @@ Valid values: true or false
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_use_floe_size_distribution" type="logical"
+	category="column_tracers" group="column_tracers">
+Use floe size distribution. Requires Icepack column package.
+
+Valid values: true or false
+Default: Defined in namelist_defaults.xml
+</entry>
 
 <!-- biogeochemistry -->
 

--- a/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
@@ -288,6 +288,22 @@ Valid values: Any positive integer.
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_nFloeCategories" type="integer"
+	category="dimensions" group="dimensions">
+The number of floe size categories to use.
+
+Valid values: Any positive integer.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_nCategories" type="integer"
+	category="dimensions" group="dimensions">
+The number of ice thickness categories to use.
+
+Valid values: Any positive integer.
+Default: Defined in namelist_defaults.xml
+</entry>
+
 <entry id="config_nIceLayers" type="integer"
 	category="dimensions" group="dimensions">
 The number of ice layers in the vertical direction to use.

--- a/components/mpas-seaice/driver/ice_comp_mct.F
+++ b/components/mpas-seaice/driver/ice_comp_mct.F
@@ -754,7 +754,11 @@ contains
     else if (trim(tempCharConfig) == "column_package") then
       call seaice_column_coupling_prep(domain)
     endif ! config_column_physics_type
-
+    
+    call MPAS_pool_get_config(domain % configs, "config_use_floe_size_distribution", tempLogicalConfig)
+    if (tempLogicalConfig) then
+      call mpas_log_write('FloeSizeDistribution coming online soon. Turn FSD off for now.', MPAS_LOG_CRIT)    
+    endif
 !-----------------------------------------------------------------------
 !
 !   send intial state to driver

--- a/components/mpas-seaice/src/Registry.xml
+++ b/components/mpas-seaice/src/Registry.xml
@@ -775,6 +775,11 @@
 			description="Modify tracers in given boundary cells."
 			possible_values="true or false"
 		/>
+		<nml_option name="config_use_floe_size_distribution" type="logical" default_value="false" units="unitless"
+			description="Use prognostic floe size distribution"
+			possible_values="true or false"
+			icepack_name="tr_fsd"
+		/>
 	</nml_record>
 
 	<nml_record name="biogeochemistry" in_defaults="true">

--- a/components/mpas-seaice/src/Registry.xml
+++ b/components/mpas-seaice/src/Registry.xml
@@ -44,6 +44,10 @@
 			definition="namelist:config_nCategories"
 			description="The number of ice thickness categories."
 		/>
+		<dim name="nFloeCategories"
+			definition="namelist:config_nFloeCategories"
+			description="The number of floe size categories."
+		/>
 		<dim name="nIceLayers"
 			definition="namelist:config_nIceLayers"
 			description="The number of ice layers in the vertical direction."
@@ -432,6 +436,10 @@
 	<nml_record name="dimensions" in_defaults="true">
 		<nml_option name="config_nCategories" type="integer" default_value="5" units="unitless"
 			description="The number of ice thickness categories to use."
+			possible_values="Any positive integer."
+		/>
+		<nml_option name="config_nFloeCategories" type="integer" default_value="1" units="unitless"
+			description="The number of floe size categories to use."
 			possible_values="Any positive integer."
 		/>
 		<nml_option name="config_nIceLayers" type="integer" default_value="7" units="unitless"


### PR DESCRIPTION
This PR only include the fsd namelist settings to 'use' the FSD and an 'abort' command if the user tries to turn on FSD before it is fully implemented. 