### PR TITLE
Physics cleanup

### DIFF
--- a/components/mpas-seaice/src/Makefile.icepack
+++ b/components/mpas-seaice/src/Makefile.icepack
@@ -13,7 +13,6 @@ OBJS =  icepack_aerosol.o \
 	icepack_itd.o \
 	icepack_kinds.o \
 	icepack_mechred.o \
-	icepack_meltpond_cesm.o \
 	icepack_meltpond_lvl.o \
 	icepack_meltpond_topo.o \
 	icepack_mushy_physics.o \
@@ -23,7 +22,6 @@ OBJS =  icepack_aerosol.o \
 	icepack_shortwave.o \
         icepack_shortwave_data.o \
 	icepack_snow.o \
-	icepack_therm_0layer.o \
 	icepack_therm_bl99.o \
 	icepack_therm_itd.o \
 	icepack_therm_mushy.o \
@@ -33,8 +31,7 @@ OBJS =  icepack_aerosol.o \
 	icepack_warnings.o \
 	icepack_wavefracspec.o \
 	icepack_zbgc.o \
-	icepack_zbgc_shared.o \
-	icepack_zsalinity.o
+	icepack_zbgc_shared.o
 
 
 all: $(OBJS)
@@ -110,9 +107,6 @@ icepack_mechred.o:icepack_kinds.o
 icepack_mechred.o:icepack_parameters.o
 icepack_mechred.o:icepack_tracers.o
 icepack_mechred.o:icepack_warnings.o
-icepack_meltpond_cesm.o:icepack_kinds.o
-icepack_meltpond_cesm.o:icepack_parameters.o
-icepack_meltpond_cesm.o:icepack_warnings.o
 icepack_meltpond_lvl.o:icepack_kinds.o
 icepack_meltpond_lvl.o:icepack_parameters.o
 icepack_meltpond_lvl.o:icepack_therm_shared.o
@@ -146,10 +140,6 @@ icepack_snow.o:icepack_kinds.o
 icepack_snow.o:icepack_parameters.o
 icepack_snow.o:icepack_therm_shared.o
 icepack_snow.o:icepack_warnings.o
-icepack_therm_0layer.o:icepack_kinds.o
-icepack_therm_0layer.o:icepack_parameters.o
-icepack_therm_0layer.o:icepack_therm_bl99.o
-icepack_therm_0layer.o:icepack_warnings.o
 icepack_therm_bl99.o:icepack_kinds.o
 icepack_therm_bl99.o:icepack_parameters.o
 icepack_therm_bl99.o:icepack_therm_shared.o
@@ -181,13 +171,11 @@ icepack_therm_vertical.o:icepack_firstyear.o
 icepack_therm_vertical.o:icepack_flux.o
 icepack_therm_vertical.o:icepack_isotope.o
 icepack_therm_vertical.o:icepack_kinds.o
-icepack_therm_vertical.o:icepack_meltpond_cesm.o
 icepack_therm_vertical.o:icepack_meltpond_lvl.o
 icepack_therm_vertical.o:icepack_meltpond_topo.o
 icepack_therm_vertical.o:icepack_mushy_physics.o
 icepack_therm_vertical.o:icepack_parameters.o
 icepack_therm_vertical.o:icepack_snow.o
-icepack_therm_vertical.o:icepack_therm_0layer.o
 icepack_therm_vertical.o:icepack_therm_bl99.o
 icepack_therm_vertical.o:icepack_therm_mushy.o
 icepack_therm_vertical.o:icepack_therm_shared.o
@@ -211,19 +199,10 @@ icepack_zbgc.o:icepack_therm_shared.o
 icepack_zbgc.o:icepack_tracers.o
 icepack_zbgc.o:icepack_warnings.o
 icepack_zbgc.o:icepack_zbgc_shared.o
-icepack_zbgc.o:icepack_zsalinity.o
 icepack_zbgc_shared.o:icepack_kinds.o
 icepack_zbgc_shared.o:icepack_parameters.o
 icepack_zbgc_shared.o:icepack_tracers.o
 icepack_zbgc_shared.o:icepack_warnings.o
-icepack_zsalinity.o:icepack_brine.o
-icepack_zsalinity.o:icepack_kinds.o
-icepack_zsalinity.o:icepack_parameters.o
-icepack_zsalinity.o:icepack_therm_shared.o
-icepack_zsalinity.o:icepack_tracers.o
-icepack_zsalinity.o:icepack_warnings.o
-icepack_zsalinity.o:icepack_zbgc_shared.o
-
 
 .F90.o:
 	$(RM) $@ $*.mod

--- a/components/mpas-seaice/src/analysis_members/Makefile
+++ b/components/mpas-seaice/src/analysis_members/Makefile
@@ -21,10 +21,10 @@ FW = ../../../mpas-framework/src
 	$(RM) $@ $*.mod
 ifeq "$(GEN_F90)" "true"
 	$(CPP) $(CPPFLAGS) $(CPPINCLUDES) $< > $*.f90
-	$(FC) $(FFLAGS) -c $*.f90 -I$(FW)/external/esmf_time_f90 -I$(FW)/framework -I$(FW)/operators -I../column -I../shared -I../model_forward $(FCINCLUDES)
+	$(FC) $(FFLAGS) -c $*.f90 -I$(FW)/external/esmf_time_f90 -I$(FW)/framework -I$(FW)/operators -I../icepack/columnphysics -I../column -I../shared -I../model_forward $(FCINCLUDES)
 else
-	$(FC) $(CPPFLAGS) $(FFLAGS) -c $*.F -I$(FW)/external/esmf_time_f90 -I$(FW)/framework -I$(FW)/operators -I../column -I../shared -I../model_forward $(CPPINCLUDES) $(FCINCLUDES)
+	$(FC) $(CPPFLAGS) $(FFLAGS) -c $*.F -I$(FW)/external/esmf_time_f90 -I$(FW)/framework -I$(FW)/operators -I../icepack/columnphysics -I../column -I../shared -I../model_forward $(CPPINCLUDES) $(FCINCLUDES)
 endif
 
 .c.o:
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(CINCLUDES) -I$(FW)/external/esmf_time_f90 -I$(FW)/framework -I$(FW)/operators -I../column -I../shared -I../model_forward -c $<
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(CINCLUDES) -I$(FW)/external/esmf_time_f90 -I$(FW)/framework -I$(FW)/operators -I../icepack/columnphysics -I../column -I../shared -I../model_forward -c $<

--- a/components/mpas-seaice/src/shared/mpas_seaice_column.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_column.F
@@ -9929,7 +9929,7 @@ contains
          config_calc_surface_temperature, &
          config_use_form_drag, &
          config_use_level_ice, &
-         config_use_cesm_meltponds, &
+         config_use_cesm_meltponds, &  ! deprecated
          config_use_level_meltponds, &
          config_use_topo_meltponds, &
          config_use_vertical_zsalinity, &
@@ -9989,7 +9989,7 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_snow_to_ice_transition_depth", config_snow_to_ice_transition_depth)
     call MPAS_pool_get_config(domain % configs, "config_use_form_drag", config_use_form_drag)
     call MPAS_pool_get_config(domain % configs, "config_use_level_ice", config_use_level_ice)
-    call MPAS_pool_get_config(domain % configs, "config_use_cesm_meltponds", config_use_cesm_meltponds)
+    call MPAS_pool_get_config(domain % configs, "config_use_cesm_meltponds", config_use_cesm_meltponds) ! deprecated
     call MPAS_pool_get_config(domain % configs, "config_use_level_meltponds", config_use_level_meltponds)
     call MPAS_pool_get_config(domain % configs, "config_use_topo_meltponds", config_use_topo_meltponds)
     call MPAS_pool_get_config(domain % configs, "config_ocean_heat_transfer_type", config_ocean_heat_transfer_type)
@@ -10110,6 +10110,13 @@ contains
        call mpas_log_write(&
             'Check for inconsistencies in restart file: config_nIceLayers /= nIceLayers', &
             messageType=MPAS_LOG_CRIT)
+
+    ! deprecate cesm ponds
+    if (config_use_cesm_meltponds) then
+       call mpas_log_write(&
+            "check_column_package_configs: config_use_cesm_meltponds = .true. but cesm ponds are being deprecated", &
+            messageType=MPAS_LOG_CRIT)
+    endif
 
     !-----------------------------------------------------------------------
     ! Check combinations

--- a/components/mpas-seaice/src/shared/mpas_seaice_column.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_column.F
@@ -10027,7 +10027,9 @@ contains
 
     ! check config_thermodynamics_type value
     if (trim(config_thermodynamics_type) == "zero layer") then
-       call config_error("config_thermodynamics_type", config_thermodynamics_type, "'zero-layer' is being deprecated")
+       call mpas_log_write(&
+            "check_column_package_configs: config_thermodynamics_type) = zero layer but 0-layer thermo is being deprecated", &
+            messageType=MPAS_LOG_WARN)
     endif
 
     if (.not. (trim(config_thermodynamics_type) == "BL99" .or. &

--- a/components/mpas-seaice/src/shared/mpas_seaice_column.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_column.F
@@ -10026,10 +10026,13 @@ contains
     !-----------------------------------------------------------------------
 
     ! check config_thermodynamics_type value
-    if (.not. (trim(config_thermodynamics_type) == "zero layer" .or. &
-               trim(config_thermodynamics_type) == "BL99" .or. &
+    if (trim(config_thermodynamics_type) == "zero layer") then
+       call config_error("config_thermodynamics_type", config_thermodynamics_type, "'zero-layer' is being deprecated")
+    endif
+
+    if (.not. (trim(config_thermodynamics_type) == "BL99" .or. &
                trim(config_thermodynamics_type) == "mushy")) then
-       call config_error("config_thermodynamics_type", config_thermodynamics_type, "'zero layer', 'BL99' or 'mushy'")
+       call config_error("config_thermodynamics_type", config_thermodynamics_type, "'BL99' or 'mushy'")
     endif
 
     ! check config_heat_conductivity_type value
@@ -10260,6 +10263,13 @@ contains
        call mpas_log_write(&
             "check_column_package_configs: config_thermodynamics_type == 'mushy' and "//&
             "config_sea_freezing_temperature_type /= 'mushy'", &
+            messageType=MPAS_LOG_CRIT)
+    endif
+
+    ! deprecate zsalinity
+    if (config_use_vertical_zsalinity) then
+       call mpas_log_write(&
+            "check_column_package_configs: vertical zSalinity has been deprecated", &
             messageType=MPAS_LOG_CRIT)
     endif
 

--- a/components/mpas-seaice/src/shared/mpas_seaice_constants.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_constants.F
@@ -15,7 +15,9 @@
 module seaice_constants
 
   use mpas_derived_types
+#ifdef CCSMCOUPLED
   use shr_const_mod
+#endif
 
   private
   save

--- a/components/mpas-seaice/src/shared/mpas_seaice_constants.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_constants.F
@@ -86,8 +86,9 @@ module seaice_constants
        seaiceSeaWaterSpecificHeat      = 4218._RKIND   ,&! specific heat of ocn    (J/kg/K)
                                                          ! freshwater value needed for enthalpy
        seaiceLatentHeatVaporization    = 2.501e6_RKIND ,&! latent heat, vaporization freshwater (J/kg)
-       seaiceLatentHeatMelting         = seaiceLatentHeatSublimation & ! latent heat of melting of fresh ice (J/kg)
-                                       - seaiceLatentHeatVaporization, &
+!       seaiceLatentHeatMelting         = seaiceLatentHeatSublimation & ! latent heat of melting of fresh ice (J/kg)
+!                                       - seaiceLatentHeatVaporization, &
+       seaiceLatentHeatMelting         = 3.34e5_RKIND  ,&! latent heat of melting of fresh ice (J/kg)
        seaiceReferenceSalinity         = 4._RKIND      ,&! ice reference salinity (ppt)
        seaiceSnowPatchiness            = 0.02_RKIND      ! parameter for fractional snow area (m)
 

--- a/components/mpas-seaice/src/shared/mpas_seaice_constants.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_constants.F
@@ -3,12 +3,13 @@
 !  seaice_constants
 !
 !> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 2013-2014
+!> \author Adrian K. Turner and Elizabeth Hunke, LANL
+!> \date 2013-2014, 2023
 !> \details
 !> Values in this module have been copied from the two ice_constants_colpkg.F90 
-!  modules in the column physics package (colpkg, in column/).  They will remain 
-!  duplicates until the column physic package is deprecated.
+!> modules in the column physics package (in column/).  They will remain 
+!> duplicates until the column physics package is deprecated.
+!
 !-----------------------------------------------------------------------
 
 module seaice_constants

--- a/components/mpas-seaice/src/shared/mpas_seaice_constants.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_constants.F
@@ -93,23 +93,17 @@ module seaice_constants
 
   ! fundamental constants
   real (kind=RKIND), parameter, public :: &
-       pii = 3.141592653589793_RKIND, & ! echmod - why is this different from pi above?
-       seaiceDegreesToRadians = pii / 180.0_RKIND, &
-       seaiceRadiansToDegrees = 180.0_RKIND / pii, &
-!echmod - BFB but slower???
-!       pii = pi, &
-!       seaiceDegreesToRadians = pi / 180.0_RKIND, &
-!       seaiceRadiansToDegrees = 180.0_RKIND / pi, &
-       seaiceSecondsPerYear = 24.0_RKIND * 3600.0_RKIND * 365.0_RKIND, & !echmod - incorrect for leap years
-       seaiceDaysPerSecond = 1.0_RKIND/seaiceSecondsPerDay
+       pii                                = pi, &    !echmod - replace pii with seaicePi elsewhere
+       seaiceDegreesToRadians             = pi / 180.0_RKIND, &
+       seaiceRadiansToDegrees             = 180.0_RKIND / pi, &
+       seaiceSecondsPerYear               = 24.0_RKIND * 3600.0_RKIND * 365.0_RKIND, & !echmod - incorrect for leap years
+       seaiceDaysPerSecond                = 1.0_RKIND/seaiceSecondsPerDay
 
   real (kind=RKIND), public :: &
-       seaicePi
-!echmod - BFB but slower???
-!       seaicePi                           = pi ! pi
+       seaicePi                           = pi ! pi
 
   character (len=*), public, parameter :: &
-       coupleAlarmID = 'coupling'
+       coupleAlarmID                      = 'coupling'
 
   real(kind=RKIND), public :: &
        seaicePuny                         = 1.0e-11_RKIND   ! a small value

--- a/components/mpas-seaice/src/shared/mpas_seaice_constants.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_constants.F
@@ -60,7 +60,7 @@ module seaice_constants
 #else
       real (kind=RKIND), parameter, public :: &
   ! fundamental constants
-       pi                              = 3.14159265358979323846_RKIND
+       pi                              = 3.14159265358979323846_RKIND, &
        seaiceSecondsPerDay             = 24.0_RKIND * 3600.0_RKIND
  
       real (kind=RKIND), public :: &

--- a/components/mpas-seaice/src/shared/mpas_seaice_forcing.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_forcing.F
@@ -2599,6 +2599,9 @@ contains
     use ice_colpkg, only: &
          colpkg_sea_freezing_temperature
 
+    use icepack_intfc, only: &
+         icepack_sea_freezing_temperature
+
     type (block_type), pointer :: block
 
     logical, intent(in) :: &
@@ -2615,7 +2618,8 @@ contains
          seaFreezingTemperature
 
     character(len=strKIND), pointer :: &
-         config_sea_freezing_temperature_type
+         config_sea_freezing_temperature_type, &
+         config_column_physics_type
 
     logical, pointer :: &
          config_do_restart
@@ -2641,16 +2645,29 @@ contains
     call MPAS_pool_get_array(ocean_coupling, "oceanMixedLayerDepth", oceanMixedLayerDepth)
     call MPAS_pool_get_array(ocean_coupling, "seaFreezingTemperature", seaFreezingTemperature)
 
-    do iCell = 1, nCellsSolve
+    if (trim(config_column_physics_type) == "icepack") then
+       do iCell = 1, nCellsSolve
 
-       ! ensure physical realism
-       seaSurfaceSalinity(iCell)   = max(seaSurfaceSalinity(iCell), 0.0_RKIND)
-       oceanMixedLayerDepth(iCell) = max(oceanMixedLayerDepth(iCell), 0.0_RKIND)
+          ! ensure physical realism
+          seaSurfaceSalinity(iCell)   = max(seaSurfaceSalinity(iCell), 0.0_RKIND)
+          oceanMixedLayerDepth(iCell) = max(oceanMixedLayerDepth(iCell), 0.0_RKIND)
 
-       ! sea freezing temperature
-       seaFreezingTemperature(iCell) = colpkg_sea_freezing_temperature(seaSurfaceSalinity(iCell))
+          ! sea freezing temperature
+          seaFreezingTemperature(iCell) = icepack_sea_freezing_temperature(seaSurfaceSalinity(iCell))
 
-    enddo ! iCell
+       enddo ! iCell
+    else if (trim(config_column_physics_type) == "column_package") then
+       do iCell = 1, nCellsSolve
+
+          ! ensure physical realism
+          seaSurfaceSalinity(iCell)   = max(seaSurfaceSalinity(iCell), 0.0_RKIND)
+          oceanMixedLayerDepth(iCell) = max(oceanMixedLayerDepth(iCell), 0.0_RKIND)
+
+          ! sea freezing temperature
+          seaFreezingTemperature(iCell) = colpkg_sea_freezing_temperature(seaSurfaceSalinity(iCell))
+
+       enddo ! iCell
+    endif ! config_column_physics_type
 
     ! only update sea surface temperature on first non-restart timestep
     if (firstTimeStep .and. .not. config_do_restart) then

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -3,9 +3,10 @@
 !  seaice_icepack
 !
 !> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 2022
+!> \author Adrian K. Turner, Elizabeth Hunke, Darin Comeau, Nicole Jeffery, Andrew Roberts, Erin Thomas, Jon Wolfe, LANL, Anthony Craig, NOAA (cntr), David Bailey, NCAR
+!> \date 2022-2023
 !> \details
+!> This module was derived from the original column physics driver by Adrian K. Turner and modified by the Icepack merge team.
 !>
 !
 !-----------------------------------------------------------------------
@@ -200,8 +201,8 @@ contains
 !  seaice_init_icepack_physics_package_parameters
 !
 !> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 18th March 2015
+!> \author Adrian K. Turner, Elizabeth Hunke, Darin Comeau, Nicole Jeffery, Andrew Roberts, Erin Thomas, Jon Wolfe, LANL, Anthony Craig, NOAA (cntr), David Bailey, NCAR
+!> \date 2022-2023
 !> \details
 !>
 !
@@ -235,8 +236,8 @@ contains
 !  seaice_init_icepack_physics_package_variables
 !
 !> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 18th March 2015
+!> \author Adrian K. Turner, Elizabeth Hunke, Darin Comeau, Nicole Jeffery, Andrew Roberts, Erin Thomas, Jon Wolfe, LANL, Anthony Craig, NOAA (cntr), David Bailey, NCAR
+!> \date 2022-2023
 !> \details
 !>
 !
@@ -301,8 +302,8 @@ contains
 !  init_column_itd
 !
 !> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 5th Feburary 2015
+!> \author Adrian K. Turner, Elizabeth Hunke, Darin Comeau, Nicole Jeffery, Andrew Roberts, Erin Thomas, Jon Wolfe, LANL, Anthony Craig, NOAA (cntr), David Bailey, NCAR
+!> \date 2022-2023
 !> \details
 !>
 !
@@ -349,11 +350,11 @@ contains
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!  init_column_thermo
+!  init_column_thermodynamic_profiles
 !
 !> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 5th Feburary 2015
+!> \author Adrian K. Turner, Elizabeth Hunke, Darin Comeau, Nicole Jeffery, Andrew Roberts, Erin Thomas, Jon Wolfe, LANL, Anthony Craig, NOAA (cntr), David Bailey, NCAR
+!> \date 2022-2023
 !> \details
 !>
 !
@@ -615,8 +616,8 @@ contains
 !  init_icepack_shortwave
 !
 !> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 5th Feburary 2015
+!> \author Adrian K. Turner, Elizabeth Hunke, Darin Comeau, Nicole Jeffery, Andrew Roberts, Erin Thomas, Jon Wolfe, LANL, Anthony Craig, NOAA (cntr), David Bailey, NCAR
+!> \date 2022-2023
 !> \details
 !>
 !
@@ -823,8 +824,8 @@ contains
 !  init_column_thermodynamic_tracers
 !
 !> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 5th Feburary 2015
+!> \author Adrian K. Turner, Elizabeth Hunke, Darin Comeau, Nicole Jeffery, Andrew Roberts, Erin Thomas, Jon Wolfe, LANL, Anthony Craig, NOAA (cntr), David Bailey, NCAR
+!> \date 2022-2023
 !> \details
 !>
 !
@@ -923,8 +924,8 @@ contains
 !  init_column_level_ice_tracers
 !
 !> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 6th Feburary 2015
+!> \author Adrian K. Turner, Elizabeth Hunke, Darin Comeau, Nicole Jeffery, Andrew Roberts, Erin Thomas, Jon Wolfe, LANL, Anthony Craig, NOAA (cntr), David Bailey, NCAR
+!> \date 2022-2023
 !> \details
 !>
 !
@@ -979,8 +980,8 @@ contains
 !  seaice_icepack_finalize
 !
 !> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 29th October 2015
+!> \author Adrian K. Turner, Elizabeth Hunke, Darin Comeau, Nicole Jeffery, Andrew Roberts, Erin Thomas, Jon Wolfe, LANL, Anthony Craig, NOAA (cntr), David Bailey, NCAR
+!> \date 2022-2023
 !> \details
 !>
 !
@@ -1002,8 +1003,8 @@ contains
 !  seaice_icepack_predynamics_time_integration
 !
 !> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 6th Feburary 2015
+!> \author Adrian K. Turner, Elizabeth Hunke, Darin Comeau, Nicole Jeffery, Andrew Roberts, Erin Thomas, Jon Wolfe, LANL, Anthony Craig, NOAA (cntr), David Bailey, NCAR
+!> \date 2022-2023
 !> \details
 !>
 !
@@ -1103,8 +1104,8 @@ contains
 !  seaice_icepack_dynamics_time_integration
 !
 !> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 6th Feburary 2015
+!> \author Adrian K. Turner, Elizabeth Hunke, Darin Comeau, Nicole Jeffery, Andrew Roberts, Erin Thomas, Jon Wolfe, LANL, Anthony Craig, NOAA (cntr), David Bailey, NCAR
+!> \date 2022-2023
 !> \details
 !>
 !
@@ -1178,8 +1179,8 @@ contains
 !  seaice_icepack_postdynamics_time_integration
 !
 !> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 6th Feburary 2015
+!> \author Adrian K. Turner, Elizabeth Hunke, Darin Comeau, Nicole Jeffery, Andrew Roberts, Erin Thomas, Jon Wolfe, LANL, Anthony Craig, NOAA (cntr), David Bailey, NCAR
+!> \date 2022-2023
 !> \details
 !>
 !
@@ -1241,8 +1242,8 @@ contains
 !  column_vertical_thermodynamics
 !
 !> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 20th January 2015
+!> \author Adrian K. Turner, Elizabeth Hunke, Darin Comeau, Nicole Jeffery, Andrew Roberts, Erin Thomas, Jon Wolfe, LANL, Anthony Craig, NOAA (cntr), David Bailey, NCAR
+!> \date 2022-2023
 !> \details
 !>
 !
@@ -1818,7 +1819,7 @@ contains
                fcondbotn=bottomConductiveFluxCategory(:,iCell), &
                fswsfcn=surfaceShortwaveFlux(:,iCell), &
                fswintn=interiorShortwaveFlux(:,iCell), &
-               fswthrun=penetratingShortwaveFlux(:,iCell), & ! Wrong dimensions?
+               fswthrun=penetratingShortwaveFlux(:,iCell), & ! Wrong dimensions? echmod check this
                fswabs=absorbedShortwaveFlux(iCell), &
                flwout=longwaveUp(iCell), &
                Sswabsn=absorbedShortwaveSnowLayer(:,:,iCell), &
@@ -2075,8 +2076,8 @@ contains
 !  column_itd_thermodynamics
 !
 !> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 21th January 2015
+!> \author Adrian K. Turner, Elizabeth Hunke, Darin Comeau, Nicole Jeffery, Andrew Roberts, Erin Thomas, Jon Wolfe, LANL, Anthony Craig, NOAA (cntr), David Bailey, NCAR
+!> \date 2022-2023
 !> \details
 !>
 !
@@ -2509,8 +2510,8 @@ contains
 !  column_prep_radiation
 !
 !> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 21th January 2015
+!> \author Adrian K. Turner, Elizabeth Hunke, Darin Comeau, Nicole Jeffery, Andrew Roberts, Erin Thomas, Jon Wolfe, LANL, Anthony Craig, NOAA (cntr), David Bailey, NCAR
+!> \date 2022-2023
 !> \details
 !>
 !
@@ -2873,8 +2874,8 @@ contains
 !  column_radiation
 !
 !> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 21th January 2015
+!> \author Adrian K. Turner, Elizabeth Hunke, Darin Comeau, Nicole Jeffery, Andrew Roberts, Erin Thomas, Jon Wolfe, LANL, Anthony Craig, NOAA (cntr), David Bailey, NCAR
+!> \date 2022-2023
 !> \details
 !>
 !
@@ -3261,8 +3262,8 @@ contains
 !  column_ridging
 !
 !> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 21th January 2015
+!> \author Adrian K. Turner, Elizabeth Hunke, Darin Comeau, Nicole Jeffery, Andrew Roberts, Erin Thomas, Jon Wolfe, LANL, Anthony Craig, NOAA (cntr), David Bailey, NCAR
+!> \date 2022-2023
 !> \details
 !>
 !
@@ -4245,8 +4246,8 @@ contains
 !  seaice_column_update_state
 !
 !> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 31st March 2015
+!> \author Adrian K. Turner, Elizabeth Hunke, Darin Comeau, Nicole Jeffery, Andrew Roberts, Erin Thomas, Jon Wolfe, LANL, Anthony Craig, NOAA (cntr), David Bailey, NCAR
+!> \date 2022-2023
 !> \details
 !>
 !
@@ -4357,8 +4358,8 @@ contains
 !  seaice_icepack_aggregate
 !
 !> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 6th March 2015
+!> \author Adrian K. Turner, Elizabeth Hunke, Darin Comeau, Nicole Jeffery, Andrew Roberts, Erin Thomas, Jon Wolfe, LANL, Anthony Craig, NOAA (cntr), David Bailey, NCAR
+!> \date 2022-2023
 !> \details
 !>
 !
@@ -4476,8 +4477,8 @@ contains
 !  seaice_icepack_aggregate_simple
 !
 !> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 29th August 2021
+!> \author Adrian K. Turner, Elizabeth Hunke, Darin Comeau, Nicole Jeffery, Andrew Roberts, Erin Thomas, Jon Wolfe, LANL, Anthony Craig, NOAA (cntr), David Bailey, NCAR
+!> \date 2022-2023
 !> \details
 !>
 !
@@ -4561,8 +4562,8 @@ contains
 !  seaice_icepack_coupling_prep
 !
 !> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 6th April
+!> \author Adrian K. Turner, Elizabeth Hunke, Darin Comeau, Nicole Jeffery, Andrew Roberts, Erin Thomas, Jon Wolfe, LANL, Anthony Craig, NOAA (cntr), David Bailey, NCAR
+!> \date 2022-2023
 !> \details
 !>
 !
@@ -5017,8 +5018,8 @@ contains
 !  seaice_column_scale_fluxes
 !
 !> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 6th April
+!> \author Adrian K. Turner, Elizabeth Hunke, Darin Comeau, Nicole Jeffery, Andrew Roberts, Erin Thomas, Jon Wolfe, LANL, Anthony Craig, NOAA (cntr), David Bailey, NCAR
+!> \date 2022-2023
 !> \details
 !>
 !
@@ -5282,8 +5283,8 @@ contains
 !  seaice_icepack_ocean_mixed_layer
 !
 !> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 6th April
+!> \author Adrian K. Turner, Elizabeth Hunke, Darin Comeau, Nicole Jeffery, Andrew Roberts, Erin Thomas, Jon Wolfe, LANL, Anthony Craig, NOAA (cntr), David Bailey, NCAR
+!> \date 2022-2023
 !> \details
 !>
 !
@@ -9150,8 +9151,8 @@ contains
 !  init_icepack_package_parameters
 !
 !> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 2nd Feburary 2015
+!> \author Adrian K. Turner, Elizabeth Hunke, Darin Comeau, Nicole Jeffery, Andrew Roberts, Erin Thomas, Jon Wolfe, LANL, Anthony Craig, NOAA (cntr), David Bailey, NCAR
+!> \date 2022-2023
 !> \details
 !>
 !
@@ -9187,8 +9188,8 @@ contains
 !  check_column_package_configs
 !
 !> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 5th Feburary 2015
+!> \author Adrian K. Turner, Elizabeth Hunke, Darin Comeau, Nicole Jeffery, Andrew Roberts, Erin Thomas, Jon Wolfe, LANL, Anthony Craig, NOAA (cntr), David Bailey, NCAR
+!> \date 2022-2023
 !> \details
 !>
 !
@@ -9621,8 +9622,8 @@ contains
 !  init_icepack_package_tracer_flags
 !
 !> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 2nd Feburary 2015
+!> \author Adrian K. Turner, Elizabeth Hunke, Darin Comeau, Nicole Jeffery, Andrew Roberts, Erin Thomas, Jon Wolfe, LANL, Anthony Craig, NOAA (cntr), David Bailey, NCAR
+!> \date 2022-2023
 !> \details
 !>
 !
@@ -9727,8 +9728,8 @@ contains
 !  init_icepack_package_tracer_sizes
 !
 !> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 9th Feburary 2015
+!> \author Adrian K. Turner, Elizabeth Hunke, Darin Comeau, Nicole Jeffery, Andrew Roberts, Erin Thomas, Jon Wolfe, LANL, Anthony Craig, NOAA (cntr), David Bailey, NCAR
+!> \date 2022-2023
 !> \details
 !>
 !
@@ -9787,8 +9788,8 @@ contains
 !  init_icepack_package_tracer_indices
 !
 !> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 5th Feburary 2015
+!> \author Adrian K. Turner, Elizabeth Hunke, Darin Comeau, Nicole Jeffery, Andrew Roberts, Erin Thomas, Jon Wolfe, LANL, Anthony Craig, NOAA (cntr), David Bailey, NCAR
+!> \date 2022-2023
 !> \details
 !>
 !
@@ -11463,8 +11464,8 @@ contains
 !  init_icepack_package_configs
 !
 !> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 2nd Feburary 2015
+!> \author Adrian K. Turner, Elizabeth Hunke, Darin Comeau, Nicole Jeffery, Andrew Roberts, Erin Thomas, Jon Wolfe, LANL, Anthony Craig, NOAA (cntr), David Bailey, NCAR
+!> \date 2022-2023
 !> \details
 !>
 !
@@ -13326,8 +13327,8 @@ contains
 !  config_cice_int
 !
 !> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 20th January 2015
+!> \author Adrian K. Turner, Elizabeth Hunke, Darin Comeau, Nicole Jeffery, Andrew Roberts, Erin Thomas, Jon Wolfe, LANL, Anthony Craig, NOAA (cntr), David Bailey, NCAR
+!> \date 2022-2023
 !> \details
 !>
 !
@@ -13418,8 +13419,8 @@ contains
 !  init_icepack_non_activated_pointers
 !
 !> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 5th March 2015
+!> \author Adrian K. Turner, Elizabeth Hunke, Darin Comeau, Nicole Jeffery, Andrew Roberts, Erin Thomas, Jon Wolfe, LANL, Anthony Craig, NOAA (cntr), David Bailey, NCAR
+!> \date 2022-2023
 !> \details
 !>
 !
@@ -13758,8 +13759,8 @@ contains
 !  finalize_icepack_non_activated_pointers
 !
 !> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 29th October 2015
+!> \author Adrian K. Turner, Elizabeth Hunke, Darin Comeau, Nicole Jeffery, Andrew Roberts, Erin Thomas, Jon Wolfe, LANL, Anthony Craig, NOAA (cntr), David Bailey, NCAR
+!> \date 2022-2023
 !> \details
 !>
 !
@@ -14156,8 +14157,8 @@ contains
 !  init_column_history_variables
 !
 !> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 3rd April 2015
+!> \author Adrian K. Turner, Elizabeth Hunke, Darin Comeau, Nicole Jeffery, Andrew Roberts, Erin Thomas, Jon Wolfe, LANL, Anthony Craig, NOAA (cntr), David Bailey, NCAR
+!> \date 2022-2023
 !> \details
 !>
 !
@@ -14193,8 +14194,8 @@ contains
 !  seaice_icepack_initial_air_drag_coefficient
 !
 !> \brief
-!> \author Adrian K. Turner, LANL
-!> \date
+!> \author Adrian K. Turner, Elizabeth Hunke, Darin Comeau, Nicole Jeffery, Andrew Roberts, Erin Thomas, Jon Wolfe, LANL, Anthony Craig, NOAA (cntr), David Bailey, NCAR
+!> \date 2022-2023
 !> \details
 !>
 !
@@ -14220,8 +14221,8 @@ contains
 !  seaice_icepack_reinitialize_fluxes
 !
 !> \brief
-!> \author Adrian K. Turner, LANL
-!> \date 31st August 2015
+!> \author Adrian K. Turner, Elizabeth Hunke, Darin Comeau, Nicole Jeffery, Andrew Roberts, Erin Thomas, Jon Wolfe, LANL, Anthony Craig, NOAA (cntr), David Bailey, NCAR
+!> \date 2022-2023
 !> \details
 !>
 !
@@ -14400,7 +14401,7 @@ contains
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !
-!  init_column_tracer_object_bio_tracer_number
+!  init_column_tracer_object_for_biogeochemistry
 !
 !> \brief
 !> \author Nicole Jeffery, LANL
@@ -15236,8 +15237,8 @@ contains
 !  seaice_icepack_reinitialize_diagnostics_thermodynamics
 !
 !> \brief Reinitialize thermodynamics diagnostics
-!> \author Adrian K. Turner, LANL
-!> \date 27th September 2015
+!> \author Adrian K. Turner, Elizabeth Hunke, Darin Comeau, Nicole Jeffery, Andrew Roberts, Erin Thomas, Jon Wolfe, LANL, Anthony Craig, NOAA (cntr), David Bailey, NCAR
+!> \date 2022-2023
 !> \details
 !>  Reinitialize thermodynamics diagnostics
 !
@@ -15612,7 +15613,7 @@ contains
           surfaceTiltForceU   = 0.0_RKIND
           surfaceTiltForceV   = 0.0_RKIND
 
-          if (config_use_velocity_solver .and. trim(config_stress_divergence_scheme) == "weak") then
+          if (config_use_velocity_solver .and. trim(config_stress_divergence_scheme) == "weak") then !echmod BUG? - why is this here and wrapped in a config_use_column_package conditional?
 
              call MPAS_pool_get_subpool(block % structs, "velocity_weak", velocityWeakPool)
 
@@ -15685,8 +15686,8 @@ contains
 !  seaice_icepack_reinitialize_diagnostics_bgc
 !
 !> \brief Reinitialize BGC diagnostics
-!> \author Adrian K. Turner, LANL
-!> \date 27th September 2015
+!> \author Adrian K. Turner, Nicole Jeffery, LANL
+!> \date 2022-2023
 !> \details
 !>  Reinitialize BGC diagnostics
 !

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -2151,7 +2151,6 @@ contains
          biologyGrid, &
          verticalGrid, &
          interfaceBiologyGrid, &
-         zSalinityFlux, &
          frazilGrowthDiagnostic
 !         frazilGrowthDiagnostic, &
 !         WaveFrequency,      &
@@ -2316,7 +2315,6 @@ contains
        call MPAS_pool_get_array(biogeochemistry, "biologyGrid", biologyGrid)
        call MPAS_pool_get_array(biogeochemistry, "verticalGrid", verticalGrid)
        call MPAS_pool_get_array(biogeochemistry, "interfaceBiologyGrid", interfaceBiologyGrid)
-       call MPAS_pool_get_array(biogeochemistry, "zSalinityFlux", zSalinityFlux)
 
        call MPAS_pool_get_array(initial, "initialSalinityProfile", initialSalinityProfile)
        call MPAS_pool_get_array(initial, "categoryThicknessLimits", categoryThicknessLimits)
@@ -2418,7 +2416,6 @@ contains
                igrid=interfaceBiologyGrid(:),  &
                faero_ocn=oceanAerosolFlux(:,iCell), &
                first_ice=newlyFormedIceLogical(:), & 
-               fzsal=zSalinityFlux(iCell), &
                flux_bio=oceanBioFluxesTemp(:), &
                ocean_bio=oceanBioConcentrationsUsed(:), &
                frazil_diag=frazilGrowthDiagnostic(iCell), &
@@ -3328,8 +3325,7 @@ contains
          areaGainRidge, &
          iceVolumeRidged, &
          openingRateRidge, &
-         categoryThicknessLimits, &
-         zSalinityFlux
+         categoryThicknessLimits
 
     real(kind=RKIND), dimension(:,:), pointer :: &
          oceanAerosolFlux, &
@@ -3436,7 +3432,6 @@ contains
 
        call MPAS_pool_get_array(biogeochemistry, "newlyFormedIce", newlyFormedIce)
        call MPAS_pool_get_array(biogeochemistry, "oceanBioFluxes", oceanBioFluxes)
-       call MPAS_pool_get_array(biogeochemistry, "zSalinityFlux", zSalinityFlux)
 
        call MPAS_pool_get_array(initial, "categoryThicknessLimits", categoryThicknessLimits)
 
@@ -3497,7 +3492,6 @@ contains
                aice=iceAreaCell(iCell), &
                fsalt=oceanSaltFlux(iCell), &
                first_ice=newlyFormedIceLogical(:), &
-               fzsal=zSalinityFlux(iCell), &
                flux_bio=oceanBioFluxes(:,iCell), & ! DC no closing argument
                Tf=seaFreezingTemperature(iCell))
 
@@ -3615,8 +3609,8 @@ contains
          seaSurfaceSalinity, &
          seaFreezingTemperature, &
          snowfallRate, &
-         zSalinityFlux, &
-         zSalinityGDFlux, &
+         zSalinityFlux, &      !echmod deprecate
+         zSalinityGDFlux, &    !echmod deprecate
          oceanMixedLayerDepth, &
          totalSkeletalAlgae, &
          oceanNitrateConc, &
@@ -3642,7 +3636,7 @@ contains
          totalVerticalBiologyIce, &
          totalVerticalBiologySnow, &
          penetratingShortwaveFlux, &
-         zSalinityIceDensity, &
+         zSalinityIceDensity, &    !echmod deprecate
          basalIceMeltCategory, &
          surfaceIceMeltCategory, &
          congelationCategory, &
@@ -3814,9 +3808,9 @@ contains
        call MPAS_pool_get_array(biogeochemistry, "oceanBioConcentrations", oceanBioConcentrations)
        call MPAS_pool_get_array(biogeochemistry, "totalVerticalBiologyIce", totalVerticalBiologyIce)
        call MPAS_pool_get_array(biogeochemistry, "totalVerticalBiologySnow", totalVerticalBiologySnow)
-       call MPAS_pool_get_array(biogeochemistry, "zSalinityIceDensity", zSalinityIceDensity)
-       call MPAS_pool_get_array(biogeochemistry, "zSalinityFlux", zSalinityFlux)
-       call MPAS_pool_get_array(biogeochemistry, "zSalinityGDFlux", zSalinityGDFlux)
+       call MPAS_pool_get_array(biogeochemistry, "zSalinityIceDensity", zSalinityIceDensity)  !echmod deprecate
+       call MPAS_pool_get_array(biogeochemistry, "zSalinityFlux", zSalinityFlux)              !echmod deprecate
+       call MPAS_pool_get_array(biogeochemistry, "zSalinityGDFlux", zSalinityGDFlux)          !echmod deprecate
        call MPAS_pool_get_array(biogeochemistry, "atmosBioFluxes", atmosBioFluxes)
        call MPAS_pool_get_array(biogeochemistry, "atmosBlackCarbonFlux", atmosBlackCarbonFlux)
        call MPAS_pool_get_array(biogeochemistry, "atmosDustFlux", atmosDustFlux)
@@ -3987,9 +3981,9 @@ contains
                totalChlorophyll(iCell), &
                penetratingShortwaveFlux(:,iCell), &
                rayleighCriteria, &
-               zSalinityIceDensity(:,iCell), &
-               zSalinityFlux(iCell), &
-               zSalinityGDFlux(iCell), &
+               zSalinityIceDensity(:,iCell), &      !echmod deprecate
+               zSalinityFlux(iCell), &              !echmod deprecate
+               zSalinityGDFlux(iCell), &            !echmod deprecate
                biologyGrid, &
                interfaceBiologyGrid, &
                interfaceGrid, &
@@ -5843,7 +5837,7 @@ contains
          config_use_aerosols, &
          config_use_brine, &
          config_use_column_biogeochemistry, &
-         config_use_vertical_zsalinity, &
+!         config_use_vertical_zsalinity, &
          config_use_vertical_biochemistry, &
          config_use_vertical_tracers, &
          config_use_skeletal_biochemistry, &
@@ -5891,7 +5885,7 @@ contains
 
     call MPAS_pool_get_config(domain % configs, "config_use_column_biogeochemistry", config_use_column_biogeochemistry)
     call MPAS_pool_get_config(domain % configs, "config_use_brine", config_use_brine)
-    call MPAS_pool_get_config(domain % configs, "config_use_vertical_zsalinity", config_use_vertical_zsalinity)
+!    call MPAS_pool_get_config(domain % configs, "config_use_vertical_zsalinity", config_use_vertical_zsalinity)
     call MPAS_pool_get_config(domain % configs, "config_use_vertical_tracers", config_use_vertical_tracers)
     call MPAS_pool_get_config(domain % configs, "config_use_skeletal_biochemistry", config_use_skeletal_biochemistry)
     call MPAS_pool_get_config(domain % configs, "config_use_vertical_biochemistry", config_use_vertical_biochemistry)
@@ -5989,10 +5983,10 @@ contains
             tracerObject % nTracers = tracerObject % nTracers + 1
 
        ! vertical zSalinity
-       if (config_use_vertical_zsalinity) then
-          tracerObject % nTracers = tracerObject % nTracers + nBioLayers
-          tracerObject % nBioTracersLayer = tracerObject % nBioTracersLayer + 1
-       endif
+!       if (config_use_vertical_zsalinity) then
+!          tracerObject % nTracers = tracerObject % nTracers + nBioLayers
+!          tracerObject % nBioTracersLayer = tracerObject % nBioTracersLayer + 1
+!       endif
        nMobileTracers = 0
 
        ! Skeletal Biogeochemistry
@@ -7436,7 +7430,7 @@ contains
     logical, pointer :: &
          config_use_skeletal_biochemistry, &
          config_use_vertical_biochemistry, &
-         config_use_vertical_zsalinity, &
+!         config_use_vertical_zsalinity, &
          config_use_vertical_tracers, &
          config_use_brine, &
          config_use_nitrate, &
@@ -7504,7 +7498,7 @@ contains
          iLayers
 
     call MPAS_pool_get_config(block % configs, "config_use_skeletal_biochemistry", config_use_skeletal_biochemistry)
-    call MPAS_pool_get_config(block % configs, "config_use_vertical_zsalinity", config_use_vertical_zsalinity)
+!    call MPAS_pool_get_config(block % configs, "config_use_vertical_zsalinity", config_use_vertical_zsalinity)
     call MPAS_pool_get_config(block % configs, "config_use_vertical_biochemistry", config_use_vertical_biochemistry)
     call MPAS_pool_get_config(block % configs, "config_use_vertical_tracers", config_use_vertical_tracers)
     call MPAS_pool_get_config(block % configs, "config_use_brine", config_use_brine)
@@ -7769,12 +7763,12 @@ contains
        endif
 
        ! salinity used with BL99 thermodynamics
-       if (config_use_vertical_zsalinity) then
-          do iLayers = 1, nBioLayers
-             tracerArrayCategory(tracerObject % index_verticalSalinity+iLayers-1,:) = &
-                  verticalSalinity(iLayers,:,iCell)
-          enddo
-       endif
+!       if (config_use_vertical_zsalinity) then
+!          do iLayers = 1, nBioLayers
+!             tracerArrayCategory(tracerObject % index_verticalSalinity+iLayers-1,:) = &
+!                  verticalSalinity(iLayers,:,iCell)
+!          enddo
+!       endif
     endif
 
   end subroutine set_cice_biogeochemistry_tracer_array_category
@@ -7808,7 +7802,7 @@ contains
     logical, pointer :: &
          config_use_skeletal_biochemistry, &
          config_use_vertical_biochemistry, &
-         config_use_vertical_zsalinity, &
+!         config_use_vertical_zsalinity, &
          config_use_vertical_tracers, &
          config_use_brine, &
          config_use_nitrate, &
@@ -7877,7 +7871,7 @@ contains
 
     call MPAS_pool_get_config(block % configs, "config_use_skeletal_biochemistry", config_use_skeletal_biochemistry)
     call MPAS_pool_get_config(block % configs, "config_use_vertical_biochemistry", config_use_vertical_biochemistry)
-    call MPAS_pool_get_config(block % configs, "config_use_vertical_zsalinity", config_use_vertical_zsalinity)
+!    call MPAS_pool_get_config(block % configs, "config_use_vertical_zsalinity", config_use_vertical_zsalinity)
     call MPAS_pool_get_config(block % configs, "config_use_vertical_tracers", config_use_vertical_tracers)
     call MPAS_pool_get_config(block % configs, "config_use_brine", config_use_brine)
     call MPAS_pool_get_config(block % configs, "config_use_nitrate", config_use_nitrate)
@@ -8149,12 +8143,12 @@ contains
        endif
 
        ! salinity used with BL99 thermodynamics
-       if (config_use_vertical_zsalinity) then
-          do iLayers = 1, nBioLayers
-             verticalSalinity(iLayers,:,iCell) = &
-                  tracerArrayCategory(tracerObject % index_verticalSalinity+iLayers-1,:)
-          enddo
-       endif
+!       if (config_use_vertical_zsalinity) then
+!          do iLayers = 1, nBioLayers
+!             verticalSalinity(iLayers,:,iCell) = &
+!                  tracerArrayCategory(tracerObject % index_verticalSalinity+iLayers-1,:)
+!          enddo
+!       endif
     endif
 
   end subroutine get_cice_biogeochemistry_tracer_array_category
@@ -8188,7 +8182,7 @@ contains
     logical, pointer :: &
          config_use_skeletal_biochemistry, &
          config_use_vertical_biochemistry, &
-         config_use_vertical_zsalinity, &
+!         config_use_vertical_zsalinity, &
          config_use_vertical_tracers, &
          config_use_brine, &
          config_use_nitrate, &
@@ -8277,7 +8271,7 @@ contains
 
     call MPAS_pool_get_config(block % configs, "config_use_skeletal_biochemistry", config_use_skeletal_biochemistry)
     call MPAS_pool_get_config(block % configs, "config_use_vertical_biochemistry", config_use_vertical_biochemistry)
-    call MPAS_pool_get_config(block % configs, "config_use_vertical_zsalinity", config_use_vertical_zsalinity)
+!    call MPAS_pool_get_config(block % configs, "config_use_vertical_zsalinity", config_use_vertical_zsalinity)
     call MPAS_pool_get_config(block % configs, "config_use_vertical_tracers", config_use_vertical_tracers)
     call MPAS_pool_get_config(block % configs, "config_use_brine", config_use_brine)
     call MPAS_pool_get_config(block % configs, "config_use_nitrate", config_use_nitrate)
@@ -8642,11 +8636,11 @@ contains
        endif
 
        ! salinity for use with BL99 thermodynamics
-       if (config_use_vertical_zsalinity) then
-          do iLayers = 1, nBioLayers
-             tracerArrayCell(tracerObject % index_verticalSalinity+iLayers-1)  = verticalSalinityCell(iLayers,iCell)
-          enddo
-       endif
+!       if (config_use_vertical_zsalinity) then
+!          do iLayers = 1, nBioLayers
+!             tracerArrayCell(tracerObject % index_verticalSalinity+iLayers-1)  = verticalSalinityCell(iLayers,iCell)
+!          enddo
+!       endif
     endif
 
   end subroutine set_cice_biogeochemistry_tracer_array_cell
@@ -8680,7 +8674,7 @@ contains
     logical, pointer :: &
          config_use_skeletal_biochemistry, &
          config_use_vertical_biochemistry, &
-         config_use_vertical_zsalinity, &
+!         config_use_vertical_zsalinity, &
          config_use_vertical_tracers, &
          config_use_brine, &
          config_use_nitrate, &
@@ -8769,7 +8763,7 @@ contains
 
     call MPAS_pool_get_config(block % configs, "config_use_skeletal_biochemistry", config_use_skeletal_biochemistry)
     call MPAS_pool_get_config(block % configs, "config_use_vertical_biochemistry", config_use_vertical_biochemistry)
-    call MPAS_pool_get_config(block % configs, "config_use_vertical_zsalinity", config_use_vertical_zsalinity)
+!    call MPAS_pool_get_config(block % configs, "config_use_vertical_zsalinity", config_use_vertical_zsalinity)
     call MPAS_pool_get_config(block % configs, "config_use_vertical_tracers", config_use_vertical_tracers)
     call MPAS_pool_get_config(block % configs, "config_use_brine", config_use_brine)
     call MPAS_pool_get_config(block % configs, "config_use_nitrate", config_use_nitrate)
@@ -9138,11 +9132,11 @@ contains
        endif
 
        ! salinity for use with BL99 thermodynamics
-       if (config_use_vertical_zsalinity) then
-          do iLayers = 1, nBioLayers
-             verticalSalinityCell(iLayers,iCell) = tracerArrayCell(tracerObject % index_verticalSalinity+iLayers-1)
-          enddo
-       endif
+!       if (config_use_vertical_zsalinity) then
+!          do iLayers = 1, nBioLayers
+!             verticalSalinityCell(iLayers,iCell) = tracerArrayCell(tracerObject % index_verticalSalinity+iLayers-1)
+!          enddo
+!       endif
     endif
 
   end subroutine get_cice_biogeochemistry_tracer_array_cell
@@ -9335,10 +9329,13 @@ contains
     !-----------------------------------------------------------------------
 
     ! check config_thermodynamics_type value
-    if (.not. (trim(config_thermodynamics_type) == "zero layer" .or. &
-               trim(config_thermodynamics_type) == "BL99" .or. &
+    if (trim(config_thermodynamics_type) == "zero layer") then
+       call config_error("config_thermodynamics_type", config_thermodynamics_type, "'zero-layer' has been deprecated")
+    endif
+
+    if (.not. (trim(config_thermodynamics_type) == "BL99" .or. &
                trim(config_thermodynamics_type) == "mushy")) then
-       call config_error("config_thermodynamics_type", config_thermodynamics_type, "'zero layer', 'BL99' or 'mushy'")
+       call config_error("config_thermodynamics_type", config_thermodynamics_type, "'BL99' or 'mushy'")
     endif
 
     ! check config_heat_conductivity_type value
@@ -9562,7 +9559,8 @@ contains
     endif
 
     ! check biogeochemistry flags:
-    if (.not. config_use_column_biogeochemistry .and. (config_use_brine .or. config_use_vertical_zsalinity .or. &
+!    if (.not. config_use_column_biogeochemistry .and. (config_use_brine .or. config_use_vertical_zsalinity .or. &
+    if (.not. config_use_column_biogeochemistry .and. (config_use_brine .or. &
         config_use_vertical_biochemistry .or. config_use_shortwave_bioabsorption .or. config_use_vertical_tracers .or. &
         config_use_skeletal_biochemistry .or. config_use_nitrate .or. config_use_carbon .or. config_use_chlorophyll .or. &
         config_use_ammonium .or. config_use_silicate .or. config_use_DMS .or. config_use_nonreactive .or. config_use_humics .or. &
@@ -9573,11 +9571,16 @@ contains
             messageType=MPAS_LOG_CRIT)
     endif
 
-    ! check vertical zSalinity requirements
-    if (config_use_vertical_zsalinity .and. ((.not. config_use_brine) .or. &
-         (.not. (trim(config_thermodynamics_type) == "BL99")))) then
+    ! deprecate vertical zSalinity
+!    if (config_use_vertical_zsalinity .and. ((.not. config_use_brine) .or. &
+!         (.not. (trim(config_thermodynamics_type) == "BL99")))) then
+!       call mpas_log_write(&
+!            "check_column_package_configs: vertical zSalinity requires config_use_brine = true and 'BL99' ", &
+!            messageType=MPAS_LOG_CRIT)
+!    endif
+    if (config_use_vertical_zsalinity) then
        call mpas_log_write(&
-            "check_column_package_configs: vertical zSalinity requires config_use_brine = true and 'BL99' ", &
+            "check_column_package_configs: vertical zSalinity has been deprecated", &
             messageType=MPAS_LOG_CRIT)
     endif
 
@@ -9640,7 +9643,7 @@ contains
          config_use_topo_meltponds, &
          config_use_aerosols, &
          config_use_brine, &
-         config_use_vertical_zsalinity, &
+!         config_use_vertical_zsalinity, &
          config_use_zaerosols, &
          config_use_nitrate, &
          config_use_DON, &
@@ -9668,7 +9671,7 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_use_topo_meltponds", config_use_topo_meltponds)
     call MPAS_pool_get_config(domain % configs, "config_use_aerosols", config_use_aerosols)
     call MPAS_pool_get_config(domain % configs, "config_use_brine", config_use_brine)
-    call MPAS_pool_get_config(domain % configs, "config_use_vertical_zsalinity", config_use_vertical_zsalinity)
+!    call MPAS_pool_get_config(domain % configs, "config_use_vertical_zsalinity", config_use_vertical_zsalinity)
     call MPAS_pool_get_config(domain % configs, "config_use_zaerosols", config_use_zaerosols)
     call MPAS_pool_get_config(domain % configs, "config_use_nitrate", config_use_nitrate)
     call MPAS_pool_get_config(domain % configs, "config_use_DON", config_use_DON)
@@ -10655,7 +10658,6 @@ contains
 
     ! ktherm:
     ! type of thermodynamics
-    ! 0 = 0-layer approximation
     ! 1 = Bitz and Lipscomb 1999
     ! 2 = mushy layer theory
     !ktherm = config_cice_int("config_thermodynamics_type", config_thermodynamics_type)
@@ -10916,9 +10918,10 @@ contains
     ! if true, solve skeletal biochemistry
     !skl_bgc = config_use_skeletal_biochemistry
 
-    ! solve_zsal:
-    ! if true, update salinity profile from solve_S_dt
-    !solve_zsal = config_use_vertical_zsalinity
+! zsalinity has been deprecated
+!    ! solve_zsal:
+!    ! if true, update salinity profile from solve_S_dt
+!    !solve_zsal = config_use_vertical_zsalinity
 
     ! modal_aero:
     ! if true, use modal aerosal optical properties
@@ -11405,13 +11408,13 @@ contains
     ! ratio of C to N in proteins (mol/mol)
     ! ratio_C2N_proteins = config_ratio_C_to_N_proteins
 
-    ! grid_oS:
-    ! for bottom flux (zsalinity)
-    !grid_oS = config_zsalinity_molecular_sublayer
+!    ! grid_oS:
+!    ! for bottom flux (zsalinity)
+!    !grid_oS = config_zsalinity_molecular_sublayer
 
     ! l_skS:
-    ! 0.02 characteristic skeletal layer thickness (m) (zsalinity)
-    !l_skS = config_zsalinity_gravity_drainage_scale
+!    ! 0.02 characteristic skeletal layer thickness (m) (zsalinity)
+!    !l_skS = config_zsalinity_gravity_drainage_scale
 
     !-----------------------------------------------------------------------
     ! Parameters for snow
@@ -11568,7 +11571,6 @@ contains
          config_use_vertical_biochemistry, &
          config_use_shortwave_bioabsorption, &
          config_use_skeletal_biochemistry, &
-         config_use_vertical_zsalinity, &
          config_use_modal_aerosols, &
          config_use_snow_liquid_ponds, &
          config_use_snow_grain_radius
@@ -11609,8 +11611,6 @@ contains
          config_biogrid_top_molecular_sublayer, &
          config_new_ice_fraction_biotracer, &
          config_fraction_biotracer_in_frazil, &
-         config_zsalinity_molecular_sublayer, &
-         config_zsalinity_gravity_drainage_scale, &
          config_snow_porosity_at_ice_surface, &
          config_ratio_Si_to_N_diatoms, &
          config_ratio_Si_to_N_small_plankton, &
@@ -11825,16 +11825,13 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_use_shortwave_bioabsorption", config_use_shortwave_bioabsorption)
     call MPAS_pool_get_config(domain % configs, "config_use_modal_aerosols", config_use_modal_aerosols)
     call MPAS_pool_get_config(domain % configs, "config_use_skeletal_biochemistry", config_use_skeletal_biochemistry)
-    call MPAS_pool_get_config(domain % configs, "config_use_vertical_zsalinity", config_use_vertical_zsalinity)
     call MPAS_pool_get_config(domain % configs, "config_biogrid_bottom_molecular_sublayer", &
                                                  config_biogrid_bottom_molecular_sublayer)
     call MPAS_pool_get_config(domain % configs, "config_bio_gravity_drainage_length_scale", &
                                                  config_bio_gravity_drainage_length_scale)
     call MPAS_pool_get_config(domain % configs, "config_biogrid_top_molecular_sublayer", config_biogrid_top_molecular_sublayer)
-    call MPAS_pool_get_config(domain % configs, "config_zsalinity_gravity_drainage_scale", config_zsalinity_gravity_drainage_scale)
     call MPAS_pool_get_config(domain % configs, "config_new_ice_fraction_biotracer", config_new_ice_fraction_biotracer)
     call MPAS_pool_get_config(domain % configs, "config_fraction_biotracer_in_frazil", config_fraction_biotracer_in_frazil)
-    call MPAS_pool_get_config(domain % configs, "config_zsalinity_molecular_sublayer", config_zsalinity_molecular_sublayer)
     call MPAS_pool_get_config(domain % configs, "config_snow_porosity_at_ice_surface", config_snow_porosity_at_ice_surface)
     call MPAS_pool_get_config(domain % configs, "config_ratio_Si_to_N_diatoms", config_ratio_Si_to_N_diatoms)
     call MPAS_pool_get_config(domain % configs, "config_ratio_Si_to_N_small_plankton", config_ratio_Si_to_N_small_plankton)
@@ -12253,12 +12250,11 @@ contains
          solve_zbgc_in           = config_use_vertical_biochemistry, &
          modal_aero_in           = config_use_modal_aerosols, &
          skl_bgc_in              = config_use_skeletal_biochemistry, &
-         solve_zsal_in           = config_use_vertical_zsalinity, &
          grid_o_in               = config_biogrid_bottom_molecular_sublayer, &
          l_sk_in                 = config_bio_gravity_drainage_length_scale, &
          initbio_frac_in         = config_new_ice_fraction_biotracer, &
-         grid_oS_in              = config_zsalinity_molecular_sublayer, &
-         l_skS_in                = config_zsalinity_gravity_drainage_scale, &
+!         grid_oS_in              = config_zsalinity_molecular_sublayer, &
+!         l_skS_in                = config_zsalinity_gravity_drainage_scale, &
          dEdd_algae_in           = config_use_shortwave_bioabsorption, &
          phi_snow_in             = config_snow_porosity_at_ice_surface, &
          !T_max_in                = , &         ! BGC
@@ -12488,7 +12484,6 @@ contains
 
     ! ktherm:
     ! type of thermodynamics
-    ! 0 = 0-layer approximation
     ! 1 = Bitz and Lipscomb 1999
     ! 2 = mushy layer theory
     !ktherm = config_cice_int("config_thermodynamics_type", config_thermodynamics_type)
@@ -12765,9 +12760,10 @@ contains
     ! if true, solve skeletal biochemistry
     !skl_bgc = config_use_skeletal_biochemistry
 
-    ! solve_zsal:
-    ! if true, update salinity profile from solve_S_dt
-    !solve_zsal = config_use_vertical_zsalinity
+! zsalinity has been deprecated
+!    ! solve_zsal:
+!    ! if true, update salinity profile from solve_S_dt
+!    !solve_zsal = config_use_vertical_zsalinity
 
     ! modal_aero:
     ! if true, use modal aerosal optical properties
@@ -12779,7 +12775,7 @@ contains
     !grid_o = config_biogrid_bottom_molecular_sublayer
 
     ! l_sk:
-    ! characteristic diffusive scale (zsalinity) (m)
+    ! characteristic diffusive scale (brine) (m)
     !l_sk =config_bio_gravity_drainage_length_scale
 
     ! grid_o_t:
@@ -13254,13 +13250,13 @@ contains
     ! ratio of C to N in proteins (mol/mol)
     ! ratio_C2N_proteins = config_ratio_C_to_N_proteins
 
-    ! grid_oS:
-    ! for bottom flux (zsalinity)
-    !grid_oS = config_zsalinity_molecular_sublayer
+!    ! grid_oS:
+!    ! for bottom flux (zsalinity)
+!    !grid_oS = config_zsalinity_molecular_sublayer
 
-    ! l_skS:
-    ! 0.02 characteristic skeletal layer thickness (m) (zsalinity)
-    !l_skS = config_zsalinity_gravity_drainage_scale
+!    ! l_skS:
+!    ! 0.02 characteristic skeletal layer thickness (m) (zsalinity)
+!    !l_skS = config_zsalinity_gravity_drainage_scale
 
     !-----------------------------------------------------------------------
     ! Parameters for snow
@@ -13351,8 +13347,6 @@ contains
     case ("config_thermodynamics_type")
 
        select case (trim(configValue))
-       case ("zero layer")
-          configValueCice = 0
        case ("BL99")
           configValueCice = 1
        case ("mushy")
@@ -13475,7 +13469,7 @@ contains
          pkgTracerVerticalDONActive, &
          pkgTracerVerticalIronActive, &
          pkgTracerZAerosolsActive, &
-         pkgTracerZSalinityActive, &
+!         pkgTracerZSalinityActive, &
          pkgColumnTracerEffectiveSnowDensityActive, &
          pkgColumnTracerSnowGrainRadiusActive
 
@@ -13542,7 +13536,7 @@ contains
        call MPAS_pool_get_package(block % packages, "pkgTracerVerticalDONActive", pkgTracerVerticalDONActive)
        call MPAS_pool_get_package(block % packages, "pkgTracerVerticalIronActive", pkgTracerVerticalIronActive)
        call MPAS_pool_get_package(block % packages, "pkgTracerZAerosolsActive", pkgTracerZAerosolsActive)
-       call MPAS_pool_get_package(block % packages, "pkgTracerZSalinityActive", pkgTracerZSalinityActive)
+!       call MPAS_pool_get_package(block % packages, "pkgTracerZSalinityActive", pkgTracerZSalinityActive) !echmod - deprecate
        call MPAS_pool_get_package(block % packages, "pkgColumnTracerEffectiveSnowDensityActive", pkgColumnTracerEffectiveSnowDensityActive)
        call MPAS_pool_get_package(block % packages, "pkgColumnTracerSnowGrainRadiusActive", pkgColumnTracerSnowGrainRadiusActive)
 
@@ -13690,9 +13684,9 @@ contains
           call set_stand_in_tracer_array(block, "verticalAerosolsSnow")
           call set_stand_in_tracer_array(block, "verticalAerosolsIce")
        endif
-       if (.not. pkgTracerZSalinityActive) then
-          call set_stand_in_tracer_array(block, "verticalSalinity")
-       endif
+!       if (.not. pkgTracerZSalinityActive) then                          !echmod - deprecate
+!          call set_stand_in_tracer_array(block, "verticalSalinity")
+!       endif
 
        ! snow density tracer
        if (.not. pkgColumnTracerEffectiveSnowDensityActive) then
@@ -13814,7 +13808,7 @@ contains
          pkgTracerVerticalDONActive, &
          pkgTracerVerticalIronActive, &
          pkgTracerZAerosolsActive, &
-         pkgTracerZSalinityActive, &
+!         pkgTracerZSalinityActive, &
          pkgColumnTracerEffectiveSnowDensityActive, &
          pkgColumnTracerSnowGrainRadiusActive
 
@@ -13873,7 +13867,7 @@ contains
        call MPAS_pool_get_package(block % packages, "pkgTracerVerticalDONActive", pkgTracerVerticalDONActive)
        call MPAS_pool_get_package(block % packages, "pkgTracerVerticalIronActive", pkgTracerVerticalIronActive)
        call MPAS_pool_get_package(block % packages, "pkgTracerZAerosolsActive", pkgTracerZAerosolsActive)
-       call MPAS_pool_get_package(block % packages, "pkgTracerZSalinityActive", pkgTracerZSalinityActive)
+!       call MPAS_pool_get_package(block % packages, "pkgTracerZSalinityActive", pkgTracerZSalinityActive)
        call MPAS_pool_get_package(block % packages, "pkgColumnTracerEffectiveSnowDensityActive", pkgColumnTracerEffectiveSnowDensityActive)
        call MPAS_pool_get_package(block % packages, "pkgColumnTracerSnowGrainRadiusActive", pkgColumnTracerSnowGrainRadiusActive)
 
@@ -14020,9 +14014,9 @@ contains
           call finalize_stand_in_tracer_array(block, "verticalAerosolsSnow")
           call finalize_stand_in_tracer_array(block, "verticalAerosolsIce")
        endif
-       if (.not. pkgTracerZSalinityActive) then
-          call finalize_stand_in_tracer_array(block, "verticalSalinity")
-       endif
+!       if (.not. pkgTracerZSalinityActive) then
+!          call finalize_stand_in_tracer_array(block, "verticalSalinity")
+!       endif
 
        ! snow density tracer
        if (.not. pkgColumnTracerEffectiveSnowDensityActive) then
@@ -14428,7 +14422,7 @@ contains
 
     logical, pointer :: &
          config_use_brine, &
-         config_use_vertical_zsalinity, &
+         config_use_vertical_zsalinity, &      !echmod deprecate
          config_use_vertical_biochemistry, &
          config_use_vertical_tracers, &
          config_use_skeletal_biochemistry, &
@@ -14576,7 +14570,7 @@ contains
     tracerObject % nTracers = tracerObject % nTracersNotBio
 
     call MPAS_pool_get_config(domain % configs, "config_use_brine", config_use_brine)
-    call MPAS_pool_get_config(domain % configs, "config_use_vertical_zsalinity", config_use_vertical_zsalinity)
+    call MPAS_pool_get_config(domain % configs, "config_use_vertical_zsalinity", config_use_vertical_zsalinity)  !echmod deprecate
     call MPAS_pool_get_config(domain % configs, "config_use_shortwave_bioabsorption", config_use_shortwave_bioabsorption)
     call MPAS_pool_get_config(domain % configs, "config_use_vertical_tracers", config_use_vertical_tracers)
     call MPAS_pool_get_config(domain % configs, "config_use_skeletal_biochemistry", config_use_skeletal_biochemistry)
@@ -14801,7 +14795,7 @@ contains
          config_use_silicate, &
          config_use_DMS, &
          config_use_nonreactive, &
-         config_use_vertical_zsalinity, &
+         config_use_vertical_zsalinity, &      !echmod deprecate
          use_nitrogen, &
          config_use_carbon, &
          config_use_chlorophyll, &
@@ -14829,7 +14823,7 @@ contains
          tracerObject % index_humicsConc, &
          tracerObject % index_humicsConcLayer, &
          config_use_humics, &
-         config_use_vertical_zsalinity, &
+         config_use_vertical_zsalinity, &            !echmod deprecate
          config_use_skeletal_biochemistry, &
          config_use_vertical_tracers, &
          config_use_shortwave_bioabsorption, &
@@ -14966,8 +14960,8 @@ contains
 
     use ice_colpkg, only: &
          colpkg_init_bgc, &
-         colpkg_init_hbrine, &
-         colpkg_init_zsalinity
+         colpkg_init_hbrine!, &
+!         colpkg_init_zsalinity
 
     type(domain_type), intent(inout) :: domain
 
@@ -14985,10 +14979,10 @@ contains
 
     logical, pointer :: &
          config_use_brine, &
-         config_use_vertical_zsalinity, &
+!         config_use_vertical_zsalinity, &
          config_use_vertical_tracers, &
          config_use_skeletal_biochemistry, &
-         config_do_restart_zsalinity, &
+!         config_do_restart_zsalinity, &
          config_do_restart_bgc, &
          config_do_restart_hbrine, &
          config_use_macromolecules
@@ -15067,10 +15061,10 @@ contains
          abortMessage
 
     call MPAS_pool_get_config(domain % configs, "config_use_brine", config_use_brine)
-    call MPAS_pool_get_config(domain % configs, "config_do_restart_zsalinity", config_do_restart_zsalinity)
+!    call MPAS_pool_get_config(domain % configs, "config_do_restart_zsalinity", config_do_restart_zsalinity)
     call MPAS_pool_get_config(domain % configs, "config_do_restart_bgc", config_do_restart_bgc)
     call MPAS_pool_get_config(domain % configs, "config_do_restart_hbrine", config_do_restart_hbrine)
-    call MPAS_pool_get_config(domain % configs, "config_use_vertical_zsalinity", config_use_vertical_zsalinity)
+!    call MPAS_pool_get_config(domain % configs, "config_use_vertical_zsalinity", config_use_vertical_zsalinity)
     call MPAS_pool_get_config(domain % configs, "config_use_skeletal_biochemistry", config_use_skeletal_biochemistry)
     call MPAS_pool_get_config(domain % configs, "config_use_vertical_tracers", config_use_vertical_tracers)
     call MPAS_pool_get_config(domain % configs, "config_dt", config_dt)
@@ -15165,18 +15159,18 @@ contains
           call set_cice_tracer_array_category(block, tracerObject, &
                tracerArrayCategory, iCell, setGetPhysicsTracers, setGetBGCTracers)
 
-          if (config_use_vertical_zsalinity) then
-             call colpkg_init_zsalinity(&
-                  nBioLayers, &
-                  tracerObject % nTracersNotBio, &
-                  config_do_restart_zsalinity, &
-                  rayleighCriteria, &
-                  rayleighCriteriaReal(iCell), &
-                  tracerArrayCategory(tracerObject % nTracersNotBio+1:tracerObject % nTracers,:), &
-                  tracerObject % index_verticalSalinity, &
-                  nCategories, &
-                  seaSurfaceSalinity(iCell))
-          endif
+!          if (config_use_vertical_zsalinity) then
+!             call colpkg_init_zsalinity(&
+!                  nBioLayers, &
+!                  tracerObject % nTracersNotBio, &
+!                  config_do_restart_zsalinity, &
+!                  rayleighCriteria, &
+!                  rayleighCriteriaReal(iCell), &
+!                  tracerArrayCategory(tracerObject % nTracersNotBio+1:tracerObject % nTracers,:), &
+!                  tracerObject % index_verticalSalinity, &
+!                  nCategories, &
+!                  seaSurfaceSalinity(iCell))
+!          endif
 
           if (config_use_vertical_tracers .or. config_use_skeletal_biochemistry) then
              call colpkg_init_bgc(&
@@ -15713,8 +15707,8 @@ contains
          primaryProduction, &
          netSpecificAlgalGrowthRate, &
          netBrineHeight, &
-         zSalinityFlux, &
-         zSalinityGDFlux, &
+!         zSalinityFlux, &
+!         zSalinityGDFlux, &
          totalChlorophyll, &
          totalCarbonContentCell
 
@@ -15735,8 +15729,8 @@ contains
          config_use_column_biogeochemistry, &
          config_use_column_shortwave, &
          config_use_column_package, &
-         config_use_vertical_biochemistry, &
-         config_use_vertical_zsalinity
+         config_use_vertical_biochemistry!, &
+!         config_use_vertical_zsalinity
 
     call MPAS_pool_get_config(domain % blocklist % configs, "config_use_column_package", config_use_column_package)
 
@@ -15748,7 +15742,7 @@ contains
           ! biogeochemistry
           call MPAS_pool_get_config(block % configs, "config_use_column_biogeochemistry", config_use_column_biogeochemistry)
           call MPAS_pool_get_config(block % configs, "config_use_vertical_biochemistry", config_use_vertical_biochemistry)
-          call MPAS_pool_get_config(block % configs, "config_use_vertical_zsalinity", config_use_vertical_zsalinity)
+!          call MPAS_pool_get_config(block % configs, "config_use_vertical_zsalinity", config_use_vertical_zsalinity)
 
           if (config_use_column_biogeochemistry) then
 
@@ -15772,14 +15766,14 @@ contains
 
              end if
 
-             if (config_use_vertical_zsalinity) then
-                call MPAS_pool_get_array(biogeochemistryPool, "zSalinityFlux", zSalinityFlux)
-                call MPAS_pool_get_array(biogeochemistryPool, "zSalinityGDFlux", zSalinityGDFlux)
+!             if (config_use_vertical_zsalinity) then
+!                call MPAS_pool_get_array(biogeochemistryPool, "zSalinityFlux", zSalinityFlux)
+!                call MPAS_pool_get_array(biogeochemistryPool, "zSalinityGDFlux", zSalinityGDFlux)
 
-                zSalinityFlux              = 0.0_RKIND
-                zSalinityGDFlux            = 0.0_RKIND
+!                zSalinityFlux              = 0.0_RKIND
+!                zSalinityGDFlux            = 0.0_RKIND
 
-             end if
+!             end if
 
              call MPAS_pool_get_array(biogeochemistryPool, "netBrineHeight", netBrineHeight)
              call MPAS_pool_get_array(biogeochemistryPool, "oceanBioFluxes", oceanBioFluxes)

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -3237,7 +3237,6 @@ contains
                rsnow=snow_grain_radius(:,:), &
                l_print_point=.false., &
                initonly=lInitialization)
-          call column_write_warnings(.false.)
 
           ! set the category tracer array
           call get_cice_tracer_array_category(block, ciceTracerObject, &
@@ -5700,6 +5699,7 @@ contains
          icepack_configure
 
     use seaice_constants, only: &
+         pi, &          !echmod - do we need this here, or can we set seaicePi in seaice_constants?
          seaicePi, &
          seaiceGravity, &
          seaicePuny, &
@@ -5737,9 +5737,6 @@ contains
          iceThicknessMinimum, &
          snowThicknessMinimum
     !gramsCarbonPerMolCarbon          = R_gC2molC
-
-    use ice_constants_colpkg, only: &  ! for E3SM runs this is currently in src/column/constants/cesm/
-         pi
 
     call icepack_configure()
     call seaice_icepack_write_warnings(icepack_warnings_aborted())
@@ -9293,7 +9290,6 @@ contains
          config_nIceLayers
 
     character(len=strKIND), pointer :: &
-         config_column_physics_type, &
          config_thermodynamics_type, &
          config_heat_conductivity_type, &
          config_shortwave_type, &
@@ -9356,8 +9352,6 @@ contains
     call MPAS_pool_get_dimension(domain % blocklist % dimensions, "nCategories", nCategories)
     call MPAS_pool_get_dimension(domain % blocklist % dimensions, "nSnowLayers", nSnowLayers)
     call MPAS_pool_get_dimension(domain % blocklist % dimensions, "nIceLayers", nIceLayers)
-
-    call MPAS_pool_get_config(domain % configs, "config_column_physics_type", config_column_physics_type)
 
     call MPAS_pool_get_config(domain % configs, "config_thermodynamics_type", config_thermodynamics_type)
     call MPAS_pool_get_config(domain % configs, "config_heat_conductivity_type", config_heat_conductivity_type)
@@ -9968,7 +9962,7 @@ contains
 !
 !-----------------------------------------------------------------------
 
-  subroutine init_column_package_configs(domain)
+  subroutine init_column_package_configs(domain)   !colpkg routine - remove
 
     !use ice_colpkg_shared, only: &
     !     ktherm, &

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -1819,7 +1819,7 @@ contains
                fcondbotn=bottomConductiveFluxCategory(:,iCell), &
                fswsfcn=surfaceShortwaveFlux(:,iCell), &
                fswintn=interiorShortwaveFlux(:,iCell), &
-               fswthrun=penetratingShortwaveFlux(:,iCell), & ! Wrong dimensions? echmod check this
+               fswthrun=penetratingShortwaveFlux(:,iCell), &
                fswabs=absorbedShortwaveFlux(iCell), &
                flwout=longwaveUp(iCell), &
                Sswabsn=absorbedShortwaveSnowLayer(:,:,iCell), &
@@ -5838,7 +5838,7 @@ contains
          config_use_aerosols, &
          config_use_brine, &
          config_use_column_biogeochemistry, &
-!         config_use_vertical_zsalinity, &
+!         config_use_vertical_zsalinity, &      !echmod deprecate
          config_use_vertical_biochemistry, &
          config_use_vertical_tracers, &
          config_use_skeletal_biochemistry, &
@@ -5886,7 +5886,7 @@ contains
 
     call MPAS_pool_get_config(domain % configs, "config_use_column_biogeochemistry", config_use_column_biogeochemistry)
     call MPAS_pool_get_config(domain % configs, "config_use_brine", config_use_brine)
-!    call MPAS_pool_get_config(domain % configs, "config_use_vertical_zsalinity", config_use_vertical_zsalinity)
+!    call MPAS_pool_get_config(domain % configs, "config_use_vertical_zsalinity", config_use_vertical_zsalinity)  !echmod deprecate
     call MPAS_pool_get_config(domain % configs, "config_use_vertical_tracers", config_use_vertical_tracers)
     call MPAS_pool_get_config(domain % configs, "config_use_skeletal_biochemistry", config_use_skeletal_biochemistry)
     call MPAS_pool_get_config(domain % configs, "config_use_vertical_biochemistry", config_use_vertical_biochemistry)
@@ -5983,7 +5983,7 @@ contains
        if (config_use_brine) &
             tracerObject % nTracers = tracerObject % nTracers + 1
 
-       ! vertical zSalinity
+       ! vertical zSalinity                               !echmod deprecate
 !       if (config_use_vertical_zsalinity) then
 !          tracerObject % nTracers = tracerObject % nTracers + nBioLayers
 !          tracerObject % nBioTracersLayer = tracerObject % nBioTracersLayer + 1
@@ -7431,7 +7431,7 @@ contains
     logical, pointer :: &
          config_use_skeletal_biochemistry, &
          config_use_vertical_biochemistry, &
-!         config_use_vertical_zsalinity, &
+!         config_use_vertical_zsalinity, &      !echmod deprecate
          config_use_vertical_tracers, &
          config_use_brine, &
          config_use_nitrate, &
@@ -7499,7 +7499,7 @@ contains
          iLayers
 
     call MPAS_pool_get_config(block % configs, "config_use_skeletal_biochemistry", config_use_skeletal_biochemistry)
-!    call MPAS_pool_get_config(block % configs, "config_use_vertical_zsalinity", config_use_vertical_zsalinity)
+!    call MPAS_pool_get_config(block % configs, "config_use_vertical_zsalinity", config_use_vertical_zsalinity)      !echmod deprecate
     call MPAS_pool_get_config(block % configs, "config_use_vertical_biochemistry", config_use_vertical_biochemistry)
     call MPAS_pool_get_config(block % configs, "config_use_vertical_tracers", config_use_vertical_tracers)
     call MPAS_pool_get_config(block % configs, "config_use_brine", config_use_brine)
@@ -7763,7 +7763,7 @@ contains
           enddo
        endif
 
-       ! salinity used with BL99 thermodynamics
+       ! salinity used with BL99 thermodynamics        !echmod deprecate
 !       if (config_use_vertical_zsalinity) then
 !          do iLayers = 1, nBioLayers
 !             tracerArrayCategory(tracerObject % index_verticalSalinity+iLayers-1,:) = &
@@ -7803,7 +7803,7 @@ contains
     logical, pointer :: &
          config_use_skeletal_biochemistry, &
          config_use_vertical_biochemistry, &
-!         config_use_vertical_zsalinity, &
+!         config_use_vertical_zsalinity, &      !echmod deprecate
          config_use_vertical_tracers, &
          config_use_brine, &
          config_use_nitrate, &
@@ -7872,7 +7872,7 @@ contains
 
     call MPAS_pool_get_config(block % configs, "config_use_skeletal_biochemistry", config_use_skeletal_biochemistry)
     call MPAS_pool_get_config(block % configs, "config_use_vertical_biochemistry", config_use_vertical_biochemistry)
-!    call MPAS_pool_get_config(block % configs, "config_use_vertical_zsalinity", config_use_vertical_zsalinity)
+!    call MPAS_pool_get_config(block % configs, "config_use_vertical_zsalinity", config_use_vertical_zsalinity)       !echmod deprecate
     call MPAS_pool_get_config(block % configs, "config_use_vertical_tracers", config_use_vertical_tracers)
     call MPAS_pool_get_config(block % configs, "config_use_brine", config_use_brine)
     call MPAS_pool_get_config(block % configs, "config_use_nitrate", config_use_nitrate)
@@ -8143,7 +8143,7 @@ contains
           enddo
        endif
 
-       ! salinity used with BL99 thermodynamics
+       ! salinity used with BL99 thermodynamics        !echmod deprecate
 !       if (config_use_vertical_zsalinity) then
 !          do iLayers = 1, nBioLayers
 !             verticalSalinity(iLayers,:,iCell) = &
@@ -8183,7 +8183,7 @@ contains
     logical, pointer :: &
          config_use_skeletal_biochemistry, &
          config_use_vertical_biochemistry, &
-!         config_use_vertical_zsalinity, &
+!         config_use_vertical_zsalinity, &       !echmod deprecate
          config_use_vertical_tracers, &
          config_use_brine, &
          config_use_nitrate, &
@@ -8272,7 +8272,7 @@ contains
 
     call MPAS_pool_get_config(block % configs, "config_use_skeletal_biochemistry", config_use_skeletal_biochemistry)
     call MPAS_pool_get_config(block % configs, "config_use_vertical_biochemistry", config_use_vertical_biochemistry)
-!    call MPAS_pool_get_config(block % configs, "config_use_vertical_zsalinity", config_use_vertical_zsalinity)
+!    call MPAS_pool_get_config(block % configs, "config_use_vertical_zsalinity", config_use_vertical_zsalinity)      !echmod deprecate
     call MPAS_pool_get_config(block % configs, "config_use_vertical_tracers", config_use_vertical_tracers)
     call MPAS_pool_get_config(block % configs, "config_use_brine", config_use_brine)
     call MPAS_pool_get_config(block % configs, "config_use_nitrate", config_use_nitrate)
@@ -8636,7 +8636,7 @@ contains
           enddo
        endif
 
-       ! salinity for use with BL99 thermodynamics
+       ! salinity used with BL99 thermodynamics        !echmod deprecate
 !       if (config_use_vertical_zsalinity) then
 !          do iLayers = 1, nBioLayers
 !             tracerArrayCell(tracerObject % index_verticalSalinity+iLayers-1)  = verticalSalinityCell(iLayers,iCell)
@@ -8675,7 +8675,7 @@ contains
     logical, pointer :: &
          config_use_skeletal_biochemistry, &
          config_use_vertical_biochemistry, &
-!         config_use_vertical_zsalinity, &
+!         config_use_vertical_zsalinity, &       !echmod deprecate
          config_use_vertical_tracers, &
          config_use_brine, &
          config_use_nitrate, &
@@ -8764,7 +8764,7 @@ contains
 
     call MPAS_pool_get_config(block % configs, "config_use_skeletal_biochemistry", config_use_skeletal_biochemistry)
     call MPAS_pool_get_config(block % configs, "config_use_vertical_biochemistry", config_use_vertical_biochemistry)
-!    call MPAS_pool_get_config(block % configs, "config_use_vertical_zsalinity", config_use_vertical_zsalinity)
+!    call MPAS_pool_get_config(block % configs, "config_use_vertical_zsalinity", config_use_vertical_zsalinity)       !echmod deprecate
     call MPAS_pool_get_config(block % configs, "config_use_vertical_tracers", config_use_vertical_tracers)
     call MPAS_pool_get_config(block % configs, "config_use_brine", config_use_brine)
     call MPAS_pool_get_config(block % configs, "config_use_nitrate", config_use_nitrate)
@@ -9132,7 +9132,7 @@ contains
           enddo
        endif
 
-       ! salinity for use with BL99 thermodynamics
+       ! salinity used with BL99 thermodynamics        !echmod deprecate
 !       if (config_use_vertical_zsalinity) then
 !          do iLayers = 1, nBioLayers
 !             verticalSalinityCell(iLayers,iCell) = tracerArrayCell(tracerObject % index_verticalSalinity+iLayers-1)
@@ -9235,7 +9235,7 @@ contains
          config_use_cesm_meltponds, &  ! deprecated
          config_use_level_meltponds, &
          config_use_topo_meltponds, &
-         config_use_vertical_zsalinity, &
+         config_use_vertical_zsalinity, &      ! deprecated
          config_use_brine, &
          config_use_vertical_tracers, &
          config_use_vertical_biochemistry, &
@@ -9299,7 +9299,7 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_ocean_heat_transfer_type", config_ocean_heat_transfer_type)
     call MPAS_pool_get_config(domain % configs, "config_sea_freezing_temperature_type", config_sea_freezing_temperature_type)
     call MPAS_pool_get_config(domain % configs, "config_use_brine", config_use_brine)
-    call MPAS_pool_get_config(domain % configs, "config_use_vertical_zsalinity", config_use_vertical_zsalinity)
+    call MPAS_pool_get_config(domain % configs, "config_use_vertical_zsalinity", config_use_vertical_zsalinity)      ! deprecated
     call MPAS_pool_get_config(domain % configs, "config_use_shortwave_bioabsorption", config_use_shortwave_bioabsorption)
     call MPAS_pool_get_config(domain % configs, "config_use_vertical_tracers", config_use_vertical_tracers)
     call MPAS_pool_get_config(domain % configs, "config_use_skeletal_biochemistry", config_use_skeletal_biochemistry)
@@ -9331,7 +9331,9 @@ contains
 
     ! check config_thermodynamics_type value
     if (trim(config_thermodynamics_type) == "zero layer") then
-       call config_error("config_thermodynamics_type", config_thermodynamics_type, "'zero-layer' has been deprecated")
+       call mpas_log_write(&
+            "check_column_package_configs: config_thermodynamics_type) = zero layer but 0-layer thermo has been deprecated", &
+            messageType=MPAS_LOG_WARN)
     endif
 
     if (.not. (trim(config_thermodynamics_type) == "BL99" .or. &
@@ -9573,15 +9575,9 @@ contains
     endif
 
     ! deprecate vertical zSalinity
-!    if (config_use_vertical_zsalinity .and. ((.not. config_use_brine) .or. &
-!         (.not. (trim(config_thermodynamics_type) == "BL99")))) then
-!       call mpas_log_write(&
-!            "check_column_package_configs: vertical zSalinity requires config_use_brine = true and 'BL99' ", &
-!            messageType=MPAS_LOG_CRIT)
-!    endif
     if (config_use_vertical_zsalinity) then
        call mpas_log_write(&
-            "check_column_package_configs: vertical zSalinity has been deprecated", &
+            "check_column_package_configs: config_use_vertical_zsalinity = .true. but vertical zSalinity has been deprecated", &
             messageType=MPAS_LOG_CRIT)
     endif
 
@@ -9644,7 +9640,7 @@ contains
          config_use_topo_meltponds, &
          config_use_aerosols, &
          config_use_brine, &
-!         config_use_vertical_zsalinity, &
+!         config_use_vertical_zsalinity, &      !echmod deprecate
          config_use_zaerosols, &
          config_use_nitrate, &
          config_use_DON, &
@@ -9672,7 +9668,7 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_use_topo_meltponds", config_use_topo_meltponds)
     call MPAS_pool_get_config(domain % configs, "config_use_aerosols", config_use_aerosols)
     call MPAS_pool_get_config(domain % configs, "config_use_brine", config_use_brine)
-!    call MPAS_pool_get_config(domain % configs, "config_use_vertical_zsalinity", config_use_vertical_zsalinity)
+!    call MPAS_pool_get_config(domain % configs, "config_use_vertical_zsalinity", config_use_vertical_zsalinity)   !echmod deprecate
     call MPAS_pool_get_config(domain % configs, "config_use_zaerosols", config_use_zaerosols)
     call MPAS_pool_get_config(domain % configs, "config_use_nitrate", config_use_nitrate)
     call MPAS_pool_get_config(domain % configs, "config_use_DON", config_use_DON)
@@ -13470,7 +13466,7 @@ contains
          pkgTracerVerticalDONActive, &
          pkgTracerVerticalIronActive, &
          pkgTracerZAerosolsActive, &
-!         pkgTracerZSalinityActive, &
+!         pkgTracerZSalinityActive, &           !echmod deprecate
          pkgColumnTracerEffectiveSnowDensityActive, &
          pkgColumnTracerSnowGrainRadiusActive
 
@@ -13809,7 +13805,7 @@ contains
          pkgTracerVerticalDONActive, &
          pkgTracerVerticalIronActive, &
          pkgTracerZAerosolsActive, &
-!         pkgTracerZSalinityActive, &
+!         pkgTracerZSalinityActive, &                   !echmod deprecate
          pkgColumnTracerEffectiveSnowDensityActive, &
          pkgColumnTracerSnowGrainRadiusActive
 
@@ -13868,7 +13864,7 @@ contains
        call MPAS_pool_get_package(block % packages, "pkgTracerVerticalDONActive", pkgTracerVerticalDONActive)
        call MPAS_pool_get_package(block % packages, "pkgTracerVerticalIronActive", pkgTracerVerticalIronActive)
        call MPAS_pool_get_package(block % packages, "pkgTracerZAerosolsActive", pkgTracerZAerosolsActive)
-!       call MPAS_pool_get_package(block % packages, "pkgTracerZSalinityActive", pkgTracerZSalinityActive)
+!       call MPAS_pool_get_package(block % packages, "pkgTracerZSalinityActive", pkgTracerZSalinityActive)      !echmod deprecate
        call MPAS_pool_get_package(block % packages, "pkgColumnTracerEffectiveSnowDensityActive", pkgColumnTracerEffectiveSnowDensityActive)
        call MPAS_pool_get_package(block % packages, "pkgColumnTracerSnowGrainRadiusActive", pkgColumnTracerSnowGrainRadiusActive)
 
@@ -14015,7 +14011,7 @@ contains
           call finalize_stand_in_tracer_array(block, "verticalAerosolsSnow")
           call finalize_stand_in_tracer_array(block, "verticalAerosolsIce")
        endif
-!       if (.not. pkgTracerZSalinityActive) then
+!       if (.not. pkgTracerZSalinityActive) then                            !echmod deprecate
 !          call finalize_stand_in_tracer_array(block, "verticalSalinity")
 !       endif
 
@@ -14962,7 +14958,7 @@ contains
     use ice_colpkg, only: &
          colpkg_init_bgc, &
          colpkg_init_hbrine!, &
-!         colpkg_init_zsalinity
+!         colpkg_init_zsalinity        !echmod deprecate
 
     type(domain_type), intent(inout) :: domain
 
@@ -14980,10 +14976,10 @@ contains
 
     logical, pointer :: &
          config_use_brine, &
-!         config_use_vertical_zsalinity, &
+!         config_use_vertical_zsalinity, &      !echmod deprecate
          config_use_vertical_tracers, &
          config_use_skeletal_biochemistry, &
-!         config_do_restart_zsalinity, &
+!         config_do_restart_zsalinity, &        !echmod deprecate
          config_do_restart_bgc, &
          config_do_restart_hbrine, &
          config_use_macromolecules
@@ -15062,10 +15058,10 @@ contains
          abortMessage
 
     call MPAS_pool_get_config(domain % configs, "config_use_brine", config_use_brine)
-!    call MPAS_pool_get_config(domain % configs, "config_do_restart_zsalinity", config_do_restart_zsalinity)
+!    call MPAS_pool_get_config(domain % configs, "config_do_restart_zsalinity", config_do_restart_zsalinity)  !echmod deprecate
     call MPAS_pool_get_config(domain % configs, "config_do_restart_bgc", config_do_restart_bgc)
     call MPAS_pool_get_config(domain % configs, "config_do_restart_hbrine", config_do_restart_hbrine)
-!    call MPAS_pool_get_config(domain % configs, "config_use_vertical_zsalinity", config_use_vertical_zsalinity)
+!    call MPAS_pool_get_config(domain % configs, "config_use_vertical_zsalinity", config_use_vertical_zsalinity) !echmod deprecate
     call MPAS_pool_get_config(domain % configs, "config_use_skeletal_biochemistry", config_use_skeletal_biochemistry)
     call MPAS_pool_get_config(domain % configs, "config_use_vertical_tracers", config_use_vertical_tracers)
     call MPAS_pool_get_config(domain % configs, "config_dt", config_dt)
@@ -15160,7 +15156,7 @@ contains
           call set_cice_tracer_array_category(block, tracerObject, &
                tracerArrayCategory, iCell, setGetPhysicsTracers, setGetBGCTracers)
 
-!          if (config_use_vertical_zsalinity) then
+!          if (config_use_vertical_zsalinity) then        !echmod deprecate
 !             call colpkg_init_zsalinity(&
 !                  nBioLayers, &
 !                  tracerObject % nTracersNotBio, &
@@ -15708,8 +15704,8 @@ contains
          primaryProduction, &
          netSpecificAlgalGrowthRate, &
          netBrineHeight, &
-!         zSalinityFlux, &
-!         zSalinityGDFlux, &
+!         zSalinityFlux, &        !echmod deprecate
+!         zSalinityGDFlux, &      !echmod deprecate
          totalChlorophyll, &
          totalCarbonContentCell
 
@@ -15731,7 +15727,7 @@ contains
          config_use_column_shortwave, &
          config_use_column_package, &
          config_use_vertical_biochemistry!, &
-!         config_use_vertical_zsalinity
+!         config_use_vertical_zsalinity         !echmod deprecate
 
     call MPAS_pool_get_config(domain % blocklist % configs, "config_use_column_package", config_use_column_package)
 
@@ -15743,7 +15739,7 @@ contains
           ! biogeochemistry
           call MPAS_pool_get_config(block % configs, "config_use_column_biogeochemistry", config_use_column_biogeochemistry)
           call MPAS_pool_get_config(block % configs, "config_use_vertical_biochemistry", config_use_vertical_biochemistry)
-!          call MPAS_pool_get_config(block % configs, "config_use_vertical_zsalinity", config_use_vertical_zsalinity)
+!          call MPAS_pool_get_config(block % configs, "config_use_vertical_zsalinity", config_use_vertical_zsalinity)    !echmod deprecate
 
           if (config_use_column_biogeochemistry) then
 
@@ -15767,7 +15763,7 @@ contains
 
              end if
 
-!             if (config_use_vertical_zsalinity) then
+!             if (config_use_vertical_zsalinity) then          !echmod deprecate
 !                call MPAS_pool_get_array(biogeochemistryPool, "zSalinityFlux", zSalinityFlux)
 !                call MPAS_pool_get_array(biogeochemistryPool, "zSalinityGDFlux", zSalinityGDFlux)
 

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -2888,7 +2888,7 @@ contains
     use icepack_intfc, only: &
          icepack_step_radiation
     use seaice_constants, only: &
-         pii
+         seaicePi
 
     type(domain_type), intent(inout) :: domain
 
@@ -3177,7 +3177,7 @@ contains
           endif
 
           lonCellColumn = lonCell(iCell)
-          if (lonCellColumn > pii) lonCellColumn = lonCellColumn - 2.0_RKIND * pii
+          if (lonCellColumn > seaicePi) lonCellColumn = lonCellColumn - 2.0_RKIND * seaicePi
 
           ! set the category tracer array
           call set_cice_tracer_array_category(block, ciceTracerObject, &
@@ -5699,7 +5699,6 @@ contains
          icepack_configure
 
     use seaice_constants, only: &
-         pi, &          !echmod - do we need this here, or can we set seaicePi in seaice_constants?
          seaicePi, &
          seaiceGravity, &
          seaicePuny, &
@@ -5740,9 +5739,6 @@ contains
 
     call icepack_configure()
     call seaice_icepack_write_warnings(icepack_warnings_aborted())
-
-!echmod - set this in seaice_constants instead
-    seaicePi                         = pi
 
     iceAreaMinimum       = seaicePuny
     iceThicknessMinimum  = seaicePuny
@@ -11561,7 +11557,6 @@ contains
          icepack_query_parameters ! debugging
 
     use seaice_constants, only: &
-         pii, &                              ! pi                     !echmod: use SHR value instead?
          seaicePuny, &                       ! a small number
          seaiceBigNumber, &                     ! a large number
          seaiceSecondsPerDay, &              ! number of seconds in 1 day
@@ -12088,10 +12083,6 @@ contains
     call icepack_query_parameters(puny_out=rtmp2)
     if (rtmp1 /= rtmp2) call mpas_log_write('puny differs $r $r',realArgs=(/rtmp1,rtmp2/))
 
-    rtmp1 = pii       ! defined in mpas_seaice_constants.F
-    call icepack_query_parameters(pi_out=rtmp2)
-    if (rtmp1 /= rtmp2) call mpas_log_write('pii differs $r $r',realArgs=(/rtmp1,rtmp2/))
-
     rtmp1 = seaicePi  ! defined above using pi from ice_constants_colpkg.F90
     call icepack_query_parameters(pi_out=rtmp2)
     if (rtmp1 /= rtmp2) call mpas_log_write('pi differs $r $r',realArgs=(/rtmp1,rtmp2/))
@@ -12225,7 +12216,6 @@ contains
          !argcheck_in             = , &               ! may not be needed in the driver
          puny_in                 = seaicePuny, &
          bignum_in               = seaiceBigNumber, &
-!         pi_in                   = pii, &            ! use SHR value instead
          pi_in                   = seaicePi, &
          secday_in               = seaiceSecondsPerDay, &
          rhos_in                 = seaiceDensitySnow, &

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -17232,7 +17232,7 @@ contains
          icepack_warnings_clear, &
          icepack_warnings_getall
 
-    character(len=strKINDWarnings), dimension(:), allocatable :: &
+    character(len=256), dimension(:), allocatable :: & ! icepack char_len_long=256
          warnings
 
     logical, intent(in) :: &

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -5699,43 +5699,10 @@ contains
          icepack_configure
 
     use seaice_constants, only: &
-         seaicePi, &
-         seaiceGravity, &
          seaicePuny, &
-         seaiceDensityIce, &
-         seaiceDensitySnow, &
-         seaiceDensitySeaWater, &
-         seaiceDensityFreshwater, &
-         seaiceStefanBoltzmann, &
-         seaiceIceSnowEmissivity, &
-         seaiceFreshWaterFreezingPoint, &
-         seaiceSeaWaterSpecificHeat, &
-         seaiceFreshIceSpecificHeat, &
-         seaiceAirSpecificHeat, &
-         seaiceWaterVaporSpecificHeat, &
-         seaiceLatentHeatVaporization, &
-         seaiceLatentHeatSublimation, &
-         seaiceLatentHeatMelting, &
-         seaiceIceSurfaceMeltingTemperature, &
-         seaiceSnowSurfaceMeltingTemperature, &
-         seaiceZvir, &
-         seaiceReferenceSalinity, &
-         seaiceMaximumSalinity, &
-         seaiceMeltingTemperatureDepression, &
-         seaiceOceanAlbedo, &
-         seaiceVonKarmanConstant, &
-         seaiceIceSurfaceRoughness, &
-         seaiceStabilityReferenceHeight, &
-         seaiceSnowPatchiness, &
-         seaiceIceStrengthConstantHiblerP, &
-         seaiceIceStrengthConstantHiblerC, &
-         seaiceIceOceanDragCoefficient, &
-         skeletalLayerThickness, &
-         gramsCarbonPerMolCarbon, &
          iceAreaMinimum, &
          iceThicknessMinimum, &
          snowThicknessMinimum
-    !gramsCarbonPerMolCarbon          = R_gC2molC
 
     call icepack_configure()
     call seaice_icepack_write_warnings(icepack_warnings_aborted())
@@ -5871,7 +5838,6 @@ contains
          config_use_ice_age, &
          config_use_first_year_ice, &
          config_use_level_ice, &
-         config_use_cesm_meltponds, &
          config_use_level_meltponds, &
          config_use_topo_meltponds, &
          config_use_aerosols, &
@@ -5917,7 +5883,6 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_use_ice_age", config_use_ice_age)
     call MPAS_pool_get_config(domain % configs, "config_use_first_year_ice", config_use_first_year_ice)
     call MPAS_pool_get_config(domain % configs, "config_use_level_ice", config_use_level_ice)
-    call MPAS_pool_get_config(domain % configs, "config_use_cesm_meltponds", config_use_cesm_meltponds)
     call MPAS_pool_get_config(domain % configs, "config_use_level_meltponds", config_use_level_meltponds)
     call MPAS_pool_get_config(domain % configs, "config_use_topo_meltponds", config_use_topo_meltponds)
     call MPAS_pool_get_config(domain % configs, "config_use_aerosols", config_use_aerosols)
@@ -5984,8 +5949,7 @@ contains
          tracerObject % nTracers = tracerObject % nTracers + 2
 
     ! pond tracers
-    if (config_use_cesm_meltponds .or. &
-        config_use_level_meltponds .or. &
+    if (config_use_level_meltponds .or. &
         config_use_topo_meltponds) &
          tracerObject % nTracers = tracerObject % nTracers + 2
 
@@ -6162,7 +6126,6 @@ contains
          config_use_ice_age, &
          config_use_first_year_ice, &
          config_use_level_ice, &
-         config_use_cesm_meltponds, &
          config_use_level_meltponds, &
          config_use_topo_meltponds, &
          config_use_aerosols, &
@@ -6181,7 +6144,6 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_use_ice_age", config_use_ice_age)
     call MPAS_pool_get_config(domain % configs, "config_use_first_year_ice", config_use_first_year_ice)
     call MPAS_pool_get_config(domain % configs, "config_use_level_ice", config_use_level_ice)
-    call MPAS_pool_get_config(domain % configs, "config_use_cesm_meltponds", config_use_cesm_meltponds)
     call MPAS_pool_get_config(domain % configs, "config_use_level_meltponds", config_use_level_meltponds)
     call MPAS_pool_get_config(domain % configs, "config_use_topo_meltponds", config_use_topo_meltponds)
     call MPAS_pool_get_config(domain % configs, "config_use_aerosols", config_use_aerosols)
@@ -6236,8 +6198,7 @@ contains
     tracerObject % index_pondDepth        = indexMissingValue
     tracerObject % index_pondLidThickness = indexMissingValue
 
-    if (config_use_cesm_meltponds .or. &
-        config_use_level_meltponds .or. &
+    if (config_use_level_meltponds .or. &
         config_use_topo_meltponds) then
        nTracers = nTracers + 1
        tracerObject % index_pondArea = nTracers
@@ -6309,7 +6270,6 @@ contains
          config_use_ice_age, &
          config_use_first_year_ice, &
          config_use_level_ice, &
-         config_use_cesm_meltponds, &
          config_use_level_meltponds, &
          config_use_topo_meltponds, &
          config_use_aerosols, &
@@ -6329,7 +6289,6 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_use_ice_age", config_use_ice_age)
     call MPAS_pool_get_config(domain % configs, "config_use_first_year_ice", config_use_first_year_ice)
     call MPAS_pool_get_config(domain % configs, "config_use_level_ice", config_use_level_ice)
-    call MPAS_pool_get_config(domain % configs, "config_use_cesm_meltponds", config_use_cesm_meltponds)
     call MPAS_pool_get_config(domain % configs, "config_use_level_meltponds", config_use_level_meltponds)
     call MPAS_pool_get_config(domain % configs, "config_use_topo_meltponds", config_use_topo_meltponds)
     call MPAS_pool_get_config(domain % configs, "config_use_aerosols", config_use_aerosols)
@@ -6366,12 +6325,6 @@ contains
     if (config_use_level_ice) then
        tracerObject % parentIndex(tracerObject % index_levelIceArea)   = 0
        tracerObject % parentIndex(tracerObject % index_levelIceVolume) = 1
-    endif
-
-    ! cesm melt ponds
-    if (config_use_cesm_meltponds) then
-       tracerObject % parentIndex(tracerObject % index_pondArea)  = 0
-       tracerObject % parentIndex(tracerObject % index_pondDepth) = 2 + tracerObject % index_pondArea
     endif
 
     ! level ice ponds
@@ -6500,26 +6453,15 @@ contains
          tracerObject
 
     logical, pointer :: &
-         config_use_cesm_meltponds, &
          config_use_level_meltponds, &
          config_use_topo_meltponds
 
-    call MPAS_pool_get_config(domain % configs, "config_use_cesm_meltponds", config_use_cesm_meltponds)
     call MPAS_pool_get_config(domain % configs, "config_use_level_meltponds", config_use_level_meltponds)
     call MPAS_pool_get_config(domain % configs, "config_use_topo_meltponds", config_use_topo_meltponds)
 
     ! initialize
     tracerObject % ancestorNumber = 0
     tracerObject % ancestorIndices = 0
-
-    ! cesm meltponds
-    if (config_use_cesm_meltponds) then
-
-       ! melt pond depth
-       tracerObject % ancestorNumber (tracerObject % index_pondDepth)   = 1
-       tracerObject % ancestorIndices(tracerObject % index_pondDepth,1) = tracerObject % index_pondArea ! on melt pond area
-
-    endif
 
     ! level melt ponds
     if (config_use_level_meltponds) then
@@ -6747,7 +6689,6 @@ contains
          config_use_ice_age, &
          config_use_first_year_ice, &
          config_use_level_ice, &
-         config_use_cesm_meltponds, &
          config_use_level_meltponds, &
          config_use_topo_meltponds, &
          config_use_aerosols, &
@@ -6790,7 +6731,6 @@ contains
     call MPAS_pool_get_config(block % configs, "config_use_ice_age", config_use_ice_age)
     call MPAS_pool_get_config(block % configs, "config_use_first_year_ice", config_use_first_year_ice)
     call MPAS_pool_get_config(block % configs, "config_use_level_ice", config_use_level_ice)
-    call MPAS_pool_get_config(block % configs, "config_use_cesm_meltponds", config_use_cesm_meltponds)
     call MPAS_pool_get_config(block % configs, "config_use_level_meltponds", config_use_level_meltponds)
     call MPAS_pool_get_config(block % configs, "config_use_topo_meltponds", config_use_topo_meltponds)
     call MPAS_pool_get_config(block % configs, "config_use_aerosols", config_use_aerosols)
@@ -6862,8 +6802,7 @@ contains
     endif
 
     ! pond tracers
-    if (config_use_cesm_meltponds .or. &
-        config_use_level_meltponds .or. &
+    if (config_use_level_meltponds .or. &
         config_use_topo_meltponds) then
        tracerArrayCategory(nTracers,:) = pondArea(1,:,iCell)
        nTracers = nTracers + 1
@@ -6935,7 +6874,6 @@ contains
          config_use_ice_age, &
          config_use_first_year_ice, &
          config_use_level_ice, &
-         config_use_cesm_meltponds, &
          config_use_level_meltponds, &
          config_use_topo_meltponds, &
          config_use_aerosols, &
@@ -6979,7 +6917,6 @@ contains
     call MPAS_pool_get_config(block % configs, "config_use_ice_age", config_use_ice_age)
     call MPAS_pool_get_config(block % configs, "config_use_first_year_ice", config_use_first_year_ice)
     call MPAS_pool_get_config(block % configs, "config_use_level_ice", config_use_level_ice)
-    call MPAS_pool_get_config(block % configs, "config_use_cesm_meltponds", config_use_cesm_meltponds)
     call MPAS_pool_get_config(block % configs, "config_use_level_meltponds", config_use_level_meltponds)
     call MPAS_pool_get_config(block % configs, "config_use_topo_meltponds", config_use_topo_meltponds)
     call MPAS_pool_get_config(block % configs, "config_use_aerosols", config_use_aerosols)
@@ -7051,8 +6988,7 @@ contains
     endif
 
     ! pond tracers
-    if (config_use_cesm_meltponds .or. &
-        config_use_level_meltponds .or. &
+    if (config_use_level_meltponds .or. &
         config_use_topo_meltponds) then
        pondArea(1,:,iCell) = tracerArrayCategory(nTracers,:)
        nTracers = nTracers + 1
@@ -7124,7 +7060,6 @@ contains
          config_use_ice_age, &
          config_use_first_year_ice, &
          config_use_level_ice, &
-         config_use_cesm_meltponds, &
          config_use_level_meltponds, &
          config_use_topo_meltponds, &
          config_use_aerosols, &
@@ -7169,7 +7104,6 @@ contains
     call MPAS_pool_get_config(block % configs, "config_use_ice_age", config_use_ice_age)
     call MPAS_pool_get_config(block % configs, "config_use_first_year_ice", config_use_first_year_ice)
     call MPAS_pool_get_config(block % configs, "config_use_level_ice", config_use_level_ice)
-    call MPAS_pool_get_config(block % configs, "config_use_cesm_meltponds", config_use_cesm_meltponds)
     call MPAS_pool_get_config(block % configs, "config_use_level_meltponds", config_use_level_meltponds)
     call MPAS_pool_get_config(block % configs, "config_use_topo_meltponds", config_use_topo_meltponds)
     call MPAS_pool_get_config(block % configs, "config_use_aerosols", config_use_aerosols)
@@ -7241,8 +7175,7 @@ contains
     endif
 
     ! pond tracers
-    if (config_use_cesm_meltponds .or. &
-        config_use_level_meltponds .or. &
+    if (config_use_level_meltponds .or. &
         config_use_topo_meltponds) then
        tracerArrayCell(nTracers) = pondAreaCell(iCell)
        nTracers = nTracers + 1
@@ -7314,7 +7247,6 @@ contains
          config_use_ice_age, &
          config_use_first_year_ice, &
          config_use_level_ice, &
-         config_use_cesm_meltponds, &
          config_use_level_meltponds, &
          config_use_topo_meltponds, &
          config_use_aerosols, &
@@ -7359,7 +7291,6 @@ contains
     call MPAS_pool_get_config(block % configs, "config_use_ice_age", config_use_ice_age)
     call MPAS_pool_get_config(block % configs, "config_use_first_year_ice", config_use_first_year_ice)
     call MPAS_pool_get_config(block % configs, "config_use_level_ice", config_use_level_ice)
-    call MPAS_pool_get_config(block % configs, "config_use_cesm_meltponds", config_use_cesm_meltponds)
     call MPAS_pool_get_config(block % configs, "config_use_level_meltponds", config_use_level_meltponds)
     call MPAS_pool_get_config(block % configs, "config_use_topo_meltponds", config_use_topo_meltponds)
     call MPAS_pool_get_config(block % configs, "config_use_aerosols", config_use_aerosols)
@@ -7431,8 +7362,7 @@ contains
     endif
 
     ! pond tracers
-    if (config_use_cesm_meltponds .or. &
-        config_use_level_meltponds .or. &
+    if (config_use_level_meltponds .or. &
         config_use_topo_meltponds) then
        pondAreaCell(iCell) = tracerArrayCell(nTracers)
        nTracers = nTracers + 1
@@ -9307,7 +9237,7 @@ contains
          config_calc_surface_temperature, &
          config_use_form_drag, &
          config_use_level_ice, &
-         config_use_cesm_meltponds, &
+         config_use_cesm_meltponds, &  ! deprecated
          config_use_level_meltponds, &
          config_use_topo_meltponds, &
          config_use_vertical_zsalinity, &
@@ -9368,7 +9298,7 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_snow_to_ice_transition_depth", config_snow_to_ice_transition_depth)
     call MPAS_pool_get_config(domain % configs, "config_use_form_drag", config_use_form_drag)
     call MPAS_pool_get_config(domain % configs, "config_use_level_ice", config_use_level_ice)
-    call MPAS_pool_get_config(domain % configs, "config_use_cesm_meltponds", config_use_cesm_meltponds)
+    call MPAS_pool_get_config(domain % configs, "config_use_cesm_meltponds", config_use_cesm_meltponds) ! deprecated
     call MPAS_pool_get_config(domain % configs, "config_use_level_meltponds", config_use_level_meltponds)
     call MPAS_pool_get_config(domain % configs, "config_use_topo_meltponds", config_use_topo_meltponds)
     call MPAS_pool_get_config(domain % configs, "config_ocean_heat_transfer_type", config_ocean_heat_transfer_type)
@@ -9495,13 +9425,19 @@ contains
             'Check for inconsistencies in restart file: config_nIceLayers /= nIceLayers', &
             messageType=MPAS_LOG_CRIT)
 
+    ! deprecate cesm ponds
+    if (config_use_cesm_meltponds) then
+       call mpas_log_write(&
+            "check_column_package_configs: config_use_cesm_meltponds = .true. but cesm ponds have been deprecated", &
+            messageType=MPAS_LOG_CRIT)
+    endif
+
     !-----------------------------------------------------------------------
     ! Check combinations
     !-----------------------------------------------------------------------
 
     ! check only single meltpond option on
     nPondSchemesActive = 0
-    if (config_use_cesm_meltponds)  nPondSchemesActive = nPondSchemesActive + 1
     if (config_use_level_meltponds) nPondSchemesActive = nPondSchemesActive + 1
     if (config_use_topo_meltponds)  nPondSchemesActive = nPondSchemesActive + 1
     if (nPondSchemesActive > 1) then
@@ -9551,15 +9487,8 @@ contains
             messageType=MPAS_LOG_CRIT)
     endif
 
-    ! check cesm ponds and freezing lids inconsistency
-    if (config_use_cesm_meltponds .and. trim(config_pond_refreezing_type) /= "cesm") then
-       call mpas_log_write(&
-            "check_column_package_configs: config_use_cesm_meltponds = .true. and config_pond_refreezing_type /= 'cesm'", &
-            messageType=MPAS_LOG_CRIT)
-    endif
-
     ! check dEdd shortwave if using ponds
-    use_meltponds = (config_use_cesm_meltponds .or. config_use_level_meltponds .or. config_use_topo_meltponds)
+    use_meltponds = (config_use_level_meltponds .or. config_use_topo_meltponds)
     if (trim(config_shortwave_type(1:4)) /= 'dEdd' .and. use_meltponds .and. config_calc_surface_temperature) then
        call mpas_log_write(&
             "check_column_package_configs: config_shortwave_type(1:4)) /= 'dEdd' .and. use_meltponds = .true.", &
@@ -9601,13 +9530,6 @@ contains
     if (config_use_form_drag .and. .not. config_calc_surface_stresses) then
        call mpas_log_write(&
             "check_column_package_configs: config_use_form_drag = .true. and config_calc_surface_stresses = .false.", &
-            messageType=MPAS_LOG_CRIT)
-    endif
-
-    ! check am not using form drag with cesm ponds
-    if (config_use_form_drag .and. config_use_cesm_meltponds) then
-       call mpas_log_write(&
-            "check_column_package_configs: config_use_form_drag = .true. and config_use_cesm_meltponds = .true.", &
             messageType=MPAS_LOG_CRIT)
     endif
 
@@ -9714,7 +9636,6 @@ contains
          config_use_ice_age, &
          config_use_first_year_ice, &
          config_use_level_ice, &
-         config_use_cesm_meltponds, &
          config_use_level_meltponds, &
          config_use_topo_meltponds, &
          config_use_aerosols, &
@@ -9743,7 +9664,6 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_use_ice_age", config_use_ice_age)
     call MPAS_pool_get_config(domain % configs, "config_use_first_year_ice", config_use_first_year_ice)
     call MPAS_pool_get_config(domain % configs, "config_use_level_ice", config_use_level_ice)
-    call MPAS_pool_get_config(domain % configs, "config_use_cesm_meltponds", config_use_cesm_meltponds)
     call MPAS_pool_get_config(domain % configs, "config_use_level_meltponds", config_use_level_meltponds)
     call MPAS_pool_get_config(domain % configs, "config_use_topo_meltponds", config_use_topo_meltponds)
     call MPAS_pool_get_config(domain % configs, "config_use_aerosols", config_use_aerosols)
@@ -9769,14 +9689,13 @@ contains
     if (config_use_skeletal_biochemistry .or. config_use_vertical_biochemistry) &
          use_nitrogen = .true.
 
-    use_meltponds = (config_use_cesm_meltponds .or. config_use_level_meltponds .or. config_use_topo_meltponds)
+    use_meltponds = (config_use_level_meltponds .or. config_use_topo_meltponds)
 
     call icepack_init_tracer_flags(&
          tr_iage_in      = config_use_ice_age, &
          tr_FY_in        = config_use_first_year_ice, &
          tr_lvl_in       = config_use_level_ice, &
          tr_pond_in      = use_meltponds, &
-         !tr_pond_cesm_in = config_use_cesm_meltponds, & ! deprecated
          tr_pond_lvl_in  = config_use_level_meltponds, &
          tr_pond_topo_in = config_use_topo_meltponds, &
          !tr_fsd_in       = , &

--- a/components/mpas-seaice/src/shared/mpas_seaice_initialize.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_initialize.F
@@ -641,6 +641,14 @@ contains
          colpkg_init_trcr, &
          colpkg_enthalpy_snow
 
+    use icepack_intfc, only: &
+         icepack_init_trcr, &
+         icepack_enthalpy_snow, &
+         icepack_warnings_aborted
+
+    use seaice_icepack, only: &
+         seaice_icepack_write_warnings
+
     type(block_type), intent(inout) :: &
          block !< Input/Output:
 
@@ -691,6 +699,9 @@ contains
          config_initial_latitude_north, &
          config_initial_latitude_south
 
+    character(len=strKIND), pointer :: &
+         config_column_physics_type
+
     integer :: &
          iCell, &
          iSnowLayer, &
@@ -702,6 +713,8 @@ contains
     call MPAS_pool_get_config(configs, "config_initial_snow_volume", config_initial_snow_volume)
     call MPAS_pool_get_config(configs, "config_initial_latitude_north", config_initial_latitude_north)
     call MPAS_pool_get_config(configs, "config_initial_latitude_south", config_initial_latitude_south)
+
+    call MPAS_pool_get_config(configs, "config_column_physics_type", config_column_physics_type)
 
     call MPAS_pool_get_subpool(block % structs, "mesh", mesh)
     call MPAS_pool_get_subpool(block % structs, "tracers", tracers)
@@ -744,30 +757,62 @@ contains
        surfaceTemperature(1,:,iCell) = seaFreezingTemperature(iCell)
        iceEnthalpy(:,:,iCell)        = 0.0_RKIND
 
-       do iSnowLayer = 1, nSnowLayers
-          snowEnthalpy(iSnowLayer,:,iCell) = colpkg_enthalpy_snow(0.0_RKIND)
-       end do
+       if (trim(config_column_physics_type) == "icepack") then
 
-       if (latCell(iCell) > config_initial_latitude_north * seaiceDegreesToRadians .or. &
-           latCell(iCell) < config_initial_latitude_south * seaiceDegreesToRadians) then
+          do iSnowLayer = 1, nSnowLayers
+             snowEnthalpy(iSnowLayer,:,iCell) = icepack_enthalpy_snow(0.0_RKIND)
+          end do
 
-          ! has ice
-          iceAreaCategory(1,1,iCell)    = config_initial_ice_area
-          iceVolumeCategory(1,1,iCell)  = config_initial_ice_volume
-          snowVolumeCategory(1,1,iCell) = config_initial_snow_volume
-          surfaceTemperature(1,1,iCell) = -1.0_RKIND
+          if (latCell(iCell) > config_initial_latitude_north * seaiceDegreesToRadians .or. &
+              latCell(iCell) < config_initial_latitude_south * seaiceDegreesToRadians) then
 
-          call colpkg_init_trcr(&
-               airTemperature(iCell), &
-               seaFreezingTemperature(iCell), &
-               initialSalinityProfile(:,iCell), &
-               initialMeltingTemperatureProfile(:,iCell), &
-               surfaceTemperature(1,1,iCell), &
-               nIceLayers, &
-               nSnowLayers, &
-               iceEnthalpy(:,1,iCell), &
-               snowEnthalpy(:,1,iCell))
-       endif
+             ! has ice
+             iceAreaCategory(1,1,iCell)    = config_initial_ice_area
+             iceVolumeCategory(1,1,iCell)  = config_initial_ice_volume
+             snowVolumeCategory(1,1,iCell) = config_initial_snow_volume
+             surfaceTemperature(1,1,iCell) = -1.0_RKIND
+
+             call icepack_init_trcr(&
+                  airTemperature(iCell), &
+                  seaFreezingTemperature(iCell), &
+                  initialSalinityProfile(:,iCell), &
+                  initialMeltingTemperatureProfile(:,iCell), &
+                  surfaceTemperature(1,1,iCell), &
+                  nIceLayers, &
+                  nSnowLayers, &
+                  iceEnthalpy(:,1,iCell), &
+                  snowEnthalpy(:,1,iCell))
+             call seaice_icepack_write_warnings(icepack_warnings_aborted())
+          endif
+
+       else if (trim(config_column_physics_type) == "column_package") then
+
+          do iSnowLayer = 1, nSnowLayers
+             snowEnthalpy(iSnowLayer,:,iCell) = colpkg_enthalpy_snow(0.0_RKIND)
+          end do
+
+          if (latCell(iCell) > config_initial_latitude_north * seaiceDegreesToRadians .or. &
+              latCell(iCell) < config_initial_latitude_south * seaiceDegreesToRadians) then
+
+             ! has ice
+             iceAreaCategory(1,1,iCell)    = config_initial_ice_area
+             iceVolumeCategory(1,1,iCell)  = config_initial_ice_volume
+             snowVolumeCategory(1,1,iCell) = config_initial_snow_volume
+             surfaceTemperature(1,1,iCell) = -1.0_RKIND
+
+             call colpkg_init_trcr(&
+                  airTemperature(iCell), &
+                  seaFreezingTemperature(iCell), &
+                  initialSalinityProfile(:,iCell), &
+                  initialMeltingTemperatureProfile(:,iCell), &
+                  surfaceTemperature(1,1,iCell), &
+                  nIceLayers, &
+                  nSnowLayers, &
+                  iceEnthalpy(:,1,iCell), &
+                  snowEnthalpy(:,1,iCell))
+          endif
+
+       endif ! config_column_physics_type
 
        iceAreaCell(iCell) = sum(iceAreaCategory(1,:,iCell))
        surfaceTemperatureCell(iCell) = -20.15_RKIND
@@ -1184,6 +1229,14 @@ contains
          colpkg_init_trcr, &
          colpkg_enthalpy_snow
 
+    use icepack_intfc, only: &
+         icepack_init_trcr, &
+         icepack_enthalpy_snow, &
+         icepack_warnings_aborted
+
+    use seaice_icepack, only: &
+         seaice_icepack_write_warnings
+
     type(block_type), intent(inout) :: &
          block !< Input/Output:
 
@@ -1225,6 +1278,9 @@ contains
          config_initial_ice_volume, &
          config_initial_snow_volume
 
+    character(len=strKIND), pointer :: &
+         config_column_physics_type
+
     integer :: &
          iCell, &
          iCategory, &
@@ -1234,6 +1290,7 @@ contains
     call MPAS_pool_get_config(configs, "config_initial_ice_area", config_initial_ice_area)
     call MPAS_pool_get_config(configs, "config_initial_ice_volume", config_initial_ice_volume)
     call MPAS_pool_get_config(configs, "config_initial_snow_volume", config_initial_snow_volume)
+    call MPAS_pool_get_config(configs, "config_column_physics_type", config_column_physics_type)
 
     call MPAS_pool_get_subpool(block % structs, "mesh", mesh)
     call MPAS_pool_get_subpool(block % structs, "tracers", tracers)
@@ -1263,25 +1320,52 @@ contains
 
     do iCell = 1, nCellsSolve
 
-       ! has ice
-       do iCategory = 1, nCategories
+       if (trim(config_column_physics_type) == "icepack") then
 
-          iceAreaCategory(1,iCategory,iCell)    = config_initial_ice_area
-          iceVolumeCategory(1,iCategory,iCell)  = config_initial_ice_volume
-          snowVolumeCategory(1,iCategory,iCell) = config_initial_snow_volume
+          ! has ice
+          do iCategory = 1, nCategories
 
-          call colpkg_init_trcr(&
-               airTemperature(iCell), &
-               seaFreezingTemperature(iCell), &
-               initialSalinityProfile(:,iCell), &
-               initialMeltingTemperatureProfile(:,iCell), &
-               surfaceTemperature(1,iCategory,iCell), &
-               nIceLayers, &
-               nSnowLayers, &
-               iceEnthalpy(:,iCategory,iCell), &
-               snowEnthalpy(:,iCategory,iCell))
+             iceAreaCategory(1,iCategory,iCell)    = config_initial_ice_area
+             iceVolumeCategory(1,iCategory,iCell)  = config_initial_ice_volume
+             snowVolumeCategory(1,iCategory,iCell) = config_initial_snow_volume
 
-       enddo ! iCategory
+             call icepack_init_trcr(&
+                  airTemperature(iCell), &
+                  seaFreezingTemperature(iCell), &
+                  initialSalinityProfile(:,iCell), &
+                  initialMeltingTemperatureProfile(:,iCell), &
+                  surfaceTemperature(1,iCategory,iCell), &
+                  nIceLayers, &
+                  nSnowLayers, &
+                  iceEnthalpy(:,iCategory,iCell), &
+                  snowEnthalpy(:,iCategory,iCell))
+             call seaice_icepack_write_warnings(icepack_warnings_aborted())
+
+          enddo ! iCategory
+
+       else if (trim(config_column_physics_type) == "column_package") then
+
+          ! has ice
+          do iCategory = 1, nCategories
+
+             iceAreaCategory(1,iCategory,iCell)    = config_initial_ice_area
+             iceVolumeCategory(1,iCategory,iCell)  = config_initial_ice_volume
+             snowVolumeCategory(1,iCategory,iCell) = config_initial_snow_volume
+
+             call colpkg_init_trcr(&
+                  airTemperature(iCell), &
+                  seaFreezingTemperature(iCell), &
+                  initialSalinityProfile(:,iCell), &
+                  initialMeltingTemperatureProfile(:,iCell), &
+                  surfaceTemperature(1,iCategory,iCell), &
+                  nIceLayers, &
+                  nSnowLayers, &
+                  iceEnthalpy(:,iCategory,iCell), &
+                  snowEnthalpy(:,iCategory,iCell))
+
+          enddo ! iCategory
+
+       endif ! config_column_physics_type
 
     enddo ! iCell
 

--- a/components/mpas-seaice/src/shared/mpas_seaice_initialize.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_initialize.F
@@ -171,6 +171,9 @@ contains
     ! special boundaries tracers
     call seaice_set_special_boundaries_tracers(domain)
 
+    ! check constants
+    call seaice_check_constants
+
   end subroutine seaice_init!}}}
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
@@ -2875,5 +2878,32 @@ contains
   end subroutine init_test_ice_shelf_mask
 
 !-----------------------------------------------------------------------
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  seaice_check_constants
+!
+!> \brief
+!> \author Elizabeth Hunke, LANL
+!> \date 29 September 2023
+!> \details
+!>
+!
+!-----------------------------------------------------------------------
+
+  subroutine seaice_check_constants
+
+    use seaice_constants, only: &
+         seaiceIceSnowEmissivity
+
+#ifdef CCSMCOUPLED
+    if (seaiceIceSnowEmissivity /= 1._RKIND) then
+      call mpas_log_write(&
+           'seaice_check_constants: seaiceIceSnowEmissivity out of bounds', &
+           messageType=MPAS_LOG_CRIT)
+    endif
+#endif
+
+  end subroutine seaice_check_constants
 
 end module seaice_initialize

--- a/components/mpas-seaice/src/shared/mpas_seaice_prescribed.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_prescribed.F
@@ -301,44 +301,43 @@ contains
 
                          temperatureGradient = seaFreezingTemperature(iCell) - surfaceTemperature(1,iCategory,iCell)
 
-!echmod - add icepack option for ice and snow quantities
                          if (trim(config_column_physics_type) == "icepack") then
 
-                         ! ice quantities
-                         do iIceLayer = 1, nIceLayers
+                            ! ice quantities
+                            do iIceLayer = 1, nIceLayers
 
-                            depth = (real(iIceLayer,kind=RKIND) - 0.5_RKIND) / real(nIceLayers,kind=RKIND)
-                            iceTemperature = surfaceTemperature(1,iCategory,iCell) + temperatureGradient * depth
-                            iceSalinity(iIceLayer,iCategory,iCell) = icepack_salinity_profile(depth)
-                            iceEnthalpy(iIceLayer,iCategory,iCell) = seaice_icepack_enthalpy_ice(iceTemperature,iceSalinity(iIceLayer,iCategory,iCell))
+                               depth = (real(iIceLayer,kind=RKIND) - 0.5_RKIND) / real(nIceLayers,kind=RKIND)
+                               iceTemperature = surfaceTemperature(1,iCategory,iCell) + temperatureGradient * depth
+                               iceSalinity(iIceLayer,iCategory,iCell) = icepack_salinity_profile(depth)
+                               iceEnthalpy(iIceLayer,iCategory,iCell) = seaice_icepack_enthalpy_ice(iceTemperature,iceSalinity(iIceLayer,iCategory,iCell))
 
-                         enddo ! iIceLayer
+                            enddo ! iIceLayer
 
-                         ! snow quantities
-                         do iSnowLayer = 1, nSnowLayers
-                            snowEnthalpy(iSnowLayer,iCategory,iCell) = icepack_enthalpy_snow(surfaceTemperature(1,iCategory,iCell))
-                         enddo ! iSnowLayer
+                            ! snow quantities
+                            do iSnowLayer = 1, nSnowLayers
+                               snowEnthalpy(iSnowLayer,iCategory,iCell) = icepack_enthalpy_snow(surfaceTemperature(1,iCategory,iCell))
+                            enddo ! iSnowLayer
 
                          else if (trim(config_column_physics_type) == "column_package") then
 
-                         ! ice quantities
-                         do iIceLayer = 1, nIceLayers
+                            ! ice quantities
+                            do iIceLayer = 1, nIceLayers
 
-                            depth = (real(iIceLayer,kind=RKIND) - 0.5_RKIND) / real(nIceLayers,kind=RKIND)
-                            iceTemperature = surfaceTemperature(1,iCategory,iCell) + temperatureGradient * depth
-                            iceSalinity(iIceLayer,iCategory,iCell) = colpkg_salinity_profile(depth)
-                            iceEnthalpy(iIceLayer,iCategory,iCell) = colpkg_enthalpy_ice(iceTemperature,iceSalinity(iIceLayer,iCategory,iCell))
+                               depth = (real(iIceLayer,kind=RKIND) - 0.5_RKIND) / real(nIceLayers,kind=RKIND)
+                               iceTemperature = surfaceTemperature(1,iCategory,iCell) + temperatureGradient * depth
+                               iceSalinity(iIceLayer,iCategory,iCell) = colpkg_salinity_profile(depth)
+                               iceEnthalpy(iIceLayer,iCategory,iCell) = colpkg_enthalpy_ice(iceTemperature,iceSalinity(iIceLayer,iCategory,iCell))
 
-                         enddo ! iIceLayer
+                            enddo ! iIceLayer
 
-                         ! snow quantities
-                         do iSnowLayer = 1, nSnowLayers
-                            snowEnthalpy(iSnowLayer,iCategory,iCell) = colpkg_enthalpy_snow(surfaceTemperature(1,iCategory,iCell))
-                         enddo ! iSnowLayer
+                            ! snow quantities
+                            do iSnowLayer = 1, nSnowLayers
+                               snowEnthalpy(iSnowLayer,iCategory,iCell) = colpkg_enthalpy_snow(surfaceTemperature(1,iCategory,iCell))
+                            enddo ! iSnowLayer
+
+                         endif ! config_column_physics_type
 
                       endif
-
-                      endif ! config_column_physics_type
 
                    else
 


### PR DESCRIPTION
Implement calls to icepack instead of colpkg for nonstandard configurations: ISPOL, uniform_1D, single_cell.

Set a single value for pi.  There are still 3 different variables: pi, pii, seaicePi (pi and pii are parameters; seaicePi is not).

Check that emissivity=1 in coupled configurations and abort if it is not.

Deprecate cesm ponds, 0-layer thermo and zsalinity.  These are fully deprecated in icepack, although the MPAS-SI icepack driver still includes some active zsalinity arguments for BGC; others are commented out in case we need them.  Icepack aborts if any of them are turned on.  The column driver also aborts if any of these are turned on, but the code is still available if the abort is manually removed.  Not tested.  

Update authorship in the icepack driver.

BFB in 3-month D cases.