### PR TITLE
Add configs

### DIFF
--- a/components/mpas-seaice/bld/build-namelist
+++ b/components/mpas-seaice/bld/build-namelist
@@ -861,7 +861,7 @@ add_default($nl, 'config_max_dry_snow_radius');
 
 add_default($nl, 'config_snow_to_ice_transition_depth');
 add_default($nl, 'config_pond_refreezing_type');
-add_default($nl, 'config_pond_flushing_timescale');
+add_default($nl, 'config_pond_flushing_factor');
 add_default($nl, 'config_min_meltwater_retained_fraction');
 add_default($nl, 'config_max_meltwater_retained_fraction');
 add_default($nl, 'config_pond_depth_to_fraction_ratio');
@@ -901,7 +901,7 @@ add_default($nl, 'config_floediam');
 add_default($nl, 'config_ice_strength_formulation');
 add_default($nl, 'config_ridging_participation_function');
 add_default($nl, 'config_ridging_redistribution_function');
-add_default($nl, 'config_ridiging_efolding_scale');
+add_default($nl, 'config_ridging_efolding_scale');
 add_default($nl, 'config_ratio_ridging_work_to_PE');
 
 ##############################

--- a/components/mpas-seaice/bld/build-namelist
+++ b/components/mpas-seaice/bld/build-namelist
@@ -882,6 +882,7 @@ add_default($nl, 'config_rapid_model_critical_Ra');
 add_default($nl, 'config_rapid_mode_aspect_ratio');
 add_default($nl, 'config_slow_mode_drainage_strength');
 add_default($nl, 'config_slow_mode_critical_porosity');
+add_default($nl, 'config_macro_drainage_timescale');
 add_default($nl, 'config_congelation_ice_porosity');
 
 #######################

--- a/components/mpas-seaice/bld/build-namelist
+++ b/components/mpas-seaice/bld/build-namelist
@@ -840,6 +840,9 @@ add_default($nl, 'config_snow_shortwave_tuning_parameter');
 add_default($nl, 'config_temp_change_snow_grain_radius_change');
 add_default($nl, 'config_max_melting_snow_grain_radius');
 add_default($nl, 'config_algae_absorption_coefficient');
+add_default($nl, 'config_use_shortwave_redistribution');
+add_default($nl, 'config_shortwave_redistribution_fraction');
+add_default($nl, 'config_shortwave_redistribution_threshold');
 
 ########################
 # Namelist group: snow #

--- a/components/mpas-seaice/bld/build-namelist-section
+++ b/components/mpas-seaice/bld/build-namelist-section
@@ -398,6 +398,7 @@ add_default($nl, 'config_rapid_model_critical_Ra');
 add_default($nl, 'config_rapid_mode_aspect_ratio');
 add_default($nl, 'config_slow_mode_drainage_strength');
 add_default($nl, 'config_slow_mode_critical_porosity');
+add_default($nl, 'config_macro_drainage_timescale');
 add_default($nl, 'config_congelation_ice_porosity');
 
 #######################

--- a/components/mpas-seaice/bld/build-namelist-section
+++ b/components/mpas-seaice/bld/build-namelist-section
@@ -356,6 +356,9 @@ add_default($nl, 'config_snow_shortwave_tuning_parameter');
 add_default($nl, 'config_temp_change_snow_grain_radius_change');
 add_default($nl, 'config_max_melting_snow_grain_radius');
 add_default($nl, 'config_algae_absorption_coefficient');
+add_default($nl, 'config_use_shortwave_redistribution');
+add_default($nl, 'config_shortwave_redistribution_fraction');
+add_default($nl, 'config_shortwave_redistribution_threshold');
 
 ########################
 # Namelist group: snow #

--- a/components/mpas-seaice/bld/build-namelist-section
+++ b/components/mpas-seaice/bld/build-namelist-section
@@ -377,7 +377,7 @@ add_default($nl, 'config_max_dry_snow_radius');
 
 add_default($nl, 'config_snow_to_ice_transition_depth');
 add_default($nl, 'config_pond_refreezing_type');
-add_default($nl, 'config_pond_flushing_timescale');
+add_default($nl, 'config_pond_flushing_factor');
 add_default($nl, 'config_min_meltwater_retained_fraction');
 add_default($nl, 'config_max_meltwater_retained_fraction');
 add_default($nl, 'config_pond_depth_to_fraction_ratio');
@@ -418,7 +418,7 @@ add_default($nl, 'config_floediam');
 add_default($nl, 'config_ice_strength_formulation');
 add_default($nl, 'config_ridging_participation_function');
 add_default($nl, 'config_ridging_redistribution_function');
-add_default($nl, 'config_ridiging_efolding_scale');
+add_default($nl, 'config_ridging_efolding_scale');
 add_default($nl, 'config_ratio_ridging_work_to_PE');
 
 ##############################

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -369,7 +369,7 @@
 <!-- meltponds -->
 <config_snow_to_ice_transition_depth>0.0</config_snow_to_ice_transition_depth>
 <config_pond_refreezing_type>'hlid'</config_pond_refreezing_type>
-<config_pond_flushing_timescale>1.0e-3</config_pond_flushing_timescale>
+<config_pond_flushing_factor>1.0e-3</config_pond_flushing_factor>
 <config_min_meltwater_retained_fraction>0.15</config_min_meltwater_retained_fraction>
 <config_max_meltwater_retained_fraction>1.0</config_max_meltwater_retained_fraction>
 <config_pond_depth_to_fraction_ratio>0.8</config_pond_depth_to_fraction_ratio>
@@ -398,7 +398,7 @@
 <config_ice_strength_formulation>'Rothrock75'</config_ice_strength_formulation>
 <config_ridging_participation_function>'exponential'</config_ridging_participation_function>
 <config_ridging_redistribution_function>'exponential'</config_ridging_redistribution_function>
-<config_ridiging_efolding_scale>3.0</config_ridiging_efolding_scale>
+<config_ridging_efolding_scale>3.0</config_ridging_efolding_scale>
 <config_ratio_ridging_work_to_PE>17.0</config_ratio_ridging_work_to_PE>
 
 <!-- atmosphere -->

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -387,6 +387,7 @@
 <config_rapid_mode_aspect_ratio>1.0</config_rapid_mode_aspect_ratio>
 <config_slow_mode_drainage_strength>-5.0e-8</config_slow_mode_drainage_strength>
 <config_slow_mode_critical_porosity>0.05</config_slow_mode_critical_porosity>
+<config_macro_drainage_timescale>10.</config_macro_drainage_timescale>
 <config_congelation_ice_porosity>0.85</config_congelation_ice_porosity>
 
 <!-- itd -->

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -354,6 +354,9 @@
 <config_temp_change_snow_grain_radius_change>1.5</config_temp_change_snow_grain_radius_change>
 <config_max_melting_snow_grain_radius>1500.0</config_max_melting_snow_grain_radius>
 <config_algae_absorption_coefficient>0.6</config_algae_absorption_coefficient>
+<config_use_shortwave_redistribution>false</config_use_shortwave_redistribution>
+<config_shortwave_redistribution_fraction>0.9</config_shortwave_redistribution_fraction>
+<config_shortwave_redistribution_threshold>0.02</config_shortwave_redistribution_threshold>
 
 <!-- snow -->
 <config_snow_redistribution_scheme>'ITDrdg'</config_snow_redistribution_scheme>

--- a/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
@@ -2461,6 +2461,14 @@ Valid values: Any real number between 0 and 1.
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_macro_drainage_timescale" type="real"
+	category="thermodynamics" group="thermodynamics">
+Timescale for macroscopic drainage.
+
+Valid values: Any positive real number.
+Default: Defined in namelist_defaults.xml
+</entry>
+
 <entry id="config_congelation_ice_porosity" type="real"
 	category="thermodynamics" group="thermodynamics">
 Liquid fraction of congelation ice.

--- a/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
@@ -2330,9 +2330,9 @@ Valid values: 'cesm' or 'hlid'
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_pond_flushing_timescale" type="real"
+<entry id="config_pond_flushing_factor" type="real"
 	category="meltponds" group="meltponds">
-Alter e-folding time scale for flushing.?????
+Alters e-folding time scale for flushing with BL99 thermodynamics.
 
 Valid values:
 Default: Defined in namelist_defaults.xml
@@ -2508,7 +2508,7 @@ Valid values: 'Hibler80' or 'exponential'
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_ridiging_efolding_scale" type="real"
+<entry id="config_ridging_efolding_scale" type="real"
 	category="ridging" group="ridging">
 E-folding scale of ridged ice (krdg_redist = 1)
 

--- a/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
@@ -2236,6 +2236,30 @@ Valid values:
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_use_shortwave_redistribution" type="logical"
+	category="shortwave" group="shortwave">
+Redistribute shortwave from layers near the melting temperature to the surface.
+
+Valid values: true or false
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_shortwave_redistribution_fraction" type="real"
+	category="shortwave" group="shortwave">
+Fraction of shortwave moved from a layer near the melting temperature to the surface.
+
+Valid values: fraction between 0 and 1
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_shortwave_redistribution_threshold" type="real"
+	category="shortwave" group="shortwave">
+Temperature threshold for moving shortwave to the surface.
+
+Valid values:
+Default: Defined in namelist_defaults.xml
+</entry>
+
 
 <!-- snow -->
 

--- a/components/mpas-seaice/src/Registry.xml
+++ b/components/mpas-seaice/src/Registry.xml
@@ -1727,6 +1727,11 @@
 			possible_values="Any real number between 0 and 1."
 			icepack_name="phi_c_slow_mode"
 		/>
+		<nml_option name="config_macro_drainage_timescale" type="real" default_value="10." units="days"
+			description="Timescale for macroscopic drainage."
+			possible_values="Any positive real number."
+			icepack_name="tscale_pnd_drain"
+		/>
 		<nml_option name="config_congelation_ice_porosity" type="real" default_value="0.85" units="unitless"
 			description="Liquid fraction of congelation ice."
 			possible_values="Any real number between 0 and 1."

--- a/components/mpas-seaice/src/Registry.xml
+++ b/components/mpas-seaice/src/Registry.xml
@@ -1644,8 +1644,8 @@
 			possible_values="'cesm' or 'hlid'"
 			icepack_name="frzpnd"
 		/>
-		<nml_option name="config_pond_flushing_timescale" type="real" default_value="1.0e-3" units=""
-			description="Alter e-folding time scale for flushing.?????"
+		<nml_option name="config_pond_flushing_factor" type="real" default_value="1.0e-3" units=""
+			description="Alters e-folding time scale for flushing with BL99 thermodynamics."
 			possible_values=""
 			icepack_name="dpscale"
 		/>
@@ -1761,7 +1761,7 @@
 			possible_values="'Hibler80' or 'exponential'"
 			icepack_name="krdg_redist"
 		/>
-		<nml_option name="config_ridiging_efolding_scale" type="real" default_value="3.0" units="m^0.5"
+		<nml_option name="config_ridging_efolding_scale" type="real" default_value="3.0" units="m^0.5"
 			description="E-folding scale of ridged ice (krdg_redist = 1)"
 			possible_values=""
 			icepack_name="mu_rdg"

--- a/components/mpas-seaice/src/Registry.xml
+++ b/components/mpas-seaice/src/Registry.xml
@@ -1583,6 +1583,21 @@
 			possible_values=""
 			icepack_name="kalg"
 		/>
+		<nml_option name="config_use_shortwave_redistribution" type="logical" default_value="false" units="none"
+			description="redistribution shortwave from layers near the melting temperature"
+			possible_values="true or false"
+			icepack_name="sw_redist"
+		/>
+		<nml_option name="config_shortwave_redistribution_fraction" type="real" default_value="0.9" units="none"
+			description="Fraction of shortwave moved from a layer near the melting temperature to the surface."
+			possible_values="fraction between 0 and 1"
+			icepack_name="sw_frac"
+		/>
+		<nml_option name="config_shortwave_redistribution_threshold" type="real" default_value="0.02" units="C"
+			description="Temperature threshold for moving shortwave to the surface."
+			possible_values=""
+			icepack_name="sw_dtemp"
+		/>
 	</nml_record>
 
 	<nml_record name="snow" in_defaults="true">

--- a/components/mpas-seaice/src/shared/mpas_seaice_column.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_column.F
@@ -11011,10 +11011,10 @@ contains
          config_temp_change_snow_grain_radius_change, &
          config_max_melting_snow_grain_radius, &
          config_algae_absorption_coefficient, &
-         config_ridiging_efolding_scale, &
+         config_ridging_efolding_scale, &
          config_ratio_ridging_work_to_PE, &
          config_snow_to_ice_transition_depth, &
-         config_pond_flushing_timescale, &
+         config_pond_flushing_factor, &
          config_min_meltwater_retained_fraction, &
          config_max_meltwater_retained_fraction, &
          config_pond_depth_to_fraction_ratio, &
@@ -11183,7 +11183,7 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_ice_strength_formulation", config_ice_strength_formulation)
     call MPAS_pool_get_config(domain % configs, "config_ridging_participation_function", config_ridging_participation_function)
     call MPAS_pool_get_config(domain % configs, "config_ridging_redistribution_function", config_ridging_redistribution_function)
-    call MPAS_pool_get_config(domain % configs, "config_ridiging_efolding_scale", config_ridiging_efolding_scale)
+    call MPAS_pool_get_config(domain % configs, "config_ridging_efolding_scale", config_ridging_efolding_scale)
     call MPAS_pool_get_config(domain % configs, "config_ratio_ridging_work_to_PE", config_ratio_ridging_work_to_PE)
     call MPAS_pool_get_config(domain % configs, "config_atmos_boundary_method", config_atmos_boundary_method)
     call MPAS_pool_get_config(domain % configs, "config_calc_surface_stresses", config_calc_surface_stresses)
@@ -11196,7 +11196,7 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_category_bounds_type", config_category_bounds_type)
     call MPAS_pool_get_config(domain % configs, "config_snow_to_ice_transition_depth", config_snow_to_ice_transition_depth)
     call MPAS_pool_get_config(domain % configs, "config_pond_refreezing_type", config_pond_refreezing_type)
-    call MPAS_pool_get_config(domain % configs, "config_pond_flushing_timescale", config_pond_flushing_timescale)
+    call MPAS_pool_get_config(domain % configs, "config_pond_flushing_factor", config_pond_flushing_factor)
     call MPAS_pool_get_config(domain % configs, "config_min_meltwater_retained_fraction", config_min_meltwater_retained_fraction)
     call MPAS_pool_get_config(domain % configs, "config_max_meltwater_retained_fraction", config_max_meltwater_retained_fraction)
     call MPAS_pool_get_config(domain % configs, "config_pond_depth_to_fraction_ratio", config_pond_depth_to_fraction_ratio)
@@ -11384,7 +11384,7 @@ contains
          config_cice_int("config_ice_strength_formulation", config_ice_strength_formulation), &
          config_cice_int("config_ridging_participation_function", config_ridging_participation_function), &
          config_cice_int("config_ridging_redistribution_function", config_ridging_redistribution_function), &
-         config_ridiging_efolding_scale, &
+         config_ridging_efolding_scale, &
          config_ratio_ridging_work_to_PE, &
          config_atmos_boundary_method, &
          config_calc_surface_stresses, &
@@ -11397,7 +11397,7 @@ contains
          config_cice_int("config_category_bounds_type", config_category_bounds_type), &
          config_snow_to_ice_transition_depth, &
          config_pond_refreezing_type, &
-         config_pond_flushing_timescale, &
+         config_pond_flushing_factor, &
          config_min_meltwater_retained_fraction, &
          config_max_meltwater_retained_fraction, &
          config_pond_depth_to_fraction_ratio, &
@@ -11678,7 +11678,7 @@ contains
     ! mu_rdg:
     ! gives e-folding scale of ridged ice (m^.5)
     ! (krdg_redist = 1)
-    !mu_rdg = config_ridiging_efolding_scale
+    !mu_rdg = config_ridging_efolding_scale
 
     ! Cf
     ! ratio of ridging work to PE change in ridging (kstrength = 1)
@@ -11759,8 +11759,8 @@ contains
     !frzpnd = config_pond_refreezing_type
 
     ! dpscale:
-    ! alter e-folding time scale for flushing
-    !dpscale = config_pond_flushing_timescale
+    ! alters e-folding time scale for flushing with BL99 thermodynamics
+    !dpscale = config_pond_flushing_factor
 
     ! rfracmin:
     ! minimum retained fraction of meltwater

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -11570,7 +11570,8 @@ contains
          config_use_skeletal_biochemistry, &
          config_use_modal_aerosols, &
          config_use_snow_liquid_ponds, &
-         config_use_snow_grain_radius
+         config_use_snow_grain_radius, &
+         config_use_shortwave_redistribution
 
     real(kind=RKIND), pointer :: &
          config_min_friction_velocity, &
@@ -11591,6 +11592,8 @@ contains
          config_ice_shortwave_tuning_parameter, &
          config_pond_shortwave_tuning_parameter, &
          config_snow_shortwave_tuning_parameter, &
+         config_shortwave_redistribution_fraction, &
+         config_shortwave_redistribution_threshold, &
          config_temp_change_snow_grain_radius_change, &
          config_max_melting_snow_grain_radius, &
          config_algae_absorption_coefficient, &
@@ -11751,7 +11754,7 @@ contains
          config_itd_conversion_type_int, &
          config_category_bounds_type_int
 
-    character(len=strKIND) :: tmp_config_shortwave
+    character(len=strKIND) :: tmp_config_shortwave_type
     character(len=strKIND) :: tmp_config_snw_ssp_table
     character(len=strKIND) :: snw_aging_table = 'snicar'
 
@@ -11787,6 +11790,9 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_ice_shortwave_tuning_parameter", config_ice_shortwave_tuning_parameter)
     call MPAS_pool_get_config(domain % configs, "config_pond_shortwave_tuning_parameter", config_pond_shortwave_tuning_parameter)
     call MPAS_pool_get_config(domain % configs, "config_snow_shortwave_tuning_parameter", config_snow_shortwave_tuning_parameter)
+    call MPAS_pool_get_config(domain % configs, "config_use_shortwave_redistribution", config_use_shortwave_redistribution)
+    call MPAS_pool_get_config(domain % configs, "config_shortwave_redistribution_fraction", config_shortwave_redistribution_fraction)
+    call MPAS_pool_get_config(domain % configs, "config_shortwave_redistribution_threshold", config_shortwave_redistribution_threshold)
     call MPAS_pool_get_config(domain % configs, "config_temp_change_snow_grain_radius_change", &
                                                  config_temp_change_snow_grain_radius_change)
     call MPAS_pool_get_config(domain % configs, "config_max_melting_snow_grain_radius", config_max_melting_snow_grain_radius)
@@ -11980,11 +11986,11 @@ contains
     config_category_bounds_type_int = config_cice_int("config_category_bounds_type", config_category_bounds_type)
 
     if (config_use_snicar_ad .and. (trim(config_shortwave_type(1:4)) == "dEdd")) then
-       tmp_config_shortwave     = 'dEdd_snicar_ad'
-       tmp_config_snw_ssp_table = 'snicar'
+       tmp_config_shortwave_type = 'dEdd_snicar_ad'
+       tmp_config_snw_ssp_table  = 'snicar'
     else
-       tmp_config_shortwave     = config_shortwave_type
-       tmp_config_snw_ssp_table = 'test'
+       tmp_config_shortwave_type = config_shortwave_type
+       tmp_config_snw_ssp_table  = 'test'
     endif
 
 !echmod debugging
@@ -12201,7 +12207,7 @@ contains
          phi_c_slow_mode_in      = config_slow_mode_critical_porosity, &
          phi_i_mushy_in          = config_congelation_ice_porosity, &
 !         shortwave_in            = config_shortwave_type, &
-         shortwave_in            = tmp_config_shortwave, &
+         shortwave_in            = tmp_config_shortwave_type, &
          albedo_type_in          = config_albedo_type, &
          albsnowi_in             = config_infrared_snow_albedo, &
          albicev_in              = config_visible_ice_albedo, &
@@ -12275,9 +12281,9 @@ contains
          !t_sk_conv_in            = , &
          !t_sk_ox_in              = , &
          !frazil_scav_in          = , &
-         !sw_redist_in            = , &        ! not yet implemented in MPAS-SI (stealth feature)
-         !sw_frac_in              = , &        ! not yet implemented in MPAS-SI (stealth feature)
-         !sw_dtemp_in             = , &        ! not yet implemented in MPAS-SI (stealth feature)
+         sw_redist_in            = config_use_shortwave_redistribution, &
+         sw_frac_in              = config_shortwave_redistribution_fraction, &
+         sw_dtemp_in             = config_shortwave_redistribution_threshold, &
          snwgrain_in             = config_use_snow_grain_radius, &
          snwredist_in            = config_snow_redistribution_scheme, &
          use_smliq_pnd_in        = config_use_snow_liquid_ponds, &
@@ -12589,6 +12595,18 @@ contains
     ! R_snw:
     ! snow tuning parameter; +1 > ~.01 change in broadband albedo
     !R_snw = config_snow_shortwave_tuning_parameter
+
+    ! sw_redist
+    ! Redistribute shortwave from layers near the melting temperature to the surface
+    !sw_redist = config_use_shortwave_redistribution
+
+    ! sw_frac
+    ! Fraction of shortwave moved from layers near the melting temperature to the surface
+    !sw_frac = config_shortwave_redistribution_fraction
+
+    ! sw_dtemp
+    ! Temperature threshold for moving shortwave to the surface
+    !sw_dtemp = config_shortwave_redistribution_threshold
 
     ! dT_mlt:
     ! change in temp for non-melt to melt snow grain radius change (C)

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -11580,6 +11580,7 @@ contains
          config_rapid_mode_aspect_ratio, &
          config_slow_mode_drainage_strength, &
          config_slow_mode_critical_porosity, &
+         config_macro_drainage_timescale, &
          config_congelation_ice_porosity, &
 !         config_frazil_ice_porosity, &
 !         config_frazil_salinity_reduction, &
@@ -11775,6 +11776,7 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_rapid_mode_aspect_ratio", config_rapid_mode_aspect_ratio)
     call MPAS_pool_get_config(domain % configs, "config_slow_mode_drainage_strength", config_slow_mode_drainage_strength)
     call MPAS_pool_get_config(domain % configs, "config_slow_mode_critical_porosity", config_slow_mode_critical_porosity)
+    call MPAS_pool_get_config(domain % configs, "config_macro_drainage_timescale", config_macro_drainage_timescale)
     call MPAS_pool_get_config(domain % configs, "config_congelation_ice_porosity", config_congelation_ice_porosity)
 !    call MPAS_pool_get_config(domain % configs, "config_frazil_ice_porosity", config_frazil_ice_porosity)
 !    call MPAS_pool_get_config(domain % configs, "config_frazil_salinity_reduction", config_frazil_salinity_reduction)
@@ -12206,6 +12208,7 @@ contains
          dSdt_slow_mode_in       = config_slow_mode_drainage_strength, &
          phi_c_slow_mode_in      = config_slow_mode_critical_porosity, &
          phi_i_mushy_in          = config_congelation_ice_porosity, &
+         tscale_pnd_drain_in     = config_macro_drainage_timescale, &
 !         shortwave_in            = config_shortwave_type, &
          shortwave_in            = tmp_config_shortwave_type, &
          albedo_type_in          = config_albedo_type, &
@@ -12530,6 +12533,10 @@ contains
     ! phi_c_slow_mode:
     ! liquid fraction porosity cutoff for slow mode
     !phi_c_slow_mode = config_slow_mode_critical_porosity
+
+    ! tscale_pnd_drain:
+    ! Timescale for macroscopic drainage
+    !tscale_pnd_drain = config_macro_drainage_timescale
 
     ! phi_i_mushy:
     ! liquid fraction of congelation ice

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -10116,10 +10116,10 @@ contains
          config_temp_change_snow_grain_radius_change, &
          config_max_melting_snow_grain_radius, &
          config_algae_absorption_coefficient, &
-         config_ridiging_efolding_scale, &
+         config_ridging_efolding_scale, &
          config_ratio_ridging_work_to_PE, &
          config_snow_to_ice_transition_depth, &
-         config_pond_flushing_timescale, &
+         config_pond_flushing_factor, &
          config_min_meltwater_retained_fraction, &
          config_max_meltwater_retained_fraction, &
          config_pond_depth_to_fraction_ratio, &
@@ -10288,7 +10288,7 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_ice_strength_formulation", config_ice_strength_formulation)
     call MPAS_pool_get_config(domain % configs, "config_ridging_participation_function", config_ridging_participation_function)
     call MPAS_pool_get_config(domain % configs, "config_ridging_redistribution_function", config_ridging_redistribution_function)
-    call MPAS_pool_get_config(domain % configs, "config_ridiging_efolding_scale", config_ridiging_efolding_scale)
+    call MPAS_pool_get_config(domain % configs, "config_ridging_efolding_scale", config_ridging_efolding_scale)
     call MPAS_pool_get_config(domain % configs, "config_ratio_ridging_work_to_PE", config_ratio_ridging_work_to_PE)
     call MPAS_pool_get_config(domain % configs, "config_atmos_boundary_method", config_atmos_boundary_method)
     call MPAS_pool_get_config(domain % configs, "config_calc_surface_stresses", config_calc_surface_stresses)
@@ -10301,7 +10301,7 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_category_bounds_type", config_category_bounds_type)
     call MPAS_pool_get_config(domain % configs, "config_snow_to_ice_transition_depth", config_snow_to_ice_transition_depth)
     call MPAS_pool_get_config(domain % configs, "config_pond_refreezing_type", config_pond_refreezing_type)
-    call MPAS_pool_get_config(domain % configs, "config_pond_flushing_timescale", config_pond_flushing_timescale)
+    call MPAS_pool_get_config(domain % configs, "config_pond_flushing_factor", config_pond_flushing_factor)
     call MPAS_pool_get_config(domain % configs, "config_min_meltwater_retained_fraction", config_min_meltwater_retained_fraction)
     call MPAS_pool_get_config(domain % configs, "config_max_meltwater_retained_fraction", config_max_meltwater_retained_fraction)
     call MPAS_pool_get_config(domain % configs, "config_pond_depth_to_fraction_ratio", config_pond_depth_to_fraction_ratio)
@@ -10489,7 +10489,7 @@ contains
          config_cice_int("config_ice_strength_formulation", config_ice_strength_formulation), &
          config_cice_int("config_ridging_participation_function", config_ridging_participation_function), &
          config_cice_int("config_ridging_redistribution_function", config_ridging_redistribution_function), &
-         config_ridiging_efolding_scale, &
+         config_ridging_efolding_scale, &
          config_ratio_ridging_work_to_PE, &
          config_atmos_boundary_method, &
          config_calc_surface_stresses, &
@@ -10502,7 +10502,7 @@ contains
          config_cice_int("config_category_bounds_type", config_category_bounds_type), &
          config_snow_to_ice_transition_depth, &
          config_pond_refreezing_type, &
-         config_pond_flushing_timescale, &
+         config_pond_flushing_factor, &
          config_min_meltwater_retained_fraction, &
          config_max_meltwater_retained_fraction, &
          config_pond_depth_to_fraction_ratio, &
@@ -10782,7 +10782,7 @@ contains
     ! mu_rdg:
     ! gives e-folding scale of ridged ice (m^.5)
     ! (krdg_redist = 1)
-    !mu_rdg = config_ridiging_efolding_scale
+    !mu_rdg = config_ridging_efolding_scale
 
     ! Cf
     ! ratio of ridging work to PE change in ridging (kstrength = 1)
@@ -10863,8 +10863,8 @@ contains
     !frzpnd = config_pond_refreezing_type
 
     ! dpscale:
-    ! alter e-folding time scale for flushing
-    !dpscale = config_pond_flushing_timescale
+    ! alters e-folding time scale for flushing with BL99 thermodynamics
+    !dpscale = config_pond_flushing_factor
 
     ! rfracmin:
     ! minimum retained fraction of meltwater
@@ -11594,10 +11594,10 @@ contains
          config_temp_change_snow_grain_radius_change, &
          config_max_melting_snow_grain_radius, &
          config_algae_absorption_coefficient, &
-         config_ridiging_efolding_scale, &
+         config_ridging_efolding_scale, &
          config_ratio_ridging_work_to_PE, &
          config_snow_to_ice_transition_depth, &
-         config_pond_flushing_timescale, &
+         config_pond_flushing_factor, &
          config_min_meltwater_retained_fraction, &
          config_max_meltwater_retained_fraction, &
          config_pond_depth_to_fraction_ratio, &
@@ -11794,7 +11794,7 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_ice_strength_formulation", config_ice_strength_formulation)
     call MPAS_pool_get_config(domain % configs, "config_ridging_participation_function", config_ridging_participation_function)
     call MPAS_pool_get_config(domain % configs, "config_ridging_redistribution_function", config_ridging_redistribution_function)
-    call MPAS_pool_get_config(domain % configs, "config_ridiging_efolding_scale", config_ridiging_efolding_scale)
+    call MPAS_pool_get_config(domain % configs, "config_ridging_efolding_scale", config_ridging_efolding_scale)
     call MPAS_pool_get_config(domain % configs, "config_ratio_ridging_work_to_PE", config_ratio_ridging_work_to_PE)
     call MPAS_pool_get_config(domain % configs, "config_atmos_boundary_method", config_atmos_boundary_method)
     call MPAS_pool_get_config(domain % configs, "config_calc_surface_stresses", config_calc_surface_stresses)
@@ -11808,7 +11808,7 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_snow_to_ice_transition_depth", config_snow_to_ice_transition_depth)
     call MPAS_pool_get_config(domain % configs, "config_pond_refreezing_type", config_pond_refreezing_type)
     call MPAS_pool_get_config(domain % configs, "config_salt_flux_coupling_type", config_salt_flux_coupling_type)
-    call MPAS_pool_get_config(domain % configs, "config_pond_flushing_timescale", config_pond_flushing_timescale)
+    call MPAS_pool_get_config(domain % configs, "config_pond_flushing_factor", config_pond_flushing_factor)
     call MPAS_pool_get_config(domain % configs, "config_min_meltwater_retained_fraction", config_min_meltwater_retained_fraction)
     call MPAS_pool_get_config(domain % configs, "config_max_meltwater_retained_fraction", config_max_meltwater_retained_fraction)
     call MPAS_pool_get_config(domain % configs, "config_pond_depth_to_fraction_ratio", config_pond_depth_to_fraction_ratio)
@@ -12217,7 +12217,7 @@ contains
          kstrength_in            = config_ice_strength_formulation_int, &
          krdg_partic_in          = config_ridging_participation_function_int, &
          krdg_redist_in          = config_ridging_redistribution_function_int, &
-         mu_rdg_in               = config_ridiging_efolding_scale, &
+         mu_rdg_in               = config_ridging_efolding_scale, &
          atmbndy_in              = config_atmos_boundary_method, &
          calc_strair_in          = config_calc_surface_stresses, &
          formdrag_in             = config_use_form_drag, &
@@ -12235,7 +12235,7 @@ contains
          !wave_spec_in            = , &        ! not yet implemented in MPAS-SI (stealth feature)
          !wave_spec_type_in       = , &        ! not yet implemented in MPAS-SI (stealth feature)
          !nfreq_in                = , &        ! not yet implemented in MPAS-SI (stealth feature)
-         dpscale_in              = config_pond_flushing_timescale, &
+         dpscale_in              = config_pond_flushing_factor, &
          rfracmin_in             = config_min_meltwater_retained_fraction, &
          rfracmax_in             = config_max_meltwater_retained_fraction, &
          pndaspect_in            = config_pond_depth_to_fraction_ratio, &
@@ -12624,7 +12624,7 @@ contains
     ! mu_rdg:
     ! gives e-folding scale of ridged ice (m^.5)
     ! (krdg_redist = 1)
-    !mu_rdg = config_ridiging_efolding_scale
+    !mu_rdg = config_ridging_efolding_scale
 
     ! Cf
     ! ratio of ridging work to PE change in ridging (kstrength = 1)
@@ -12705,8 +12705,8 @@ contains
     !frzpnd = config_pond_refreezing_type
 
     ! dpscale:
-    ! alter e-folding time scale for flushing
-    !dpscale = config_pond_flushing_timescale
+    ! alters e-folding time scale for flushing with BL99 thermodynamics
+    !dpscale = config_pond_flushing_factor
 
     ! rfracmin:
     ! minimum retained fraction of meltwater


### PR DESCRIPTION
Add or update namelist configuration flags:

- Change `config_pond_flushing_timescale` to `config_pond_flushing_factor`
- Fix spelling in `config_ridiging_efolding_scale`
- Add `config_use_shortwave redistribution`, `config_shortwave_redistribution_fraction`, `config_shortwave_redistribution_threshold`

BFB in 3-month D cases.