### PR TITLE
Adds and amends critical parameters to MPAS 

### DIFF
--- a/components/mpas-seaice/bld/build-namelist
+++ b/components/mpas-seaice/bld/build-namelist
@@ -531,7 +531,6 @@ add_default($nl, 'config_nCategories');
 add_default($nl, 'config_nFloeCategories');
 add_default($nl, 'config_nIceLayers');
 add_default($nl, 'config_nSnowLayers');
-add_default($nl, 'config_nFloeCategories');
 
 ##############################
 # Namelist group: initialize #

--- a/components/mpas-seaice/bld/build-namelist
+++ b/components/mpas-seaice/bld/build-namelist
@@ -936,6 +936,7 @@ if ($iceberg_mode eq 'data') {
 }
 add_default($nl, 'config_salt_flux_coupling_type');
 add_default($nl, 'config_couple_biogeochemistry_fields');
+add_default($nl, 'config_ice_ocean_drag_coefficient');
 
 ###############################
 # Namelist group: diagnostics #

--- a/components/mpas-seaice/bld/build-namelist
+++ b/components/mpas-seaice/bld/build-namelist
@@ -853,6 +853,7 @@ add_default($nl, 'config_minimum_wind_compaction');
 add_default($nl, 'config_wind_compaction_factor');
 add_default($nl, 'config_snow_redistribution_factor');
 add_default($nl, 'config_max_dry_snow_radius');
+add_default($nl, 'config_snow_thermal_conductivity');
 
 #############################
 # Namelist group: meltponds #

--- a/components/mpas-seaice/bld/build-namelist-section
+++ b/components/mpas-seaice/bld/build-namelist-section
@@ -68,9 +68,9 @@ add_default($nl, 'config_do_restart_snow_grain_radius');
 ##############################
 
 add_default($nl, 'config_nCategories');
+add_default($nl, 'config_nFloeCategories');
 add_default($nl, 'config_nIceLayers');
 add_default($nl, 'config_nSnowLayers');
-add_default($nl, 'config_nFloeCategories');
 
 ##############################
 # Namelist group: initialize #

--- a/components/mpas-seaice/bld/build-namelist-section
+++ b/components/mpas-seaice/bld/build-namelist-section
@@ -370,6 +370,7 @@ add_default($nl, 'config_minimum_wind_compaction');
 add_default($nl, 'config_wind_compaction_factor');
 add_default($nl, 'config_snow_redistribution_factor');
 add_default($nl, 'config_max_dry_snow_radius');
+add_default($nl, 'config_snow_thermal_conductivity');
 
 #############################
 # Namelist group: meltponds #

--- a/components/mpas-seaice/bld/build-namelist-section
+++ b/components/mpas-seaice/bld/build-namelist-section
@@ -445,6 +445,7 @@ add_default($nl, 'config_ocean_surface_type');
 add_default($nl, 'config_couple_biogeochemistry_fields');
 add_default($nl, 'config_use_data_icebergs');
 add_default($nl, 'config_salt_fux_coupling_type');
+add_default($nl, 'config_ice_ocean_drag_coefficient'); 
 
 ###############################
 # Namelist group: diagnostics #

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -364,6 +364,7 @@
 <config_wind_compaction_factor>27.3</config_wind_compaction_factor>
 <config_snow_redistribution_factor>0.3</config_snow_redistribution_factor>
 <config_max_dry_snow_radius>2800.0</config_max_dry_snow_radius>
+<config_snow_thermal_conductivity>0.3</config_snow_thermal_conductivity>
 
 <!-- meltponds -->
 <config_snow_to_ice_transition_depth>0.0</config_snow_to_ice_transition_depth>

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -62,7 +62,6 @@
 <config_nFloeCategories>1</config_nFloeCategories>
 <config_nIceLayers>7</config_nIceLayers>
 <config_nSnowLayers>5</config_nSnowLayers>
-<config_nFloeCategories>1</config_nFloeCategories>
 
 <!-- initialize -->
 <config_earth_radius>6371229.0</config_earth_radius>

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -419,6 +419,7 @@
 <config_couple_biogeochemistry_fields>false</config_couple_biogeochemistry_fields>
 <config_use_data_icebergs>false</config_use_data_icebergs>
 <config_salt_flux_coupling_type>'constant'</config_salt_flux_coupling_type>
+<config_ice_ocean_drag_coefficient>0.00536</config_ice_ocean_drag_coefficient>
 
 <!-- diagnostics -->
 <config_check_state>false</config_check_state>

--- a/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
@@ -2303,6 +2303,14 @@ Valid values: positive real
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_snow_thermal_conductivity" type="real"
+	category="snow" group="snow">
+thermal conductivity of snow  (W/m/deg)
+
+Valid values: positive real
+Default: Defined in namelist_defaults.xml
+</entry>
+
 
 <!-- meltponds -->
 

--- a/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
@@ -2650,6 +2650,13 @@ Valid values: 'constant' or 'prognostic'
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_ice_ocean_drag_coefficient" type="real"
+	category="ocean" group="ocean">
+Neutral ice-ocean drag coefficient
+
+Valid values:
+Default: Defined in namelist_defaults.xml
+</entry>
 
 <!-- diagnostics -->
 

--- a/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
@@ -320,14 +320,6 @@ Valid values: Any positive integer.
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_nFloeCategories" type="integer"
-	category="dimensions" group="dimensions">
-The number of ice floe categories to use.
-
-Valid values: 1(default), 12, 16, 24.
-Default: Defined in namelist_defaults.xml
-</entry>
-
 <!-- initialize -->
 
 <entry id="config_earth_radius" type="real"

--- a/components/mpas-seaice/src/Registry.xml
+++ b/components/mpas-seaice/src/Registry.xml
@@ -1631,6 +1631,11 @@
 			possible_values="positive real"
 			icepack_name="rsnw_tmax"
 		/>
+		<nml_option name="config_snow_thermal_conductivity" type="real" default_value="0.3" units="W/m/deg"
+			description="thermal conductivity of snow"
+			possible_values="positive real"
+			icepack_name="ksno"
+		/>
 	</nml_record>
 
 	<nml_record name="meltponds" in_defaults="true">

--- a/components/mpas-seaice/src/Registry.xml
+++ b/components/mpas-seaice/src/Registry.xml
@@ -1847,6 +1847,11 @@
 			description="Type of salt flux to ocean method"
 			possible_values="'constant', or 'prognostic'"
 		/>
+		<nml_option name="config_ice_ocean_drag_coefficient" type="real" default_value="0.00536" units=""
+			description="Neutral ice-ocean drag coefficient"
+			possible_values=""
+			icepack_name="dragio"
+		/>
 	</nml_record>
 
 	<nml_record name="diagnostics" in_defaults="true">

--- a/components/mpas-seaice/src/column/constants/cesm/ice_constants_colpkg.F90
+++ b/components/mpas-seaice/src/column/constants/cesm/ice_constants_colpkg.F90
@@ -37,12 +37,6 @@
                                         ! freshwater value needed for enthalpy
          depressT  = 0.054_dbl_kind   ,&! Tf:brine salinity ratio (C/ppt)
 
-#ifdef RASM_MODS
-         dragio    = 0.00962_dbl_kind ,&! ice-ocn drag coefficient for RASM as temporary measure
-#else
-         dragio    = 0.00536_dbl_kind ,&! ice-ocn drag coefficient
-#endif
-
          albocn    = 0.06_dbl_kind   ,&! ocean albedo
          gravit    = SHR_CONST_G     ,&! gravitational acceleration (m/s^2)
          viscosity_dyn = 1.79e-3_dbl_kind, & ! dynamic viscosity of brine (kg/m/s)
@@ -83,7 +77,6 @@
          ! kseaice is used only for zero-layer thermo
          kseaice= 2.00_dbl_kind  ,&! thermal conductivity of sea ice (W/m/deg)
                                    ! (used in zero layer thermodynamics option)
-         ksno   = 0.30_dbl_kind  ,&! thermal conductivity of snow  (W/m/deg)
          zref   = 10._dbl_kind   ,&! reference height for stability (m)
          hs_min = 1.e-4_dbl_kind ,&! min snow thickness for computing zTsn (m)
          snowpatch = 0.005_dbl_kind , &  ! parameter for fractional snow area (m)

--- a/components/mpas-seaice/src/column/constants/cice/ice_constants_colpkg.F90
+++ b/components/mpas-seaice/src/column/constants/cice/ice_constants_colpkg.F90
@@ -31,7 +31,6 @@
          cp_ocn    = 4218._dbl_kind   ,&! specific heat of ocn    (J/kg/K)
                                         ! freshwater value needed for enthalpy
          depressT  = 0.054_dbl_kind   ,&! Tf:brine salinity ratio (C/ppt)
-         dragio    = 0.00536_dbl_kind ,&! ice-ocn drag coefficient
          albocn    = 0.06_dbl_kind    ,&! ocean albedo
          gravit    = 9.80616_dbl_kind ,&! gravitational acceleration (m/s^2)
          viscosity_dyn = 1.79e-3_dbl_kind, & ! dynamic viscosity of brine (kg/m/s)
@@ -70,7 +69,6 @@
          ! kseaice is used only for zero-layer thermo
          kseaice= 2.00_dbl_kind  ,&! thermal conductivity of sea ice (W/m/deg)
                                    ! (used in zero layer thermodynamics option)
-         ksno   = 0.30_dbl_kind  ,&! thermal conductivity of snow  (W/m/deg)
          zref   = 10._dbl_kind   ,&! reference height for stability (m)
          hs_min = 1.e-4_dbl_kind ,&! min snow thickness for computing zTsn (m)
          snowpatch = 0.02_dbl_kind, & ! parameter for fractional snow area (m)

--- a/components/mpas-seaice/src/column/ice_atmo.F90
+++ b/components/mpas-seaice/src/column/ice_atmo.F90
@@ -18,7 +18,8 @@
            c16, c20, p001, p01, p2, p4, p5, p75, puny, &
            cp_wv, cp_air, iceruf, zref, qqqice, TTTice, qqqocn, TTTocn, &
            Lsub, Lvap, vonkar, Tffresh, zvir, gravit, &
-           pih, dragio, rhoi, rhos, rhow
+           pih, rhoi, rhos, rhow
+      use ice_colpkg_shared, only: dragio
 
       implicit none
       save

--- a/components/mpas-seaice/src/column/ice_colpkg.F90
+++ b/components/mpas-seaice/src/column/ice_colpkg.F90
@@ -4047,6 +4047,8 @@
            fbot_xfer_type_in, &
            calc_Tsfc_in, &
            ustar_min_in, &
+           dragio_in, &
+           ksno_in, &
            a_rapid_mode_in, &
            Rac_rapid_mode_in, &
            aspect_rapid_mode_in, &
@@ -4241,6 +4243,8 @@
              fbot_xfer_type, &
              calc_Tsfc, &
              ustar_min, &
+             dragio, &
+             ksno, & 
              a_rapid_mode, &
              Rac_rapid_mode, &
              aspect_rapid_mode, &
@@ -4529,6 +4533,9 @@
 ! Parameters for ocean
 !-----------------------------------------------------------------------
 
+        real (kind=dbl_kind), intent(in) :: &  
+             dragio_in          ! ice-ocean drago coefficient 
+
         logical (kind=log_kind), intent(in) :: &
              oceanmixed_ice_in           ! if true, use ocean mixed layer
         
@@ -4738,22 +4745,23 @@
       ! snow metamorphism parameters, set in namelist
       real (kind=dbl_kind), intent(in) :: &
          rsnw_fall_in , & ! fallen snow grain radius (10^-6 m))  54.5 um CLM **
-                       ! 30 um is minimum for defined mie properties 
+                          ! 30 um is minimum for defined mie properties 
          rsnw_tmax_in , & ! maximum dry metamorphism snow grain radius (10^-6 m)
-                       ! 1500 um is maximum for defined mie properties
+                          ! 1500 um is maximum for defined mie properties
          rhosnew_in   , & ! new snow density (kg/m^3)
          rhosmax_in   , & ! maximum snow density (kg/m^3)
          windmin_in   , & ! minimum wind speed to compact snow (m/s)
          snwlvlfac_in , & ! snow loss factor for wind redistribution
-         drhosdwind_in    ! wind compaction factor (kg s/m^4)
+         drhosdwind_in, & ! wind compaction factor (kg s/m^4)
+         ksno_in          ! snow thermal conductivity (W/m/deg)
 
       character(len=char_len), intent(in) :: & 
          snwredist_in     ! type of snow redistribution
-                       ! '30percent' = 30% rule, precip only
-                       ! '30percentsw' = 30% rule with shortwave
-                       ! 'ITDsd' = Lecomte PhD, 2014
-                       ! 'ITDrdg' = like ITDsd but use level/ridged ice
-                       ! 'default' or 'none' = none
+                          ! '30percent' = 30% rule, precip only
+                          ! '30percentsw' = 30% rule with shortwave
+                          ! 'ITDsd' = Lecomte PhD, 2014
+                          ! 'ITDrdg' = like ITDsd but use level/ridged ice
+                          ! 'default' or 'none' = none
 
       logical (kind=log_kind), intent(in) :: &
          use_smliq_pnd_in ! if true, use snow liquid tracer for ponds
@@ -4763,6 +4771,8 @@
         fbot_xfer_type = fbot_xfer_type_in
         calc_Tsfc = calc_Tsfc_in
         ustar_min = ustar_min_in
+        dragio = dragio_in
+        ksno = ksno_in
         a_rapid_mode = a_rapid_mode_in
         Rac_rapid_mode = Rac_rapid_mode_in
         aspect_rapid_mode = aspect_rapid_mode_in

--- a/components/mpas-seaice/src/column/ice_colpkg_shared.F90
+++ b/components/mpas-seaice/src/column/ice_colpkg_shared.F90
@@ -134,6 +134,9 @@
 ! Parameters for ocean
 !-----------------------------------------------------------------------
 
+      real (kind=dbl_kind), public :: &
+         dragio                   ! neutral ice-ocean drag coefficient
+
       logical (kind=log_kind), public :: &
          oceanmixed_ice           ! if true, use ocean mixed layer
 
@@ -192,7 +195,8 @@
          rhosmax   , & ! maximum snow density (kg/m^3)
          windmin   , & ! minimum wind speed to compact snow (m/s)
          snwlvlfac , & ! snow loss factor for wind redistribution
-         drhosdwind    ! wind compaction factor (kg s/m^4)
+         drhosdwind, & ! wind compaction factor (kg s/m^4)
+         ksno          ! snow thermal conductivity (W/m/deg)
 
       character(len=char_len), public :: & 
          snwredist     ! type of snow redistribution

--- a/components/mpas-seaice/src/column/ice_mushy_physics.F90
+++ b/components/mpas-seaice/src/column/ice_mushy_physics.F90
@@ -3,8 +3,9 @@ module ice_mushy_physics
   use ice_kinds_mod
   use ice_constants_colpkg, only: c0, c1, c2, c4, c8, c10, c1000, &
       p001, p01, p05, p1, p2, p5, pi, bignum, puny, ice_ref_salinity, &
-      viscosity_dyn, rhow, rhoi, rhos, cp_ocn, cp_ice, Lfresh, gravit, &
-      ksno
+      viscosity_dyn, rhow, rhoi, rhos, cp_ocn, cp_ice, Lfresh, gravit
+  use ice_colpkg_shared, only: ksno
+
 
   implicit none
 

--- a/components/mpas-seaice/src/column/ice_therm_0layer.F90
+++ b/components/mpas-seaice/src/column/ice_therm_0layer.F90
@@ -12,10 +12,10 @@
       module ice_therm_0layer
 
       use ice_kinds_mod
-      use ice_constants_colpkg, only: c0, c1, p5, puny, &
-          kseaice, ksno
+      use ice_constants_colpkg, only: c0, c1, p5, puny, kseaice
       use ice_therm_bl99, only: surface_fluxes
       use ice_warnings, only: add_warning
+      Use ice_colpkg_shared, only: ksno
 
       implicit none
 
@@ -125,7 +125,7 @@
 
       real (kind=dbl_kind) :: &
          heff        , & ! effective ice thickness (m)
-                         ! ( hice + hsno*kseaice/ksnow)
+                         ! ( hice + hsno*kseaice/ksno)
          kratio      , & ! ratio of ice and snow conductivies
          avg_Tsf         ! = 1. if Tsf averaged w/Tsf_start, else = 0.
 

--- a/components/mpas-seaice/src/column/ice_therm_bl99.F90
+++ b/components/mpas-seaice/src/column/ice_therm_bl99.F90
@@ -14,8 +14,8 @@
 
       use ice_kinds_mod
       use ice_constants_colpkg, only: c0, c1, c2, p01, p1, p5, puny, &
-          rhoi, rhos, hs_min, cp_ice, cp_ocn, depressT, Lfresh, ksno, kice
-      use ice_colpkg_shared, only: conduct, calc_Tsfc, solve_zsal
+          rhoi, rhos, hs_min, cp_ice, cp_ocn, depressT, Lfresh, kice
+      use ice_colpkg_shared, only: conduct, calc_Tsfc, solve_zsal, ksno
       use ice_therm_shared, only: ferrmax, l_brine, hfrazilmin
       use ice_warnings, only: add_warning
 

--- a/components/mpas-seaice/src/column/ice_therm_mushy.F90
+++ b/components/mpas-seaice/src/column/ice_therm_mushy.F90
@@ -7,8 +7,8 @@ module ice_therm_mushy
   use ice_constants_colpkg, only: c0, c1, c2, c4, c8, c10, c1000, &
       p001, p01, p05, p1, p2, p5, pi, bignum, puny, ice_ref_salinity, &
       viscosity_dyn, rhow, rhoi, rhos, cp_ocn, cp_ice, Lfresh, gravit, &
-      hs_min, ksno
-  use ice_colpkg_shared, only: a_rapid_mode, Rac_rapid_mode, &
+      hs_min
+  use ice_colpkg_shared, only: a_rapid_mode, Rac_rapid_mode, ksno, &
       aspect_rapid_mode, dSdt_slow_mode, phi_c_slow_mode, phi_i_mushy
 
   use ice_therm_shared, only: ferrmax

--- a/components/mpas-seaice/src/shared/mpas_seaice_column.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_column.F
@@ -11368,7 +11368,7 @@ contains
                realArgs=(/seaiceIceOceanDragCoefficient,config_ice_ocean_drag_coefficient/))
 
     if (seaiceSnowConductivity /= config_snow_thermal_conductivity) &
-       call mpas_log_write('ColPkg ksno differs from ', &
+       call mpas_log_write('ColPkg ksno differs from config_snow_thermal_conductivity', &
                realArgs=(/seaiceSnowConductivity,config_snow_thermal_conductivity/))
 
     call colpkg_init_parameters(&

--- a/components/mpas-seaice/src/shared/mpas_seaice_column.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_column.F
@@ -10994,6 +10994,7 @@ contains
 
     real(kind=RKIND), pointer :: &
          config_min_friction_velocity, &
+         config_ice_ocean_drag_coefficient, &
          config_rapid_mode_channel_radius, &
          config_rapid_model_critical_Ra, &
          config_rapid_mode_aspect_ratio, &
@@ -11159,6 +11160,7 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_ocean_heat_transfer_type", config_ocean_heat_transfer_type)
     call MPAS_pool_get_config(domain % configs, "config_calc_surface_temperature", config_calc_surface_temperature)
     call MPAS_pool_get_config(domain % configs, "config_min_friction_velocity", config_min_friction_velocity)
+    call MPAS_pool_get_config(domain % configs, "config_ice_ocean_drag_coefficient", config_ice_ocean_drag_coefficient)
     call MPAS_pool_get_config(domain % configs, "config_rapid_mode_channel_radius", config_rapid_mode_channel_radius)
     call MPAS_pool_get_config(domain % configs, "config_rapid_model_critical_Ra", config_rapid_model_critical_Ra)
     call MPAS_pool_get_config(domain % configs, "config_rapid_mode_aspect_ratio", config_rapid_mode_aspect_ratio)
@@ -11354,6 +11356,10 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_snow_redistribution_factor", config_snow_redistribution_factor)
     call MPAS_pool_get_config(domain % configs, "config_wind_compaction_factor", config_wind_compaction_factor)
     call MPAS_pool_get_config(domain % configs, "config_max_dry_snow_radius", config_max_dry_snow_radius)
+
+    if (seaiceIceOceanDragCoefficient /= config_ice_ocean_drag_coefficient) &
+       call mpas_log_write('ColPkg dragio differs from config_ice_ocean_drag_coefficient',
+                          realArgs=(/dragio,config_ice_ocean_drag_coefficient/))
 
     call colpkg_init_parameters(&
          config_cice_int("config_thermodynamics_type", config_thermodynamics_type), &

--- a/components/mpas-seaice/src/shared/mpas_seaice_column.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_column.F
@@ -10998,6 +10998,7 @@ contains
     real(kind=RKIND), pointer :: &
          config_min_friction_velocity, &
          config_ice_ocean_drag_coefficient, &
+         config_snow_thermal_conductivity, &
          config_rapid_mode_channel_radius, &
          config_rapid_model_critical_Ra, &
          config_rapid_mode_aspect_ratio, &
@@ -11164,6 +11165,7 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_calc_surface_temperature", config_calc_surface_temperature)
     call MPAS_pool_get_config(domain % configs, "config_min_friction_velocity", config_min_friction_velocity)
     call MPAS_pool_get_config(domain % configs, "config_ice_ocean_drag_coefficient", config_ice_ocean_drag_coefficient)
+    call MPAS_pool_get_config(domain % configs, "config_snow_thermal_conductivity", config_snow_thermal_conductivity)
     call MPAS_pool_get_config(domain % configs, "config_rapid_mode_channel_radius", config_rapid_mode_channel_radius)
     call MPAS_pool_get_config(domain % configs, "config_rapid_model_critical_Ra", config_rapid_model_critical_Ra)
     call MPAS_pool_get_config(domain % configs, "config_rapid_mode_aspect_ratio", config_rapid_mode_aspect_ratio)
@@ -11363,6 +11365,10 @@ contains
     if (seaiceIceOceanDragCoefficient /= config_ice_ocean_drag_coefficient) &
        call mpas_log_write('ColPkg dragio differs from config_ice_ocean_drag_coefficient', &
                realArgs=(/seaiceIceOceanDragCoefficient,config_ice_ocean_drag_coefficient/))
+
+    if (seaiceSnowConductivity /= config_snow_thermal_conductivity) &
+       call mpas_log_write('ColPkg ksno differs from ', &
+               realArgs=(/seaiceSnowConductivity,config_snow_thermal_conductivity/))
 
     call colpkg_init_parameters(&
          config_cice_int("config_thermodynamics_type", config_thermodynamics_type), &

--- a/components/mpas-seaice/src/shared/mpas_seaice_column.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_column.F
@@ -10957,7 +10957,8 @@ contains
          colpkg_init_parameters
 
     use seaice_constants, only: &
-         seaiceIceOceanDragCoefficient    ! ice ocean drag coefficient
+         seaiceIceOceanDragCoefficient, & ! ice ocean drag coefficient
+         seaiceSnowConductivity           ! snow thermal conductivity
 
     type(domain_type), intent(inout) :: &
          domain

--- a/components/mpas-seaice/src/shared/mpas_seaice_column.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_column.F
@@ -10956,6 +10956,9 @@ contains
     use ice_colpkg, only: &
          colpkg_init_parameters
 
+    use seaice_constants, only: &
+         seaiceIceOceanDragCoefficient    ! ice ocean drag coefficient
+
     type(domain_type), intent(inout) :: &
          domain
 
@@ -11358,8 +11361,9 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_max_dry_snow_radius", config_max_dry_snow_radius)
 
     if (seaiceIceOceanDragCoefficient /= config_ice_ocean_drag_coefficient) &
-       call mpas_log_write('ColPkg dragio differs from config_ice_ocean_drag_coefficient',
-                          realArgs=(/dragio,config_ice_ocean_drag_coefficient/))
+       call mpas_log_write('ColPkg dragio differs from config_ice_ocean_drag_coefficient', &
+               realArgs=(/seaiceIceOceanDragCoefficient,config_ice_ocean_drag_coefficient/))
+
 
     call colpkg_init_parameters(&
          config_cice_int("config_thermodynamics_type", config_thermodynamics_type), &

--- a/components/mpas-seaice/src/shared/mpas_seaice_column.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_column.F
@@ -11364,7 +11364,6 @@ contains
        call mpas_log_write('ColPkg dragio differs from config_ice_ocean_drag_coefficient', &
                realArgs=(/seaiceIceOceanDragCoefficient,config_ice_ocean_drag_coefficient/))
 
-
     call colpkg_init_parameters(&
          config_cice_int("config_thermodynamics_type", config_thermodynamics_type), &
          config_heat_conductivity_type, &

--- a/components/mpas-seaice/src/shared/mpas_seaice_column.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_column.F
@@ -6304,7 +6304,6 @@ contains
          seaiceStabilityReferenceHeight, &
          seaiceIceStrengthConstantHiblerP, &
          seaiceIceStrengthConstantHiblerC, &
-         seaiceIceOceanDragCoefficient, &
          skeletalLayerThickness, &
          gramsCarbonPerMolCarbon, &
          iceAreaMinimum, &
@@ -6329,7 +6328,6 @@ contains
          ice_ref_salinity, &
          Pstar, &
          Cstar, &
-         dragio, &
          albocn, &
          rhofresh, &
          vonkar, &
@@ -6360,7 +6358,6 @@ contains
     seaiceStabilityReferenceHeight   = zref
     seaiceIceStrengthConstantHiblerP = Pstar
     seaiceIceStrengthConstantHiblerC = Cstar
-    seaiceIceOceanDragCoefficient    = dragio
     skeletalLayerThickness           = sk_l
     gramsCarbonPerMolCarbon          = R_gC2molC
 
@@ -10956,10 +10953,6 @@ contains
     use ice_colpkg, only: &
          colpkg_init_parameters
 
-    use seaice_constants, only: &
-         seaiceIceOceanDragCoefficient, & ! ice ocean drag coefficient
-         seaiceSnowConductivity           ! snow thermal conductivity
-
     type(domain_type), intent(inout) :: &
          domain
 
@@ -11363,20 +11356,14 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_wind_compaction_factor", config_wind_compaction_factor)
     call MPAS_pool_get_config(domain % configs, "config_max_dry_snow_radius", config_max_dry_snow_radius)
 
-    if (seaiceIceOceanDragCoefficient /= config_ice_ocean_drag_coefficient) &
-       call mpas_log_write('ColPkg dragio differs from config_ice_ocean_drag_coefficient', &
-               realArgs=(/seaiceIceOceanDragCoefficient,config_ice_ocean_drag_coefficient/))
-
-    if (seaiceSnowConductivity /= config_snow_thermal_conductivity) &
-       call mpas_log_write('ColPkg ksno differs from config_snow_thermal_conductivity', &
-               realArgs=(/seaiceSnowConductivity,config_snow_thermal_conductivity/))
-
     call colpkg_init_parameters(&
          config_cice_int("config_thermodynamics_type", config_thermodynamics_type), &
          config_heat_conductivity_type, &
          config_ocean_heat_transfer_type, &
          config_calc_surface_temperature, &
          config_min_friction_velocity, &
+         config_ice_ocean_drag_coefficient, &
+         config_snow_thermal_conductivity, &
          config_rapid_mode_channel_radius, &
          config_rapid_model_critical_Ra, &
          config_rapid_mode_aspect_ratio, &
@@ -11742,6 +11729,10 @@ contains
     ! 'linear_salt' = -depressT * sss
     ! 'mushy' conforms with ktherm=2
     !tfrz_option = config_sea_freezing_temperature_type
+
+    ! dragio:
+    ! neutral ice-ocean drag coefficient
+    ! dragio = config_ice_ocean_drag_coefficient
 
     !-----------------------------------------------------------------------
     ! Parameters for the ice thickness distribution
@@ -12363,6 +12354,10 @@ contains
     ! drhosdwind:
     ! wind compaction factor (kg s/m^4)
     ! drhosdwind = config_wind_compaction_factor
+
+    ! ksno:
+    ! snow thermal conductivity
+    ! ksno = config_snow_thermal_conductivity
 
   end subroutine init_column_package_configs
 
@@ -14326,9 +14321,6 @@ contains
 
   subroutine seaice_column_reinitialize_diagnostics_thermodynamics(domain)
 
-    use seaice_constants, only: &
-         seaiceIceOceanDragCoefficient
-
     type(domain_type) :: domain
 
     type(block_type), pointer :: block
@@ -14397,6 +14389,9 @@ contains
          pondAlbedoCell
 
     ! drag variables
+    real(kind=RKIND), pointer :: &
+         config_ice_ocean_drag_coefficient
+
     real(kind=RKIND), dimension(:), pointer :: &
          airOceanDragCoefficientRatio, &
          oceanDragCoefficient, &
@@ -14515,12 +14510,15 @@ contains
           pondAlbedoCell    = 0.0_RKIND
 
           ! form drag
+          call MPAS_pool_get_config(block % configs, "config_ice_ocean_drag_coefficient", & 
+                                    config_ice_ocean_drag_coefficient)
+
           call MPAS_pool_get_subpool(block % structs, "drag", dragPool)
 
           call MPAS_pool_get_array(dragPool, "oceanDragCoefficient", oceanDragCoefficient)
           call MPAS_pool_get_array(dragPool, "airDragCoefficient", airDragCoefficient)
 
-          oceanDragCoefficient = seaiceIceOceanDragCoefficient
+          oceanDragCoefficient = config_ice_ocean_drag_coefficient
           airDragCoefficient   = seaice_column_initial_air_drag_coefficient()
 
           call MPAS_pool_get_config(block % configs, "config_use_form_drag", config_use_form_drag)

--- a/components/mpas-seaice/src/shared/mpas_seaice_constants.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_constants.F
@@ -134,7 +134,6 @@ module seaice_constants
 
   ! dynamics constants
   real(kind=RKIND), public :: &
-       seaiceIceOceanDragCoefficient      = 0.00536_RKIND, &! ice-ocn drag coefficient (also a namelist variable)
        seaiceIceStrengthConstantHiblerP   = 2.75e4_RKIND , &! P* constant in Hibler strength formula
        seaiceIceStrengthConstantHiblerC   = 20._RKIND       ! C* constant in Hibler strength formula
 
@@ -155,7 +154,6 @@ module seaice_constants
        seaiceExtinctionCoef              = 1.4_RKIND    , & ! vis extnctn coef in ice, wvlngth<700nm (1/m)
        seaiceFreshIceConductivity        = 2.03_RKIND   , & ! thermal conductivity of fresh ice(W/m/deg)
                                                             ! (kice) is not used for mushy thermo
-       seaiceSnowConductivity            = 0.30_RKIND   , & ! thermal conductivity of snow  (W/m/deg, also a namelist variable)
        seaiceSnowMinimumThickness        = 1.e-4_RKIND  , & ! min snow thickness for computing zTsn (m)
        ! weights for albedos for history and diagnostics
        ! 4 Jan 2007 BPB  Following are appropriate for complete cloud

--- a/components/mpas-seaice/src/shared/mpas_seaice_constants.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_constants.F
@@ -134,7 +134,7 @@ module seaice_constants
 
   ! dynamics constants
   real(kind=RKIND), public :: &
-       seaiceIceOceanDragCoefficient      = 0.00536_RKIND, &! ice-ocn drag coefficient
+       seaiceIceOceanDragCoefficient      = 0.00536_RKIND, &! ice-ocn drag coefficient (also a namelist variable)
        seaiceIceStrengthConstantHiblerP   = 2.75e4_RKIND , &! P* constant in Hibler strength formula
        seaiceIceStrengthConstantHiblerC   = 20._RKIND       ! C* constant in Hibler strength formula
 

--- a/components/mpas-seaice/src/shared/mpas_seaice_constants.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_constants.F
@@ -155,7 +155,7 @@ module seaice_constants
        seaiceExtinctionCoef              = 1.4_RKIND    , & ! vis extnctn coef in ice, wvlngth<700nm (1/m)
        seaiceFreshIceConductivity        = 2.03_RKIND   , & ! thermal conductivity of fresh ice(W/m/deg)
                                                             ! (kice) is not used for mushy thermo
-       seaiceSnowConductivity            = 0.30_RKIND   , & ! thermal conductivity of snow  (W/m/deg)
+       seaiceSnowConductivity            = 0.30_RKIND   , & ! thermal conductivity of snow  (W/m/deg, also a namelist variable)
        seaiceSnowMinimumThickness        = 1.e-4_RKIND  , & ! min snow thickness for computing zTsn (m)
        ! weights for albedos for history and diagnostics
        ! 4 Jan 2007 BPB  Following are appropriate for complete cloud

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -2885,6 +2885,7 @@ contains
 
     use icepack_intfc, only: &
          icepack_step_radiation
+
     use seaice_constants, only: &
          seaicePi
 
@@ -10062,7 +10063,8 @@ contains
          colpkg_init_parameters
 
     use seaice_constants, only: &
-         seaiceIceOceanDragCoefficient    ! ice ocean drag coefficient
+         seaiceIceOceanDragCoefficient, &    ! ice ocean drag coefficient
+         seaiceSnowConductivity              ! snow thermal conductivity
 
     type(domain_type), intent(inout) :: &
          domain

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -10103,6 +10103,7 @@ contains
     real(kind=RKIND), pointer :: &
          config_min_friction_velocity, &
          config_ice_ocean_drag_coefficient, &
+         config_snow_thermal_conductivity, &
          config_rapid_mode_channel_radius, &
          config_rapid_model_critical_Ra, &
          config_rapid_mode_aspect_ratio, &
@@ -10269,6 +10270,7 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_calc_surface_temperature", config_calc_surface_temperature)
     call MPAS_pool_get_config(domain % configs, "config_min_friction_velocity", config_min_friction_velocity)
     call MPAS_pool_get_config(domain % configs, "config_ice_ocean_drag_coefficient", config_ice_ocean_drag_coefficient)
+    call MPAS_pool_get_config(domain % configs, "config_snow_thermal_conductivity", config_snow_thermal_conductivity)
     call MPAS_pool_get_config(domain % configs, "config_rapid_mode_channel_radius", config_rapid_mode_channel_radius)
     call MPAS_pool_get_config(domain % configs, "config_rapid_model_critical_Ra", config_rapid_model_critical_Ra)
     call MPAS_pool_get_config(domain % configs, "config_rapid_mode_aspect_ratio", config_rapid_mode_aspect_ratio)
@@ -10468,6 +10470,10 @@ contains
     if (seaiceIceOceanDragCoefficient /= config_ice_ocean_drag_coefficient) &
        call mpas_log_write('ColPkg dragio differs from config_ice_ocean_drag_coefficient', &
                realArgs=(/seaiceIceOceanDragCoefficient,config_ice_ocean_drag_coefficient/))
+
+    if (seaiceSnowConductivity /= config_snow_thermal_conductivity) &
+       call mpas_log_write('ColPkg ksno differs from ', &
+               realArgs=(/seaiceSnowConductivity,config_snow_thermal_conductivity/))
 
     call colpkg_init_parameters(&
          config_cice_int("config_thermodynamics_type", config_thermodynamics_type), &
@@ -11584,6 +11590,7 @@ contains
     real(kind=RKIND), pointer :: &
          config_min_friction_velocity, &
          config_ice_ocean_drag_coefficient, &
+         config_snow_thermal_conductivity, &
          config_rapid_mode_channel_radius, &
          config_rapid_model_critical_Ra, &
          config_rapid_mode_aspect_ratio, &
@@ -11778,6 +11785,7 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_frazil_coupling_type", config_frazil_coupling_type)
     call MPAS_pool_get_config(domain % configs, "config_min_friction_velocity", config_min_friction_velocity)
     call MPAS_pool_get_config(domain % configs, "config_ice_ocean_drag_coefficient", config_ice_ocean_drag_coefficient)
+    call MPAS_pool_get_config(domain % configs, "config_snow_thermal_conductivity", config_snow_thermal_conductivity)
     call MPAS_pool_get_config(domain % configs, "config_rapid_mode_channel_radius", config_rapid_mode_channel_radius)
     call MPAS_pool_get_config(domain % configs, "config_rapid_model_critical_Ra", config_rapid_model_critical_Ra)
     call MPAS_pool_get_config(domain % configs, "config_rapid_mode_aspect_ratio", config_rapid_mode_aspect_ratio)
@@ -12176,7 +12184,7 @@ contains
          Cstar_in                = seaiceIceStrengthConstantHiblerC, &
          kappav_in               = seaiceExtinctionCoef, &
          kice_in                 = seaiceFreshIceConductivity, &
-         ksno_in                 = seaiceSnowConductivity, &
+         ksno_in                 = config_snow_thermal_conductivity, &
          zref_in                 = seaiceStabilityReferenceHeight, &
          hs_min_in               = seaiceSnowMinimumThickness, &
          snowpatch_in            = seaiceSnowPatchiness, & ! ccsm3 radiation scheme
@@ -13305,6 +13313,10 @@ contains
     ! drhosdwind:
     ! wind compaction factor (kg s/m^4)
     ! drhosdwind = config_wind_compaction_factor
+
+    ! ksno:
+    ! Thermal conductivity of snow (W/m/deg)
+    ! ksno = config_snow_thermal_conductivity
 
   end subroutine init_icepack_package_configs
 

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -10474,7 +10474,7 @@ contains
                realArgs=(/seaiceIceOceanDragCoefficient,config_ice_ocean_drag_coefficient/))
 
     if (seaiceSnowConductivity /= config_snow_thermal_conductivity) &
-       call mpas_log_write('ColPkg ksno differs from ', &
+       call mpas_log_write('ColPkg ksno differs from config_snow_thermal_conductivity', &
                realArgs=(/seaiceSnowConductivity,config_snow_thermal_conductivity/))
 
     call colpkg_init_parameters(&

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -10062,10 +10062,6 @@ contains
     use ice_colpkg, only: &
          colpkg_init_parameters
 
-    use seaice_constants, only: &
-         seaiceIceOceanDragCoefficient, &    ! ice ocean drag coefficient
-         seaiceSnowConductivity              ! snow thermal conductivity
-
     type(domain_type), intent(inout) :: &
          domain
 
@@ -10469,20 +10465,14 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_snow_redistribution_factor", config_snow_redistribution_factor)
     call MPAS_pool_get_config(domain % configs, "config_max_dry_snow_radius", config_max_dry_snow_radius)
 
-    if (seaiceIceOceanDragCoefficient /= config_ice_ocean_drag_coefficient) &
-       call mpas_log_write('ColPkg dragio differs from config_ice_ocean_drag_coefficient', &
-               realArgs=(/seaiceIceOceanDragCoefficient,config_ice_ocean_drag_coefficient/))
-
-    if (seaiceSnowConductivity /= config_snow_thermal_conductivity) &
-       call mpas_log_write('ColPkg ksno differs from config_snow_thermal_conductivity', &
-               realArgs=(/seaiceSnowConductivity,config_snow_thermal_conductivity/))
-
     call colpkg_init_parameters(&
          config_cice_int("config_thermodynamics_type", config_thermodynamics_type), &
          config_heat_conductivity_type, &
          config_ocean_heat_transfer_type, &
          config_calc_surface_temperature, &
          config_min_friction_velocity, &
+         config_ice_ocean_drag_coefficient, &
+         config_snow_thermal_conductivity, &
          config_rapid_mode_channel_radius, &
          config_rapid_model_critical_Ra, &
          config_rapid_mode_aspect_ratio, &
@@ -11515,7 +11505,6 @@ contains
          seaiceSnowSurfaceScatteringLayer, & ! snow surface scattering layer thickness (m)
          seaiceStabilityReferenceHeight, &   ! stability reference height (m)
          seaiceFreshWaterFreezingPoint, &    ! freezing temp of fresh ice (K)
-         seaiceIceOceanDragCoefficient, &    ! ice ocean drag coefficient
          seaiceIceSurfaceRoughness, &        ! ice surface roughness (m)
          seaiceVonKarmanConstant, &          ! Von Karman constant
          seaiceOceanAlbedo, &                ! Ocean albedo
@@ -11535,7 +11524,6 @@ contains
          seaiceFreezingTemperatureConstant, &! constant freezing temp of seawater (C)
          seaiceExtinctionCoef, &             ! vis extnctn coef in ice, wvlngth<700nm (1/m)
          seaiceFreshIceConductivity, &       ! thermal conductivity of fresh ice(W/m/deg)
-         seaiceSnowConductivity, &           ! thermal conductivity of snow  (W/m/deg)
          seaiceSnowMinimumThickness, &       ! min snow thickness for computing zTsn (m)
          seaiceFrazilMinimumThickness, &     ! min thickness of new frazil ice
          seaiceAlbedoWtVisibleDirect, &      ! visible, direct
@@ -12052,10 +12040,6 @@ contains
     rtmp1 = seaiceSeaWaterSpecificHeat
     call icepack_query_parameters(cp_ocn_out=rtmp2)
     if (rtmp1 /= rtmp2) call mpas_log_write('cp_ocn differs $r $r',realArgs=(/rtmp1,rtmp2/))
-
-    rtmp1 = seaiceIceOceanDragCoefficient
-    call icepack_query_parameters(dragio_out=rtmp2)
-    if (rtmp1 /= rtmp2) call mpas_log_write('dragio differs $r $r',realArgs=(/rtmp1,rtmp2/))
 
     rtmp1 = seaiceIceSurfaceRoughness
     call icepack_query_parameters(iceruf_out=rtmp2)
@@ -12681,22 +12665,22 @@ contains
 
     ! oceanmixed_ice:
     ! if true, use ocean mixed layer
-    !oceanmixed_ice = config_use_ocean_mixed_layer
+    ! oceanmixed_ice = config_use_ocean_mixed_layer
 
     ! fbot_xfer_type:
     ! transfer coefficient type for ice-ocean heat flux
-    !fbot_xfer_type = config_ocean_heat_transfer_type
+    ! fbot_xfer_type = config_ocean_heat_transfer_type
 
     ! tfrz_option:
     ! form of ocean freezing temperature
     ! 'minus1p8' = -1.8 C
     ! 'linear_salt' = -depressT * sss
     ! 'mushy' conforms with ktherm=2
-    !tfrz_option = config_sea_freezing_temperature_type
+    ! tfrz_option = config_sea_freezing_temperature_type
 
     ! dragio:
     ! Neutral ice-ocean drag coefficient
-    !dragio = config_ice_ocean_drag_coefficient
+    ! dragio = config_ice_ocean_drag_coefficient
 
     !-----------------------------------------------------------------------
     ! Parameters for the ice thickness distribution
@@ -15271,9 +15255,6 @@ contains
 
   subroutine seaice_icepack_reinitialize_diagnostics_thermodynamics(domain)
 
-    use seaice_constants, only: &
-         seaiceIceOceanDragCoefficient
-
     type(domain_type) :: domain
 
     type(block_type), pointer :: block
@@ -15342,6 +15323,9 @@ contains
          pondAlbedoCell
 
     ! drag variables
+    real(kind=RKIND), pointer :: &
+         config_ice_ocean_drag_coefficient
+
     real(kind=RKIND), dimension(:), pointer :: &
          airOceanDragCoefficientRatio, &
          oceanDragCoefficient, &
@@ -15460,12 +15444,15 @@ contains
           pondAlbedoCell    = 0.0_RKIND
 
           ! form drag
+          call MPAS_pool_get_config(block % configs, "config_ice_ocean_drag_coefficient", &
+                                    config_ice_ocean_drag_coefficient)
+
           call MPAS_pool_get_subpool(block % structs, "drag", dragPool)
 
           call MPAS_pool_get_array(dragPool, "oceanDragCoefficient", oceanDragCoefficient)
           call MPAS_pool_get_array(dragPool, "airDragCoefficient", airDragCoefficient)
 
-          oceanDragCoefficient = seaiceIceOceanDragCoefficient
+          oceanDragCoefficient = config_ice_ocean_drag_coefficient
           airDragCoefficient   = seaice_icepack_initial_air_drag_coefficient()
 
           call MPAS_pool_get_config(block % configs, "config_use_form_drag", config_use_form_drag)

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -10466,8 +10466,8 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_max_dry_snow_radius", config_max_dry_snow_radius)
 
     if (seaiceIceOceanDragCoefficient /= config_ice_ocean_drag_coefficient) &
-       call mpas_log_write('ColPkg dragio differs from config_ice_ocean_drag_coefficient',
-                          realArgs=(/dragio,config_ice_ocean_drag_coefficient/))
+       call mpas_log_write('ColPkg dragio differs from config_ice_ocean_drag_coefficient', &
+               realArgs=(/seaiceIceOceanDragCoefficient,config_ice_ocean_drag_coefficient/))
 
     call colpkg_init_parameters(&
          config_cice_int("config_thermodynamics_type", config_thermodynamics_type), &

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -10061,6 +10061,9 @@ contains
     use ice_colpkg, only: &
          colpkg_init_parameters
 
+    use seaice_constants, only: &
+         seaiceIceOceanDragCoefficient    ! ice ocean drag coefficient
+
     type(domain_type), intent(inout) :: &
          domain
 
@@ -10099,6 +10102,7 @@ contains
 
     real(kind=RKIND), pointer :: &
          config_min_friction_velocity, &
+         config_ice_ocean_drag_coefficient, &
          config_rapid_mode_channel_radius, &
          config_rapid_model_critical_Ra, &
          config_rapid_mode_aspect_ratio, &
@@ -10264,6 +10268,7 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_ocean_heat_transfer_type", config_ocean_heat_transfer_type)
     call MPAS_pool_get_config(domain % configs, "config_calc_surface_temperature", config_calc_surface_temperature)
     call MPAS_pool_get_config(domain % configs, "config_min_friction_velocity", config_min_friction_velocity)
+    call MPAS_pool_get_config(domain % configs, "config_ice_ocean_drag_coefficient", config_ice_ocean_drag_coefficient)
     call MPAS_pool_get_config(domain % configs, "config_rapid_mode_channel_radius", config_rapid_mode_channel_radius)
     call MPAS_pool_get_config(domain % configs, "config_rapid_model_critical_Ra", config_rapid_model_critical_Ra)
     call MPAS_pool_get_config(domain % configs, "config_rapid_mode_aspect_ratio", config_rapid_mode_aspect_ratio)
@@ -10459,6 +10464,10 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_wind_compaction_factor", config_wind_compaction_factor)
     call MPAS_pool_get_config(domain % configs, "config_snow_redistribution_factor", config_snow_redistribution_factor)
     call MPAS_pool_get_config(domain % configs, "config_max_dry_snow_radius", config_max_dry_snow_radius)
+
+    if (seaiceIceOceanDragCoefficient /= config_ice_ocean_drag_coefficient) &
+       call mpas_log_write('ColPkg dragio differs from config_ice_ocean_drag_coefficient',
+                          realArgs=(/dragio,config_ice_ocean_drag_coefficient/))
 
     call colpkg_init_parameters(&
          config_cice_int("config_thermodynamics_type", config_thermodynamics_type), &
@@ -11574,6 +11583,7 @@ contains
 
     real(kind=RKIND), pointer :: &
          config_min_friction_velocity, &
+         config_ice_ocean_drag_coefficient, &
          config_rapid_mode_channel_radius, &
          config_rapid_model_critical_Ra, &
          config_rapid_mode_aspect_ratio, &
@@ -11767,6 +11777,7 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_update_ocean_fluxes", config_update_ocean_fluxes)
     call MPAS_pool_get_config(domain % configs, "config_frazil_coupling_type", config_frazil_coupling_type)
     call MPAS_pool_get_config(domain % configs, "config_min_friction_velocity", config_min_friction_velocity)
+    call MPAS_pool_get_config(domain % configs, "config_ice_ocean_drag_coefficient", config_ice_ocean_drag_coefficient)
     call MPAS_pool_get_config(domain % configs, "config_rapid_mode_channel_radius", config_rapid_mode_channel_radius)
     call MPAS_pool_get_config(domain % configs, "config_rapid_model_critical_Ra", config_rapid_model_critical_Ra)
     call MPAS_pool_get_config(domain % configs, "config_rapid_mode_aspect_ratio", config_rapid_mode_aspect_ratio)
@@ -12141,7 +12152,7 @@ contains
          hfrazilmin_in           = seaiceFrazilMinimumThickness, &
          !floediam_in             = , &
          depressT_in             = seaiceMeltingTemperatureDepression, &
-         dragio_in               = seaiceIceOceanDragCoefficient, & ! note calc_dragio not implemented
+         dragio_in               = config_ice_ocean_drag_coefficient, & ! calc_dragio not implemented
          !thickness_ocn_layer1_in = , &        ! not yet implemented in MPAS-SI (stealth feature)
          !iceruf_ocn_in           = , &        ! under-ice roughness, not yet implemented
          albocn_in               = seaiceOceanAlbedo, &
@@ -12672,6 +12683,10 @@ contains
     ! 'linear_salt' = -depressT * sss
     ! 'mushy' conforms with ktherm=2
     !tfrz_option = config_sea_freezing_temperature_type
+
+    ! dragio:
+    ! Neutral ice-ocean drag coefficient
+    !dragio = config_ice_ocean_drag_coefficient
 
     !-----------------------------------------------------------------------
     ! Parameters for the ice thickness distribution

--- a/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver.F
@@ -2826,7 +2826,7 @@ contains
   subroutine ocean_stress_coefficient(domain)
 
     use seaice_constants, only: &
-         seaiceDensitySeaWater, &
+         seaiceDensitySeaWater
 
     type(domain_type), intent(inout) :: &
          domain

--- a/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver.F
@@ -2827,7 +2827,6 @@ contains
 
     use seaice_constants, only: &
          seaiceDensitySeaWater, &
-         seaiceIceOceanDragCoefficient
 
     type(domain_type), intent(inout) :: &
          domain
@@ -2838,6 +2837,9 @@ contains
     type(MPAS_pool_type), pointer :: &
          velocitySolverPool, &
          icestatePool
+
+    real(kind=RKIND), pointer :: &
+         configIceOceanDragCoeff
 
     real(kind=RKIND), dimension(:), pointer :: &
          oceanStressCoeff, &
@@ -2863,6 +2865,7 @@ contains
     do while (associated(blockPtr))
 
        call MPAS_pool_get_config(blockPtr % configs, "config_use_ocean_stress", configUseOceanStress)
+       call MPAS_pool_get_config(blockPtr % configs, "config_ice_ocean_drag_coefficient", configIceOceanDragCoeff)
 
        call MPAS_pool_get_dimension(blockPtr % dimensions, "nVerticesSolve", nVerticesSolve)
 
@@ -2887,7 +2890,8 @@ contains
 
                 if (solveVelocity(iVertex) == 1) then
 
-                   oceanStressCoeff(iVertex) = seaiceIceOceanDragCoefficient * seaiceDensitySeaWater * iceAreaVertex(iVertex) * &
+                   oceanStressCoeff(iVertex) = configIceOceanDragCoeff * &
+                        seaiceDensitySeaWater * iceAreaVertex(iVertex) * &
                         sqrt((uOceanVelocityVertex(iVertex) - uVelocity(iVertex))**2 + &
                              (vOceanVelocityVertex(iVertex) - vVelocity(iVertex))**2)
 
@@ -2901,7 +2905,8 @@ contains
 
                 if (solveVelocity(iVertex) == 1) then
 
-                   oceanStressCoeff(iVertex) = seaiceIceOceanDragCoefficient * seaiceDensitySeaWater * iceAreaVertex(iVertex)
+                   oceanStressCoeff(iVertex) = configIceOceanDragCoeff * &
+                        seaiceDensitySeaWater * iceAreaVertex(iVertex)
 
                 endif
 


### PR DESCRIPTION
- Adds ksno and dragio to the namelist as config_snow_thermal_conductivity = 0.3 and config_ice_ocean_drag_coefficient = 0.00536, respectively.  
- Also removes dual declarations of config_nfloecategories in the namelist.  
- With unaltered declarations of these namelist options, this PR is BFB.   
- Namelist declarations only alter the actual model values if config_column_physics_type = 'icepack'.  For all initializations of ColPkg constants rather than Icepack constants, warnings appear in the log file if the namelist values differ from internally-declared constants, but the code does not abort:
```
 ColPkg dragio differs from config_ice_ocean_drag_coefficient
 ColPkg ksno differs from config_snow_thermal_conductivity
```