### PR TITLE
Replace config_use_column_package with config_use_column_physics

### DIFF
--- a/components/mpas-seaice/bld/build-namelist
+++ b/components/mpas-seaice/bld/build-namelist
@@ -561,7 +561,7 @@ add_default($nl, 'config_use_dynamics');
 add_default($nl, 'config_use_velocity_solver');
 add_default($nl, 'config_use_advection');
 add_default($nl, 'config_use_forcing');
-add_default($nl, 'config_use_column_package');
+add_default($nl, 'config_use_column_physics');
 add_default($nl, 'config_use_prescribed_ice');
 add_default($nl, 'config_use_prescribed_ice_forcing');
 

--- a/components/mpas-seaice/bld/build-namelist-section
+++ b/components/mpas-seaice/bld/build-namelist-section
@@ -96,7 +96,7 @@ add_default($nl, 'config_use_dynamics');
 add_default($nl, 'config_use_velocity_solver');
 add_default($nl, 'config_use_advection');
 add_default($nl, 'config_use_forcing');
-add_default($nl, 'config_use_column_package');
+add_default($nl, 'config_use_column_physics');
 add_default($nl, 'config_use_prescribed_ice');
 add_default($nl, 'config_use_prescribed_ice_forcing');
 

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -98,7 +98,7 @@
 <config_use_velocity_solver>true</config_use_velocity_solver>
 <config_use_advection>true</config_use_advection>
 <config_use_forcing>false</config_use_forcing>
-<config_use_column_package>true</config_use_column_package>
+<config_use_column_physics>true</config_use_column_physics>
 <config_use_prescribed_ice>false</config_use_prescribed_ice>
 <config_use_prescribed_ice prognostic_mode="prescribed">true</config_use_prescribed_ice>
 <config_use_prescribed_ice_forcing>false</config_use_prescribed_ice_forcing>

--- a/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
@@ -453,7 +453,7 @@ Valid values: true or .false
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_use_column_package" type="logical"
+<entry id="config_use_column_physics" type="logical"
 	category="use_sections" group="use_sections">
 If true perform calculations from the column physics package.
 

--- a/components/mpas-seaice/src/Registry.xml
+++ b/components/mpas-seaice/src/Registry.xml
@@ -514,7 +514,7 @@
 			description="If true calculate input forcing fields."
 			possible_values="true or .false"
 		/>
-		<nml_option name="config_use_column_package" type="logical" default_value="true" units="unitless"
+		<nml_option name="config_use_column_physics" type="logical" default_value="true" units="unitless"
 			description="If true perform calculations from the column physics package."
 			possible_values="true or .false"
 		/>

--- a/components/mpas-seaice/src/analysis_members/mpas_seaice_miscellaneous.F
+++ b/components/mpas-seaice/src/analysis_members/mpas_seaice_miscellaneous.F
@@ -290,18 +290,18 @@ contains
            iVertex
 
       logical, pointer :: &
-           config_use_column_package, &
+           config_use_column_physics, &
            config_use_column_shortwave, &
            config_use_velocity_solver
 
       err = 0
 
-      call MPAS_pool_get_config(domain % configs, "config_use_column_package", config_use_column_package)
+      call MPAS_pool_get_config(domain % configs, "config_use_column_physics", config_use_column_physics)
       call MPAS_pool_get_config(domain % configs, "config_use_column_shortwave", config_use_column_shortwave)
       call MPAS_pool_get_config(domain % configs, "config_use_velocity_solver", config_use_velocity_solver)
 
       ! grid cell mean salinity
-      if (config_use_column_package) then
+      if (config_use_column_physics) then
          block => domain % blocklist
          do while(associated(block))
 
@@ -325,7 +325,7 @@ contains
       endif
 
       ! snow/ice broad band albedo
-      if (config_use_column_package .and. config_use_column_shortwave) then
+      if (config_use_column_physics .and. config_use_column_shortwave) then
          block => domain % blocklist
          do while(associated(block))
 

--- a/components/mpas-seaice/src/model_forward/mpas_seaice_core_interface.F
+++ b/components/mpas-seaice/src/model_forward/mpas_seaice_core_interface.F
@@ -225,7 +225,7 @@ module seaice_core_interface
 
      ! column physics package packages
      logical, pointer :: &
-          config_use_column_package, &
+          config_use_column_physics, &
           config_use_column_biogeochemistry
 
      logical, pointer :: &
@@ -313,14 +313,14 @@ module seaice_core_interface
      !pkgColumnPackage
      !pkgColumnBiogeochemistry
 
-     call MPAS_pool_get_config(configPool, "config_use_column_package", config_use_column_package)
+     call MPAS_pool_get_config(configPool, "config_use_column_physics", config_use_column_physics)
      call MPAS_pool_get_config(configPool, "config_use_column_biogeochemistry", config_use_column_biogeochemistry)
 
      call MPAS_pool_get_package(packagePool, "pkgColumnPackageActive", pkgColumnPackageActive)
      call MPAS_pool_get_package(packagePool, "pkgColumnBiogeochemistryActive", pkgColumnBiogeochemistryActive)
 
-     pkgColumnPackageActive         = config_use_column_package
-     pkgColumnBiogeochemistryActive = (config_use_column_biogeochemistry .and. config_use_column_package)
+     pkgColumnPackageActive         = config_use_column_physics
+     pkgColumnBiogeochemistryActive = (config_use_column_biogeochemistry .and. config_use_column_physics)
 
      !pkgColumnPackageActive         = .true.
      !pkgColumnBiogeochemistryActive = .true.
@@ -458,7 +458,7 @@ module seaice_core_interface
      pkgColumnTracerEffectiveSnowDensityActive = config_use_effective_snow_density
      pkgColumnTracerSnowGrainRadiusActive = config_use_snow_grain_radius
 
-     if (.not. config_use_column_package) then
+     if (.not. config_use_column_physics) then
         pkgColumnTracerIceAgeActive       = .false.
         pkgColumnTracerFirstYearIceActive = .false.
         pkgColumnTracerLevelIceActive     = .false.
@@ -493,7 +493,7 @@ module seaice_core_interface
         pkgColumnTracerSnowGrainRadiusActive      = .false.
      endif
 
-     if (.not. config_use_column_biogeochemistry .and. config_use_column_package) then
+     if (.not. config_use_column_biogeochemistry .and. config_use_column_physics) then
         pkgTracerBrineActive                = .false.
         pkgTracerMobileFractionActive       = .false.
         pkgTracerSkeletalAlgaeActive        = .false.
@@ -537,7 +537,7 @@ module seaice_core_interface
      ! form drag
      call MPAS_pool_get_config(configPool, "config_use_form_drag", config_use_form_drag)
      call MPAS_pool_get_package(packagePool, "pkgColumnFormDragActive", pkgColumnFormDragActive)
-     pkgColumnFormDragActive = (config_use_column_package .and. config_use_form_drag)
+     pkgColumnFormDragActive = (config_use_column_physics .and. config_use_form_drag)
 
      !pkgColumnFormDragActive = .true.
 

--- a/components/mpas-seaice/src/shared/mpas_seaice_column.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_column.F
@@ -218,10 +218,10 @@ contains
     type(domain_type), intent(inout) :: domain
 
     logical, pointer :: &
-         config_use_column_package
+         config_use_column_physics
 
-    call MPAS_pool_get_config(domain % configs, "config_use_column_package", config_use_column_package)
-    if (config_use_column_package) then
+    call MPAS_pool_get_config(domain % configs, "config_use_column_physics", config_use_column_physics)
+    if (config_use_column_physics) then
 
        ! set non activated variable pointers to other memory
        call init_column_non_activated_pointers(domain)
@@ -259,16 +259,16 @@ contains
          clock !< Input:
 
     logical, pointer :: &
-         config_use_column_package, &
+         config_use_column_physics, &
          config_do_restart, &
          config_use_column_biogeochemistry, &
          config_use_column_shortwave, &
          config_use_column_snow_tracers
 
-    call MPAS_pool_get_config(domain % configs, "config_use_column_package", config_use_column_package)
+    call MPAS_pool_get_config(domain % configs, "config_use_column_physics", config_use_column_physics)
     call MPAS_pool_get_config(domain % configs, "config_use_column_biogeochemistry", config_use_column_biogeochemistry)
 
-    if (config_use_column_package) then
+    if (config_use_column_physics) then
 
        ! initialize level ice tracers
        call init_column_level_ice_tracers(domain)
@@ -1048,7 +1048,7 @@ contains
     type(MPAS_clock_type), intent(in) :: clock
 
     logical, pointer :: &
-         config_use_column_package, &
+         config_use_column_physics, &
          config_use_column_shortwave, &
          config_use_column_vertical_thermodynamics, &
          config_use_column_biogeochemistry, &
@@ -1059,9 +1059,9 @@ contains
     real(kind=RKIND), pointer :: &
          config_dt
 
-    call MPAS_pool_get_config(domain % configs, "config_use_column_package", config_use_column_package)
+    call MPAS_pool_get_config(domain % configs, "config_use_column_physics", config_use_column_physics)
 
-    if (config_use_column_package) then
+    if (config_use_column_physics) then
 
        call MPAS_pool_get_config(domain % configs, "config_use_column_shortwave", config_use_column_shortwave)
        call MPAS_pool_get_config(domain % configs, "config_use_column_vertical_thermodynamics", &
@@ -1149,7 +1149,7 @@ contains
     type(MPAS_clock_type), intent(in) :: clock
 
     logical, pointer :: &
-         config_use_column_package, &
+         config_use_column_physics, &
          config_use_column_ridging, &
          config_use_vertical_tracers
 
@@ -1159,9 +1159,9 @@ contains
     real(kind=RKIND), pointer :: &
          dynamicsTimeStep
 
-    call MPAS_pool_get_config(domain % configs, "config_use_column_package", config_use_column_package)
+    call MPAS_pool_get_config(domain % configs, "config_use_column_physics", config_use_column_physics)
 
-    if (config_use_column_package) then
+    if (config_use_column_physics) then
 
        call MPAS_pool_get_config(domain % configs, "config_use_column_ridging", config_use_column_ridging)
        call MPAS_pool_get_config(domain % configs, "config_use_vertical_tracers", config_use_vertical_tracers)
@@ -1224,16 +1224,16 @@ contains
     type(MPAS_clock_type), intent(in) :: clock
 
     logical, pointer :: &
-         config_use_column_package, &
+         config_use_column_physics, &
          config_use_column_shortwave, &
          config_use_column_snow_tracers
 
     type(block_type), pointer :: &
          block
 
-    call MPAS_pool_get_config(domain % configs, "config_use_column_package", config_use_column_package)
+    call MPAS_pool_get_config(domain % configs, "config_use_column_physics", config_use_column_physics)
 
-    if (config_use_column_package) then
+    if (config_use_column_physics) then
 
        call MPAS_pool_get_config(domain % configs, "config_use_column_shortwave", config_use_column_shortwave)
        call MPAS_pool_get_config(domain % configs, "config_use_column_snow_tracers", config_use_column_snow_tracers)
@@ -13332,7 +13332,7 @@ contains
          atmosReferenceSpeed10m
 
     logical, pointer :: &
-         config_use_column_package
+         config_use_column_physics
 
     block => domain % blocklist
     do while (associated(block))
@@ -13354,9 +13354,9 @@ contains
        atmosReferenceHumidity2m(:)    = 0.0_RKIND
        atmosReferenceSpeed10m(:)      = 0.0_RKIND
 
-       call MPAS_pool_get_config(block % configs, "config_use_column_package", config_use_column_package)
+       call MPAS_pool_get_config(block % configs, "config_use_column_physics", config_use_column_physics)
 
-       if (config_use_column_package) then
+       if (config_use_column_physics) then
 
           call MPAS_pool_get_subpool(block % structs, "atmos_fluxes", atmosFluxesPool)
           call MPAS_pool_get_subpool(block % structs, "shortwave", shortwavePool)
@@ -13375,7 +13375,7 @@ contains
           evaporativeWaterFlux(:)  = 0.0_RKIND
           longwaveUp(:)            = 0.0_RKIND
 
-       endif ! config_use_column_package
+       endif ! config_use_column_physics
 
        block => block % next
     end do
@@ -13413,16 +13413,16 @@ contains
          snowMeltMassCell
 
     logical, pointer :: &
-         config_use_column_package, &
+         config_use_column_physics, &
          config_use_column_snow_tracers
 
     block => domain % blocklist
     do while (associated(block))
 
-       call MPAS_pool_get_config(block % configs, "config_use_column_package", config_use_column_package)
+       call MPAS_pool_get_config(block % configs, "config_use_column_physics", config_use_column_physics)
        call MPAS_pool_get_config(block % configs, "config_use_column_snow_tracers", config_use_column_snow_tracers)
 
-       if (config_use_column_package) then
+       if (config_use_column_physics) then
 
           call MPAS_pool_get_subpool(block % structs, "ocean_fluxes", oceanFluxesPool)
 
@@ -13447,7 +13447,7 @@ contains
 
           endif ! config_use_column_snow_tracers
 
-       endif ! config_use_column_package
+       endif ! config_use_column_physics
 
        block => block % next
     end do
@@ -14404,12 +14404,12 @@ contains
     logical, pointer :: &
          config_use_ice_age, &
          config_use_form_drag, &
-         config_use_column_package, &
+         config_use_column_physics, &
          config_use_column_snow_tracers
 
-    call MPAS_pool_get_config(domain % blocklist % configs, "config_use_column_package", config_use_column_package)
+    call MPAS_pool_get_config(domain % blocklist % configs, "config_use_column_physics", config_use_column_physics)
 
-    if (config_use_column_package) then
+    if (config_use_column_physics) then
 
        block => domain % blocklist
        do while (associated(block))
@@ -14573,7 +14573,7 @@ contains
           block => block % next
        end do
 
-    endif ! config_use_column_package
+    endif ! config_use_column_physics
 
   end subroutine seaice_column_reinitialize_diagnostics_thermodynamics
 
@@ -14642,17 +14642,17 @@ contains
 
     logical, pointer :: &
          config_use_ice_age, &
-         config_use_column_package, &
+         config_use_column_physics, &
          config_use_velocity_solver
 
     character(len=strKIND), pointer :: &
          config_stress_divergence_scheme
 
-    call MPAS_pool_get_config(domain % blocklist % configs, "config_use_column_package", config_use_column_package)
+    call MPAS_pool_get_config(domain % blocklist % configs, "config_use_column_physics", config_use_column_physics)
     call MPAS_pool_get_config(domain % blocklist % configs, "config_use_velocity_solver", config_use_velocity_solver)
     call MPAS_pool_get_config(domain % blocklist % configs, "config_stress_divergence_scheme", config_stress_divergence_scheme)
 
-    if (config_use_column_package) then
+    if (config_use_column_physics) then
 
        block => domain % blocklist
        do while (associated(block))
@@ -14741,7 +14741,7 @@ contains
           block => block % next
        end do
 
-    endif ! config_use_column_package
+    endif ! config_use_column_physics
 
   end subroutine seaice_column_reinitialize_diagnostics_dynamics
 
@@ -14793,13 +14793,13 @@ contains
     logical, pointer :: &
          config_use_column_biogeochemistry, &
          config_use_column_shortwave, &
-         config_use_column_package, &
+         config_use_column_physics, &
          config_use_vertical_biochemistry, &
          config_use_vertical_zsalinity
 
-    call MPAS_pool_get_config(domain % blocklist % configs, "config_use_column_package", config_use_column_package)
+    call MPAS_pool_get_config(domain % blocklist % configs, "config_use_column_physics", config_use_column_physics)
 
-     if (config_use_column_package) then
+     if (config_use_column_physics) then
 
        block => domain % blocklist
        do while (associated(block))
@@ -14872,7 +14872,7 @@ contains
           block => block % next
        end do
 
-    endif ! config_use_column_package
+    endif ! config_use_column_physics
 
   end subroutine seaice_column_reinitialize_diagnostics_bgc
 

--- a/components/mpas-seaice/src/shared/mpas_seaice_forcing.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_forcing.F
@@ -3124,11 +3124,11 @@ contains
     type(domain_type) :: domain
 
     logical, pointer :: &
-         config_use_column_package
+         config_use_column_physics
 
-    call MPAS_pool_get_config(domain % blocklist % configs, "config_use_column_package", config_use_column_package)
+    call MPAS_pool_get_config(domain % blocklist % configs, "config_use_column_physics", config_use_column_physics)
 
-    if (config_use_column_package) then
+    if (config_use_column_physics) then
 
        call reset_atmospheric_coupler_fluxes(domain)
        call reset_ocean_coupler_fluxes(domain)

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -213,10 +213,10 @@ contains
     type(domain_type), intent(inout) :: domain
 
     logical, pointer :: &
-         config_use_column_package
+         config_use_column_physics
 
-    call MPAS_pool_get_config(domain % configs, "config_use_column_package", config_use_column_package)
-    if (config_use_column_package) then
+    call MPAS_pool_get_config(domain % configs, "config_use_column_physics", config_use_column_physics)
+    if (config_use_column_physics) then
 
        ! set non activated variable pointers to other memory
        call init_icepack_non_activated_pointers(domain)
@@ -251,16 +251,16 @@ contains
          clock !< Input:
 
     logical, pointer :: &
-         config_use_column_package, &
+         config_use_column_physics, &
          config_do_restart, &
          config_use_column_biogeochemistry, &
          config_use_column_shortwave, &
          config_use_column_snow_tracers
 
-    call MPAS_pool_get_config(domain % configs, "config_use_column_package", config_use_column_package)
+    call MPAS_pool_get_config(domain % configs, "config_use_column_physics", config_use_column_physics)
     call MPAS_pool_get_config(domain % configs, "config_use_column_biogeochemistry", config_use_column_biogeochemistry)
 
-    if (config_use_column_package) then
+    if (config_use_column_physics) then
 
        ! initialize level ice tracers
        call init_column_level_ice_tracers(domain)
@@ -1017,7 +1017,7 @@ contains
     type(MPAS_clock_type), intent(in) :: clock
 
     logical, pointer :: &
-         config_use_column_package, &
+         config_use_column_physics, &
          config_use_column_shortwave, &
          config_use_column_vertical_thermodynamics, &
          config_use_column_biogeochemistry, &
@@ -1028,9 +1028,9 @@ contains
     real(kind=RKIND), pointer :: &
          config_dt
 
-    call MPAS_pool_get_config(domain % configs, "config_use_column_package", config_use_column_package)
+    call MPAS_pool_get_config(domain % configs, "config_use_column_physics", config_use_column_physics)
 
-    if (config_use_column_package) then
+    if (config_use_column_physics) then
 
        call MPAS_pool_get_config(domain % configs, "config_use_column_shortwave", config_use_column_shortwave)
        call MPAS_pool_get_config(domain % configs, "config_use_column_vertical_thermodynamics", &
@@ -1118,7 +1118,7 @@ contains
     type(MPAS_clock_type), intent(in) :: clock
 
     logical, pointer :: &
-         config_use_column_package, &
+         config_use_column_physics, &
          config_use_column_ridging, &
          config_use_vertical_tracers
 
@@ -1128,9 +1128,9 @@ contains
     real(kind=RKIND), pointer :: &
          dynamicsTimeStep
 
-    call MPAS_pool_get_config(domain % configs, "config_use_column_package", config_use_column_package)
+    call MPAS_pool_get_config(domain % configs, "config_use_column_physics", config_use_column_physics)
 
-    if (config_use_column_package) then
+    if (config_use_column_physics) then
 
        call MPAS_pool_get_config(domain % configs, "config_use_column_ridging", config_use_column_ridging)
        call MPAS_pool_get_config(domain % configs, "config_use_vertical_tracers", config_use_vertical_tracers)
@@ -1193,16 +1193,16 @@ contains
     type(MPAS_clock_type), intent(in) :: clock
 
     logical, pointer :: &
-         config_use_column_package, &
+         config_use_column_physics, &
          config_use_column_shortwave, &
          config_use_column_snow_tracers
 
     type(block_type), pointer :: &
          block
 
-    call MPAS_pool_get_config(domain % configs, "config_use_column_package", config_use_column_package)
+    call MPAS_pool_get_config(domain % configs, "config_use_column_physics", config_use_column_physics)
 
-    if (config_use_column_package) then
+    if (config_use_column_physics) then
 
        call MPAS_pool_get_config(domain % configs, "config_use_column_shortwave", config_use_column_shortwave)
        call MPAS_pool_get_config(domain % configs, "config_use_column_snow_tracers", config_use_column_snow_tracers)
@@ -14298,7 +14298,7 @@ contains
          atmosReferenceSpeed10m
 
     logical, pointer :: &
-         config_use_column_package
+         config_use_column_physics
 
     block => domain % blocklist
     do while (associated(block))
@@ -14320,9 +14320,9 @@ contains
        atmosReferenceHumidity2m(:)    = 0.0_RKIND
        atmosReferenceSpeed10m(:)      = 0.0_RKIND
 
-       call MPAS_pool_get_config(block % configs, "config_use_column_package", config_use_column_package)
+       call MPAS_pool_get_config(block % configs, "config_use_column_physics", config_use_column_physics)
 
-       if (config_use_column_package) then
+       if (config_use_column_physics) then
 
           call MPAS_pool_get_subpool(block % structs, "atmos_fluxes", atmosFluxesPool)
           call MPAS_pool_get_subpool(block % structs, "shortwave", shortwavePool)
@@ -14341,7 +14341,7 @@ contains
           evaporativeWaterFlux(:)  = 0.0_RKIND
           longwaveUp(:)            = 0.0_RKIND
 
-       endif ! config_use_column_package
+       endif ! config_use_column_physics
 
        block => block % next
     end do
@@ -14379,16 +14379,16 @@ contains
          snowMeltMassCell
 
     logical, pointer :: &
-         config_use_column_package, &
+         config_use_column_physics, &
          config_use_column_snow_tracers
 
     block => domain % blocklist
     do while (associated(block))
 
-       call MPAS_pool_get_config(block % configs, "config_use_column_package", config_use_column_package)
+       call MPAS_pool_get_config(block % configs, "config_use_column_physics", config_use_column_physics)
        call MPAS_pool_get_config(block % configs, "config_use_column_snow_tracers", config_use_column_snow_tracers)
 
-       if (config_use_column_package) then
+       if (config_use_column_physics) then
 
           call MPAS_pool_get_subpool(block % structs, "ocean_fluxes", oceanFluxesPool)
 
@@ -14413,7 +14413,7 @@ contains
 
           endif ! config_use_column_snow_tracers
 
-       endif ! config_use_column_package
+       endif ! config_use_column_physics
 
        block => block % next
     end do
@@ -15361,12 +15361,12 @@ contains
     logical, pointer :: &
          config_use_ice_age, &
          config_use_form_drag, &
-         config_use_column_package, &
+         config_use_column_physics, &
          config_use_column_snow_tracers
 
-    call MPAS_pool_get_config(domain % blocklist % configs, "config_use_column_package", config_use_column_package)
+    call MPAS_pool_get_config(domain % blocklist % configs, "config_use_column_physics", config_use_column_physics)
 
-    if (config_use_column_package) then
+    if (config_use_column_physics) then
 
        block => domain % blocklist
        do while (associated(block))
@@ -15530,7 +15530,7 @@ contains
           block => block % next
        end do
 
-    endif ! config_use_column_package
+    endif ! config_use_column_physics
 
   end subroutine seaice_icepack_reinitialize_diagnostics_thermodynamics
 
@@ -15599,17 +15599,17 @@ contains
 
     logical, pointer :: &
          config_use_ice_age, &
-         config_use_column_package, &
+         config_use_column_physics, &
          config_use_velocity_solver
 
     character(len=strKIND), pointer :: &
          config_stress_divergence_scheme
 
-    call MPAS_pool_get_config(domain % blocklist % configs, "config_use_column_package", config_use_column_package)
+    call MPAS_pool_get_config(domain % blocklist % configs, "config_use_column_physics", config_use_column_physics)
     call MPAS_pool_get_config(domain % blocklist % configs, "config_use_velocity_solver", config_use_velocity_solver)
     call MPAS_pool_get_config(domain % blocklist % configs, "config_stress_divergence_scheme", config_stress_divergence_scheme)
 
-    if (config_use_column_package) then
+    if (config_use_column_physics) then
 
        block => domain % blocklist
        do while (associated(block))
@@ -15634,7 +15634,7 @@ contains
           surfaceTiltForceU   = 0.0_RKIND
           surfaceTiltForceV   = 0.0_RKIND
 
-          if (config_use_velocity_solver .and. trim(config_stress_divergence_scheme) == "weak") then !echmod BUG? - why is this here and wrapped in a config_use_column_package conditional?
+          if (config_use_velocity_solver .and. trim(config_stress_divergence_scheme) == "weak") then !echmod BUG? - why is this here and wrapped in a config_use_column_physics conditional?
 
              call MPAS_pool_get_subpool(block % structs, "velocity_weak", velocityWeakPool)
 
@@ -15698,7 +15698,7 @@ contains
           block => block % next
        end do
 
-    endif ! config_use_column_package
+    endif ! config_use_column_physics
 
   end subroutine seaice_icepack_reinitialize_diagnostics_dynamics
 
@@ -15750,13 +15750,13 @@ contains
     logical, pointer :: &
          config_use_column_biogeochemistry, &
          config_use_column_shortwave, &
-         config_use_column_package, &
+         config_use_column_physics, &
          config_use_vertical_biochemistry!, &
 !         config_use_vertical_zsalinity         !echmod deprecate
 
-    call MPAS_pool_get_config(domain % blocklist % configs, "config_use_column_package", config_use_column_package)
+    call MPAS_pool_get_config(domain % blocklist % configs, "config_use_column_physics", config_use_column_physics)
 
-     if (config_use_column_package) then
+     if (config_use_column_physics) then
 
        block => domain % blocklist
        do while (associated(block))
@@ -15829,7 +15829,7 @@ contains
           block => block % next
        end do
 
-    endif ! config_use_column_package
+    endif ! config_use_column_physics
 
   end subroutine seaice_icepack_reinitialize_diagnostics_bgc
 

--- a/components/mpas-seaice/src/shared/mpas_seaice_initialize.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_initialize.F
@@ -204,19 +204,19 @@ contains
          clock !< Input:
 
     logical, pointer :: &
-         config_use_column_package, &
+         config_use_column_physics, &
          config_use_column_shortwave, &
          config_do_restart
 
     character(len=strKIND), pointer :: &
          config_column_physics_type
 
-    call MPAS_pool_get_config(domain % configs, "config_use_column_package", config_use_column_package)
+    call MPAS_pool_get_config(domain % configs, "config_use_column_physics", config_use_column_physics)
     call MPAS_pool_get_config(domain % configs, "config_use_column_shortwave", config_use_column_shortwave)
     call MPAS_pool_get_config(domain % configs, "config_do_restart", config_do_restart)
     call MPAS_pool_get_config(domain % configs, "config_column_physics_type", config_column_physics_type)
 
-    if (config_use_column_package .and. config_use_column_shortwave .and. .not. config_do_restart) then
+    if (config_use_column_physics .and. config_use_column_shortwave .and. .not. config_do_restart) then
        if (trim(config_column_physics_type) == "icepack") then
           call seaice_init_icepack_shortwave(domain, clock)
        else if (trim(config_column_physics_type) == "column_package") then
@@ -330,7 +330,7 @@ contains
 
     logical, pointer :: &
          config_do_restart, &
-         config_use_column_package
+         config_use_column_physics
 
     call MPAS_pool_get_config(domain % configs, "config_do_restart", config_do_restart)
 
@@ -497,9 +497,9 @@ contains
     endif
 
     ! aggregate tracers even if restart
-    call MPAS_pool_get_config(domain % blocklist % configs, "config_use_column_package", config_use_column_package)
+    call MPAS_pool_get_config(domain % blocklist % configs, "config_use_column_physics", config_use_column_physics)
     call MPAS_pool_get_config(domain % blocklist % configs, "config_column_physics_type", config_column_physics_type)
-    if (config_use_column_package) then
+    if (config_use_column_physics) then
        if (trim(config_column_physics_type) == "icepack") then
           call seaice_icepack_aggregate(domain)
        else if (trim(config_column_physics_type) == "column_package") then
@@ -1113,7 +1113,7 @@ contains
          iCategory
 
     logical, pointer :: &
-         config_use_column_package
+         config_use_column_physics
 
     real(kind=RKIND), parameter :: &
          thicknessWithLargestArea = 3.0_RKIND ! initial ice thickness with greatest area
@@ -1139,9 +1139,9 @@ contains
     ! init caregory limits if needed
     !--------------------------------------------------------
 
-    call MPAS_pool_get_config(block % configs, "config_use_column_package", config_use_column_package)
+    call MPAS_pool_get_config(block % configs, "config_use_column_physics", config_use_column_physics)
 
-    if (.not. config_use_column_package) then
+    if (.not. config_use_column_physics) then
 
        if (trim(config_column_physics_type) == "icepack") then
           call icepack_init_itd(&
@@ -2580,7 +2580,7 @@ contains
     logical, pointer :: &
          config_do_restart, &
          config_use_column_biogeochemistry, &
-         config_use_column_package, &
+         config_use_column_physics, &
          config_use_aerosols
 
     integer, pointer :: &
@@ -2647,9 +2647,9 @@ contains
        ! fluxes sent to atmosphere
        !-------------------------------------------------------------
 
-       call MPAS_pool_get_config(block % configs, "config_use_column_package", config_use_column_package)
+       call MPAS_pool_get_config(block % configs, "config_use_column_physics", config_use_column_physics)
 
-       if (config_use_column_package) then
+       if (config_use_column_physics) then
 
           call MPAS_pool_get_subpool(block % structs, "atmos_fluxes", atmosFluxes)
           call MPAS_pool_get_array(atmosFluxes, "longwaveUp", longwaveUp)
@@ -2662,6 +2662,7 @@ contains
           else if (trim(config_column_physics_type) == "column_package") then
              airDragCoefficient = seaice_column_initial_air_drag_coefficient()
           endif ! config_column_physics_type
+
        endif
 
        !-------------------------------------------------------------

--- a/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver.F
@@ -757,7 +757,7 @@ contains
          totalMassCell
 
     logical, pointer :: &
-         config_use_column_package, &
+         config_use_column_physics, &
          config_use_column_vertical_thermodynamics, &
          config_use_halo_exch, &
          config_aggregate_halo_exch, &
@@ -768,12 +768,12 @@ contains
          ierr
 
     ! set initial ice area if not have column physics
-    call MPAS_pool_get_config(domain % configs, "config_use_column_package", config_use_column_package)
+    call MPAS_pool_get_config(domain % configs, "config_use_column_physics", config_use_column_physics)
     call MPAS_pool_get_config(domain % configs, "config_use_column_vertical_thermodynamics", &
                                                  config_use_column_vertical_thermodynamics)
 
-    if (.not. config_use_column_package .or. &
-         (config_use_column_package .and. .not. config_use_column_vertical_thermodynamics)) then
+    if (.not. config_use_column_physics .or. &
+         (config_use_column_physics .and. .not. config_use_column_vertical_thermodynamics)) then
 
        blockPtr => domain % blocklist
        do while (associated(blockPtr))
@@ -1350,7 +1350,7 @@ contains
          solveStress
 
     logical, pointer :: &
-         config_use_column_package, &
+         config_use_column_physics, &
          config_use_column_vertical_thermodynamics, &
          config_use_halo_exch, &
          config_aggregate_halo_exch, &
@@ -1371,7 +1371,7 @@ contains
     do while (associated(blockPtr))
 
        call MPAS_pool_get_config(blockPtr % configs, "config_column_physics_type", config_column_physics_type)
-       call MPAS_pool_get_config(blockPtr % configs, "config_use_column_package", config_use_column_package)
+       call MPAS_pool_get_config(blockPtr % configs, "config_use_column_physics", config_use_column_physics)
        call MPAS_pool_get_config(blockPtr % configs, "config_use_column_vertical_thermodynamics", &
                                                       config_use_column_vertical_thermodynamics)
 
@@ -1394,8 +1394,8 @@ contains
        call MPAS_pool_get_array(tracersPool, "iceAreaCategory", iceAreaCategory, 1)
        call MPAS_pool_get_array(tracersPool, "iceVolumeCategory", iceVolumeCategory, 1)
 
-       if (.not. config_use_column_package .or. &
-            (config_use_column_package .and. .not. config_use_column_vertical_thermodynamics)) then
+       if (.not. config_use_column_physics .or. &
+            (config_use_column_physics .and. .not. config_use_column_vertical_thermodynamics)) then
 
           do iCell = 1, nCellsSolve
 
@@ -1535,7 +1535,7 @@ contains
          blockPtr
 
     logical, pointer :: &
-         config_use_column_package, &
+         config_use_column_physics, &
          config_use_column_vertical_thermodynamics, &
          config_use_air_stress, &
          config_use_halo_exch, &
@@ -1556,12 +1556,12 @@ contains
          ierr
 
     ! calculate the air stress
-    call MPAS_pool_get_config(domain % blocklist % configs, "config_use_column_package", config_use_column_package)
+    call MPAS_pool_get_config(domain % blocklist % configs, "config_use_column_physics", config_use_column_physics)
     call MPAS_pool_get_config(domain % blocklist % configs, "config_use_column_vertical_thermodynamics", &
                                                              config_use_column_vertical_thermodynamics)
 
-    if (.not. config_use_column_package .or. &
-         (config_use_column_package .and. .not. config_use_column_vertical_thermodynamics)) then
+    if (.not. config_use_column_physics .or. &
+         (config_use_column_physics .and. .not. config_use_column_vertical_thermodynamics)) then
        call constant_air_stress(domain)
     endif
 

--- a/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver_variational.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver_variational.F
@@ -1080,7 +1080,7 @@ contains
          Delta
 
     logical, pointer :: &
-         config_use_column_package
+         config_use_column_physics
 
     integer :: &
          iCell, &
@@ -1139,9 +1139,9 @@ contains
        enddo ! iCell
 
        ! ridging parameters
-       call MPAS_pool_get_config(blockPtr % configs, "config_use_column_package", config_use_column_package)
+       call MPAS_pool_get_config(blockPtr % configs, "config_use_column_physics", config_use_column_physics)
 
-       if (config_use_column_package) then
+       if (config_use_column_physics) then
 
           call MPAS_pool_get_subpool(blockPtr % structs, "ridging", ridgingPool)
 
@@ -1164,7 +1164,7 @@ contains
 
           enddo ! iCell
 
-       endif ! config_use_column_package
+       endif ! config_use_column_physics
 
        ! units - for comparison to CICE
        divergence = divergence * 100.0_RKIND * 86400.0_RKIND

--- a/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver_weak.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_velocity_solver_weak.F
@@ -759,7 +759,7 @@ contains
          strainShearing
 
     logical, pointer :: &
-         config_use_column_package
+         config_use_column_physics
 
     integer :: &
          iCell
@@ -803,9 +803,9 @@ contains
        enddo ! iCell
 
        ! ridging parameters
-       call MPAS_pool_get_config(blockPtr % configs, "config_use_column_package", config_use_column_package)
+       call MPAS_pool_get_config(blockPtr % configs, "config_use_column_physics", config_use_column_physics)
 
-       if (config_use_column_package) then
+       if (config_use_column_physics) then
 
           call MPAS_pool_get_subpool(blockPtr % structs, "ridging", ridgingPool)
 
@@ -828,7 +828,7 @@ contains
 
           enddo ! iCell
 
-       endif ! config_use_column_package
+       endif ! config_use_column_physics
 
        ! cleanup
        deallocate(Delta)


### PR DESCRIPTION
This PR replaces "config_use_column_package" with "config_use_column_physics" throughout the code to avoid confusion now that both "icepack" and "column_package" are values for "config_use_column_physics_type".

### Testing

This PR passes D-case SMS, ERS, PEM and PET tests.  It is also BFB with the main Icepack integration branch to which the PR is being submitted, as tested in a 1-month D-case integration.