### PR TITLE
Set Icepack as the default column physics package in MPAS-SI

### DIFF
--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -171,7 +171,7 @@
 <config_recover_tracer_means_check>false</config_recover_tracer_means_check>
 
 <!-- column_package -->
-<config_column_physics_type>'column_package'</config_column_physics_type>
+<config_column_physics_type>'icepack'</config_column_physics_type>
 <config_use_column_shortwave>true</config_use_column_shortwave>
 <config_use_column_vertical_thermodynamics>true</config_use_column_vertical_thermodynamics>
 <config_use_column_biogeochemistry>false</config_use_column_biogeochemistry>

--- a/components/mpas-seaice/src/Registry.xml
+++ b/components/mpas-seaice/src/Registry.xml
@@ -703,7 +703,7 @@
 
 	<!-- column physics -->
 	<nml_record name="column_package" in_defaults="true">
-		<nml_option name="config_column_physics_type" type="character" default_value="column_package" units="unitless"
+		<nml_option name="config_column_physics_type" type="character" default_value="icepack" units="unitless"
 			description="Type of column library."
 			possible_values="'icepack' and 'column_package'"
 		/>


### PR DESCRIPTION
Change the default value of `config_column_physics_type` from `column_package` to `icepack`.
BFB in 3-month D cases.