### PR TITLE
Fix icepack prescribed ice mode for F-case simulations

### DIFF
--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -5647,7 +5647,8 @@ contains
 
   !-----------------------------------------------------------------------
 
-  function seaice_icepack_enthalpy_ice(iceTemperature, iceSalinity) result(iceEnthalpy)
+  function seaice_icepack_enthalpy_ice(iceTemperature, iceSalinity, &
+                                       config_thermodynamics_type) result(iceEnthalpy)
 
     use icepack_intfc, only: icepack_enthalpy_mush
 
@@ -5658,28 +5659,24 @@ contains
         seaiceLatentHeatMelting, &            ! latent heat of melting of fresh ice (J/kg)
         seaiceSeaWaterSpecificHeat            ! specific heat of ocn (J/kg/K)
 
-    type(domain_type) :: domain
-
     real(kind=RKIND), intent(in) :: iceTemperature
     real(kind=RKIND), intent(in) :: iceSalinity
     real(kind=RKIND) :: iceEnthalpy
 
-    real(kind=RKIND) :: qin
     real(kind=RKIND) :: Tmlt
 
     character(len=strKIND), pointer :: config_thermodynamics_type
 
-    call MPAS_pool_get_config(domain % configs, "config_thermodynamics_type", config_thermodynamics_type)
-
     if (trim(config_thermodynamics_type) == "mushy") then
 
-       qin = icepack_enthalpy_mush(iceTemperature, iceSalinity)
+       iceEnthalpy = icepack_enthalpy_mush(iceTemperature, iceSalinity)
 
     else
 
        Tmlt = -iceSalinity*seaiceMeltingTemperatureDepression
-       qin = -(seaiceDensityIce * (seaiceFreshIceSpecificHeat*(Tmlt-iceTemperature) &
-               + seaiceLatentHeatMelting*(1.0_RKIND-Tmlt/iceTemperature) - seaiceSeaWaterSpecificHeat*Tmlt))
+       iceEnthalpy = -(seaiceDensityIce * (seaiceFreshIceSpecificHeat*(Tmlt-iceTemperature) &
+                     + seaiceLatentHeatMelting*(1.0_RKIND-Tmlt/iceTemperature) &
+                     - seaiceSeaWaterSpecificHeat*Tmlt))
 
     endif
 

--- a/components/mpas-seaice/src/shared/mpas_seaice_prescribed.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_prescribed.F
@@ -156,7 +156,8 @@ contains
          config_use_prescribed_ice_forcing
 
     character(len=strKIND), pointer :: &
-         config_column_physics_type
+         config_column_physics_type, &
+         config_thermodynamics_type
 
     type(block_type), pointer :: &
          blockPtr
@@ -213,6 +214,8 @@ contains
 
     call MPAS_pool_get_config(domain % configs, "config_column_physics_type", config_column_physics_type)            
     call mpas_pool_get_config(domain % configs, "config_use_prescribed_ice", config_use_prescribed_ice)
+    call mpas_pool_get_config(domain % configs, "config_thermodynamics_type", config_thermodynamics_type)
+
     if (config_use_prescribed_ice) then
 
        ! get ice coverage
@@ -309,7 +312,7 @@ contains
                                depth = (real(iIceLayer,kind=RKIND) - 0.5_RKIND) / real(nIceLayers,kind=RKIND)
                                iceTemperature = surfaceTemperature(1,iCategory,iCell) + temperatureGradient * depth
                                iceSalinity(iIceLayer,iCategory,iCell) = icepack_salinity_profile(depth)
-                               iceEnthalpy(iIceLayer,iCategory,iCell) = seaice_icepack_enthalpy_ice(iceTemperature,iceSalinity(iIceLayer,iCategory,iCell))
+                               iceEnthalpy(iIceLayer,iCategory,iCell) = seaice_icepack_enthalpy_ice(iceTemperature,iceSalinity(iIceLayer,iCategory,iCell),config_thermodynamics_type)
 
                             enddo ! iIceLayer
 


### PR DESCRIPTION
This is a bug fix to F-case (prescribed ice) simulations in Icepack.  The code now runs with the latest F-case configuration for a 2x5 day test as scripted for E3SM v3alpha. 